### PR TITLE
fix(docs): remove documented plugin ctx.registerTool() API that doesn't exist

### DIFF
--- a/documents/live-toolsmithing.md
+++ b/documents/live-toolsmithing.md
@@ -31,9 +31,10 @@ Three concrete capabilities make this loop work:
   schema.
 - **Tools register at runtime, not compile time.** `register(ctx)` is
   called when the bridge loads the plugin and gets a context object with
-  `workspace`, `workspaceFolders`, `config`, and `logger`. Each tool is
-  a `{ name, description, inputSchema, handler }` object pushed onto
-  `ctx.registerTool(...)`. No type generation, no rebuild.
+  `workspace`, `workspaceFolders`, `config`, and `logger`. It returns
+  `{ tools: [...] }`, where each tool is a
+  `{ schema: { name, description, inputSchema }, handler }` object. No
+  type generation, no rebuild.
 - **The bridge watches plugin paths.** Pass `--plugin-watch` at startup
   and any change under a registered plugin directory triggers an atomic
   re-register: tools defined by the old version are unregistered, the

--- a/documents/plugin-authoring.md
+++ b/documents/plugin-authoring.md
@@ -70,9 +70,7 @@ All fields unless marked optional are required.
 
 ## Entrypoint
 
-Your entrypoint module must export a `register` function — either named or default export. It receives a `PluginContext`.
-
-### Option A: Return a `PluginRegistration` object
+Your entrypoint module must export a `register` function — either named or default export. It receives a `PluginContext` and must RETURN a `PluginRegistration` object (`{ tools: [...] }`) — this is the only supported shape; there is no imperative alternative.
 
 ```js
 // index.mjs
@@ -122,31 +120,6 @@ export function register(ctx) {
 }
 ```
 
-### Option B: Use `ctx.registerTool()` imperatively
-
-```js
-export function register(ctx) {
-  ctx.registerTool({
-    schema: {
-      name: "myOrg_doSomething",
-      description: "Does something useful",
-      inputSchema: {
-        type: "object",
-        properties: {
-          input: { type: "string", description: "Input text" },
-        },
-        required: ["input"],
-      },
-    },
-    handler: async (args) => {
-      return { content: [{ type: "text", text: `Result: ${args.input}` }] };
-    },
-  });
-}
-```
-
-Both styles are supported. Mixing them in the same `register` call is also fine — return value tools and `ctx.registerTool()` calls are merged.
-
 ### TypeScript
 
 Install the bridge as a peer dev dependency and import types:
@@ -181,9 +154,6 @@ interface PluginContext {
     error(msg: string, data?: Record<string, unknown>): void;
     debug(msg: string, data?: Record<string, unknown>): void;
   };
-
-  /** Register a tool imperatively (alternative to returning PluginRegistration). */
-  registerTool(tool: { schema: PluginToolSchema; handler: ToolHandler }): void;
 }
 ```
 
@@ -238,52 +208,56 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 export function register(ctx) {
-  ctx.registerTool({
-    schema: {
-      name: "myOrg_listTodos",
-      description: "Find all TODO/FIXME comments in the workspace",
-      inputSchema: {
-        type: "object",
-        properties: {
-          pattern: {
-            type: "string",
-            description: "Regex to match (default: TODO|FIXME)",
+  return {
+    tools: [
+      {
+        schema: {
+          name: "myOrg_listTodos",
+          description: "Find all TODO/FIXME comments in the workspace",
+          inputSchema: {
+            type: "object",
+            properties: {
+              pattern: {
+                type: "string",
+                description: "Regex to match (default: TODO|FIXME)",
+              },
+              maxResults: {
+                type: "number",
+                description: "Maximum number of results (default: 50)",
+              },
+            },
           },
-          maxResults: {
-            type: "number",
-            description: "Maximum number of results (default: 50)",
-          },
+          annotations: { readOnlyHint: true },
+        },
+        handler: async (args) => {
+          const pattern = (args.pattern ?? "TODO|FIXME");
+          const max = args.maxResults ?? 50;
+
+          let output;
+          try {
+            const result = await execFileAsync(
+              "grep",
+              ["-rn", "--include=*.ts", "--include=*.js", "-E", pattern, ctx.workspace],
+              { maxBuffer: 1024 * 1024 },
+            );
+            output = result.stdout;
+          } catch (err) {
+            // grep exits 1 when no matches — not a real error
+            output = err.stdout ?? "";
+          }
+
+          const lines = output.trim().split("\n").filter(Boolean).slice(0, max);
+
+          if (lines.length === 0) {
+            return { content: [{ type: "text", text: "No TODOs found." }] };
+          }
+
+          const text = lines.join("\n");
+          return { content: [{ type: "text", text }] };
         },
       },
-      annotations: { readOnlyHint: true },
-    },
-    handler: async (args) => {
-      const pattern = (args.pattern ?? "TODO|FIXME");
-      const max = args.maxResults ?? 50;
-
-      let output;
-      try {
-        const result = await execFileAsync(
-          "grep",
-          ["-rn", "--include=*.ts", "--include=*.js", "-E", pattern, ctx.workspace],
-          { maxBuffer: 1024 * 1024 },
-        );
-        output = result.stdout;
-      } catch (err) {
-        // grep exits 1 when no matches — not a real error
-        output = err.stdout ?? "";
-      }
-
-      const lines = output.trim().split("\n").filter(Boolean).slice(0, max);
-
-      if (lines.length === 0) {
-        return { content: [{ type: "text", text: "No TODOs found." }] };
-      }
-
-      const text = lines.join("\n");
-      return { content: [{ type: "text", text }] };
-    },
-  });
+    ],
+  };
 }
 ```
 

--- a/scripts/audit-docs-drift.mjs
+++ b/scripts/audit-docs-drift.mjs
@@ -152,10 +152,52 @@ function auditCoverageThresholds() {
   }
 }
 
+// ── 3. Plugin API drift ──────────────────────────────────────────────────────
+//
+// Session-review finding: documents/plugin-authoring.md and
+// documents/live-toolsmithing.md both documented an imperative
+// `ctx.registerTool()` API for plugin authors, but PluginContext
+// (src/plugin.ts) never implemented it — a plugin author following that
+// documented pattern got `ctx.registerTool is not a function` and their
+// plugin was silently skipped (see src/__tests__/pluginLoader.test.ts's
+// regression test pinning that failure). Docs were fixed to describe only
+// the actually-supported return-value shape (`register(ctx)` returns
+// `{ tools: [...] }`); this check keeps that fix from silently regressing
+// if `ctx.registerTool` — or `PluginContext`'s `registerTool` — is
+// reintroduced into docs without ever landing in the real type.
+
+function auditPluginApiDrift() {
+  const pluginSrc = read("src/plugin.ts");
+  const hasRegisterToolMethod = /\bregisterTool\s*\(/.test(pluginSrc);
+
+  for (const doc of [
+    "documents/plugin-authoring.md",
+    "documents/live-toolsmithing.md",
+  ]) {
+    const text = read(doc);
+    const mentionsRegisterTool = /\bregisterTool\s*\(/.test(text);
+    if (mentionsRegisterTool && !hasRegisterToolMethod) {
+      drift.push(
+        `plugin-api: ${doc} mentions "registerTool(" but src/plugin.ts's PluginContext does not implement a registerTool method — this describes an API that does not exist. Either implement PluginContext.registerTool, or remove/rewrite the doc example to use the return-value \`register(ctx) => { tools: [...] }\` shape (the only currently-supported contract).`,
+      );
+    } else if (mentionsRegisterTool) {
+      notes.push(
+        `plugin-api: ${doc} mentions "registerTool(" and src/plugin.ts now implements it — docs and code agree.`,
+      );
+    }
+  }
+  if (drift.every((d) => !d.startsWith("plugin-api:"))) {
+    notes.push(
+      "plugin-api: no documented-but-nonexistent registerTool() reference found",
+    );
+  }
+}
+
 // ── run ──────────────────────────────────────────────────────────────────────
 
 auditToolCount();
 auditCoverageThresholds();
+auditPluginApiDrift();
 
 for (const n of notes) console.log(`  ℹ ${n}`);
 if (drift.length > 0) {

--- a/src/__tests__/pluginLoader.test.ts
+++ b/src/__tests__/pluginLoader.test.ts
@@ -375,6 +375,45 @@ describe("loadPlugins", () => {
     ).toBe(true);
   });
 
+  // Regression (diagnostic-report triage): documents/plugin-authoring.md
+  // previously documented an imperative "Option B: ctx.registerTool()" API
+  // (and its "Complete Example") — but PluginContext (src/plugin.ts) never
+  // implemented a `registerTool` method, and the loader's contract (see the
+  // "returns wrong shape" test above) requires `register()` to RETURN
+  // `{ tools: [...] }`. A plugin author following that documented pattern
+  // got `ctx.registerTool is not a function` and their plugin silently
+  // skipped. Pins that this exact documented (now-removed) pattern still
+  // fails to load, so the docs fix (removing Option B) doesn't quietly
+  // regress back to describing a nonexistent API.
+  it("warns and skips a plugin using the (unsupported) ctx.registerTool() pattern", async () => {
+    const pluginDir = path.join(tmpDir, "imperative-registertool");
+    fs.mkdirSync(pluginDir);
+    writePlugin(
+      pluginDir,
+      makeManifest(),
+      `export function register(ctx) {
+        ctx.registerTool({
+          schema: {
+            name: "testPlugin_doSomething",
+            description: "Does something",
+            inputSchema: { type: "object", properties: {} },
+          },
+          handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+        });
+      }`,
+    );
+
+    const log = makeLogger();
+    const tools = await loadPlugins([pluginDir], makeConfig(), log);
+
+    expect(tools).toEqual([]);
+    expect(
+      log.calls.some(
+        (c) => c.level === "warn" && c.msg.includes("register() threw"),
+      ),
+    ).toBe(true);
+  });
+
   it("warns but still loads when register() returns 0 tools", async () => {
     const pluginDir = path.join(tmpDir, "zero-tools");
     fs.mkdirSync(pluginDir);


### PR DESCRIPTION
## Summary
Fifth and last fix from the diagnostic-report triage (workflow review, confirmed CONFIRMED/HIGH). `documents/plugin-authoring.md` documented an imperative **"Option B: `ctx.registerTool()`"** pattern (plus a "Complete Example" built entirely on it), and `documents/live-toolsmithing.md` described tools as "pushed onto `ctx.registerTool(...)`". Neither `PluginContext` (`src/plugin.ts`) nor the plugin loader (`src/pluginLoader.ts`) ever implemented a `registerTool` method — the loader's actual contract requires `register(ctx)` to **RETURN** `{ tools: [...] }`, full stop (`src/pluginLoader.ts` ~line 497-502). A plugin author following the documented imperative pattern got `ctx.registerTool is not a function`, their `register()` threw, and the plugin was silently skipped at load time.

## Fix
- Rewrote `documents/plugin-authoring.md`: removed "Option B" entirely, rewrote the "Complete Example" (`myOrg_listTodos`) to use the return-value shape, and removed the `registerTool` line from the `PluginContext Reference` block — all now match `plugin.ts`'s own header docblock example and CLAUDE.md's plugin section (which never mentioned `registerTool` in the first place).
- Fixed the same claim in `documents/live-toolsmithing.md`.
- Added a **plugin-api drift check** to `scripts/audit-docs-drift.mjs` so this can't silently regress: it flags any `registerTool(` mention in either doc unless `PluginContext` actually implements the method. Verified the check fires — temporarily reintroduced the bad doc line, confirmed it flagged with the expected message, reverted.

## Test plan (bug-fix protocol: test-first)
- [x] Added a regression test to `pluginLoader.test.ts` reproducing the exact (now-removed) documented pattern verbatim — confirmed a plugin literally copy-pasting the old "Option B" example still fails to load with `register() threw`, pinning that failure so it can't quietly start "working" via some unrelated change without the docs being revisited
- [x] All 31 tests in `pluginLoader.test.ts` pass
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs` (including the new plugin-api check), `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` clean

## Status
This closes out all 5 CONFIRMED/HIGH items identified in this session's diagnostic-report triage:
1. #1204 — policy.yml fail-open holes
2. #1205 — bare `{error}` connector failures cached as success
3. #1206 — reconnect-result-loss (stale-socket response routing)
4. #1207 — worker-sandbox tool-enumeration gap
5. this PR — plugin docs describing a nonexistent API

Remaining items from the original diagnostic report were either MEDIUM severity (not prioritized this round), REFUTED (`oauth-mcp-session-cors` — already fixed by an earlier July 2026 change), or the general `spawnDepth` recursive-spawn-protection gap (pre-existing, driver-agnostic tech debt, tracked separately in #1202's description).