### PR TITLE
fix(connectors): stop a stale in-flight refresh from resurrecting cleared tokens

### DIFF
--- a/src/connectors/__tests__/baseConnector.refreshRace.test.ts
+++ b/src/connectors/__tests__/baseConnector.refreshRace.test.ts
@@ -64,8 +64,16 @@ class TestConnector extends BaseConnector {
     this.auth = auth;
   }
 
+  getAuth(): AuthContext | null {
+    return this.auth;
+  }
+
   callRefreshDeduped() {
     return this.refreshTokenDeduped();
+  }
+
+  callClearTokens() {
+    return this.clearTokens();
   }
 }
 
@@ -172,5 +180,83 @@ describe("BaseConnector.refreshTokenDeduped()", () => {
     const second = await c.callRefreshDeduped();
     expect(second?.token).toBe("at_new");
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("BaseConnector — disconnect race with an in-flight refresh (diagnostic-report triage)", () => {
+  // A refresh that's already in flight when the user disconnects previously
+  // committed its result unconditionally on resolution: `this.auth = newAuth`
+  // + `saveTokens()` ran with no idea `clearTokens()` had already wiped both
+  // in-memory state and secure storage moments earlier. The disconnect
+  // appeared to succeed, then the connector silently reappeared as
+  // "connected" once the stale fetch resolved — persisting credentials the
+  // user just explicitly removed.
+  it("does not resurrect credentials when clearTokens() runs while a refresh is in flight", async () => {
+    const c = new TestConnector();
+    c.setAuth({
+      token: "at_old",
+      refreshToken: "rt_v1",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    let resolveFetch!: (v: Response) => void;
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const refreshPromise = c.callRefreshDeduped();
+
+    // User disconnects WHILE the refresh above is still awaiting the IdP.
+    await c.callClearTokens();
+    expect(c.getAuth()).toBeNull();
+    expect(deleteTokens).toHaveBeenCalledTimes(1);
+
+    // The stale refresh now resolves successfully — must NOT resurrect auth.
+    resolveFetch(
+      new Response(
+        JSON.stringify({
+          access_token: "at_new",
+          refresh_token: "rt_v2",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const result = await refreshPromise;
+
+    expect(result).toBeNull();
+    expect(c.getAuth()).toBeNull();
+    // The resurrecting persist call must never have happened.
+    expect(storeTokens).not.toHaveBeenCalled();
+  });
+
+  it("still commits normally when no disconnect races the refresh", async () => {
+    // Sanity check: the epoch guard must not break the ordinary path.
+    const c = new TestConnector();
+    c.setAuth({
+      token: "at_old",
+      refreshToken: "rt_v1",
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "at_new",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await c.callRefreshDeduped();
+    expect(result?.token).toBe("at_new");
+    expect(c.getAuth()?.token).toBe("at_new");
+    expect(storeTokens).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/connectors/baseConnector.ts
+++ b/src/connectors/baseConnector.ts
@@ -101,6 +101,15 @@ export abstract class BaseConnector {
    * refresh token — fatal on IdPs that rotate refresh tokens (Google).
    */
   private refreshInflight: Promise<AuthContext | null> | null = null;
+  /**
+   * Bumped by `clearTokens()`. `refreshToken()` snapshots this at entry and
+   * refuses to commit a fetched token if it has changed by the time the IdP
+   * responds — otherwise a refresh in flight when the user disconnects can
+   * finish AFTER `clearTokens()` already wiped storage and `this.auth`, and
+   * unconditionally overwrite both with a freshly rotated token, silently
+   * resurrecting credentials the user just explicitly removed.
+   */
+  private tokenEpoch = 0;
 
   abstract readonly providerName: string;
 
@@ -164,6 +173,7 @@ export abstract class BaseConnector {
     const { deleteTokens } = await import("./tokenStorage.js");
     await deleteTokens(this.providerName);
     this.auth = null;
+    this.tokenEpoch++;
   }
 
   /**
@@ -188,6 +198,8 @@ export abstract class BaseConnector {
    */
   protected async refreshToken(): Promise<AuthContext | null> {
     if (!this.auth?.refreshToken) return null;
+    // Snapshot BEFORE the network round-trip — see `tokenEpoch`'s doc comment.
+    const epochAtStart = this.tokenEpoch;
 
     const config = this.getOAuthConfig();
     if (!config) return null;
@@ -276,6 +288,14 @@ export abstract class BaseConnector {
         return null;
       }
       expiresAt = new Date(Date.now() + seconds * 1000);
+    }
+
+    // The user may have disconnected (clearTokens()) while the fetch above
+    // was in flight. Committing this fetched token now would resurrect
+    // credentials the user just explicitly removed — refuse instead.
+    // `this.auth` can also be null here for the same reason; guard both.
+    if (this.tokenEpoch !== epochAtStart || !this.auth) {
+      return null;
     }
 
     const newAuth: AuthContext = {


### PR DESCRIPTION
## Summary
First of the MEDIUM-severity items from the diagnostic-report triage (workflow review, confirmed CONFIRMED). `BaseConnector.refreshToken()` (`src/connectors/baseConnector.ts`) is a long-lived async operation — it awaits a network round-trip to the IdP's token endpoint. If the user disconnects (`clearTokens()`) while a refresh is still in flight, the previous code committed the refresh's result unconditionally once it resolved: `this.auth = newAuth` followed by `saveTokens()`, with no idea `clearTokens()` had already wiped both in-memory state and secure storage moments earlier.

Net effect: the disconnect appeared to succeed, then the connector silently reappeared as "connected" once the stale fetch resolved — persisting credentials the user had just explicitly removed.

## Fix
Added a `tokenEpoch` counter, bumped by `clearTokens()`. `refreshToken()` snapshots it before the network round-trip and refuses to commit (`this.auth = newAuth` / `saveTokens()`) if the epoch changed by the time the IdP responds — the fetched token is simply discarded (`return null`), same as any other failed/transient refresh.

## Test plan (bug-fix protocol: test-first)
- [x] Added a regression test that starts a refresh, calls `clearTokens()` while it's still pending (fetch not yet resolved), then resolves the stale fetch successfully — asserts the refresh returns `null`, `this.auth` stays `null`, and `storeTokens` is never called (no resurrection)
- [x] **Confirmed this test FAILED against the old code** before writing the fix — interestingly as a thrown `TypeError` dereferencing the just-nulled `this.auth.scopes`, itself direct evidence the race was never guarded against
- [x] Added a sanity-check test pinning the ordinary (non-racing) commit path is unchanged
- [x] All 5 tests in `baseConnector.refreshRace.test.ts` pass; full `src/connectors/__tests__/` suite (75 files, 1353 tests) still green
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs`, `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` clean

## Next
Two more MEDIUM items from the same triage queued: `duplicate-session-id-teardown` (a second live WebSocket session overwriting the session map can have its close handler tear down the replacement without verifying socket identity) and `kill-switch-scope-overstated` (dashboard UI claims the kill switch fans out to every running bridge, but only reaches one discovered bridge).