### PR TITLE
fix(bridge): stale connection close must not tear down a replacement session

### DIFF
--- a/src/__tests__/bridge-duplicate-session-id.test.ts
+++ b/src/__tests__/bridge-duplicate-session-id.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression test (diagnostic-report triage): a stale connection's "close"
+ * event must not tear down a DIFFERENT, still-live session that happens to
+ * share the same session id.
+ *
+ * ROOT CAUSE: two connections presenting the same X-Claude-Code-Session-Id
+ * (a duplicate/racing client, or a client that reconnects while its old
+ * socket hasn't actually closed yet) both reach the "fresh session" path
+ * when the first session has no grace timer yet (still actively connected).
+ * The second connection's `this.sessions.set(sessionId, sessionB)` silently
+ * overwrites the map entry that pointed to the first connection's session.
+ *
+ * When the FIRST (now-superseded) connection's own WebSocket eventually
+ * closes, its "close" handler looked up the session purely by id —
+ * `this.sessions.get(sessionId)` — with no check that the entry still
+ * pointed at ITS OWN `ws`. It found the second connection's (still-live)
+ * session object and scheduled that session for grace-period cleanup,
+ * eventually tearing it down even though its actual WebSocket was never
+ * closed and remained in active use.
+ *
+ * Fix: both "close" handlers in bridge.ts (resume path and fresh-session
+ * path) now check `current.ws === ws` before acting — a close event whose
+ * session entry has already been replaced by a newer connection is ignored.
+ */
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import type { Config } from "../config.js";
+import { makeConfig as buildConfig } from "./helpers/fixtures.js";
+import { send, waitFor } from "./wsHelpers.js";
+
+vi.mock("../bridgeToken.js", () => ({
+  loadOrCreateBridgeToken: vi.fn(() => "bridge-test-token"),
+}));
+vi.mock("../probe.js", () => ({ probeAll: vi.fn(async () => ({})) }));
+vi.mock("../pluginLoader.js", () => ({
+  loadPlugins: vi.fn(async () => []),
+  loadPluginsFull: vi.fn(async () => []),
+}));
+vi.mock("../bridgeToolsRules.js", () => ({
+  repairBridgeToolsRulesIfStale: vi.fn(),
+}));
+vi.mock("../telemetry.js", () => ({
+  initTelemetry: vi.fn(),
+  shutdownTelemetry: vi.fn(async () => {}),
+}));
+
+const { Bridge } = await import("../bridge.js");
+
+const AUTH = "bridge-fixed-token";
+
+function makeConfig(workspace: string): Config {
+  return buildConfig({
+    workspace,
+    workspaceFolders: [workspace],
+    ideName: "Test",
+    maxResultSize: 512 * 1024,
+    gracePeriodMs: 5_000,
+    driver: "none",
+    toolRateLimit: 100,
+    fixedToken: AUTH,
+    fullMode: false,
+    analyticsEnabled: false,
+    wsPingIntervalMs: 0,
+    lspVerbosity: "minimal",
+  });
+}
+
+function connect(port: number, sessionId: string): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+    headers: {
+      "x-claude-code-ide-authorization": AUTH,
+      "x-claude-code-session-id": sessionId,
+    },
+  });
+  return new Promise((resolve, reject) => {
+    ws.on("open", () => resolve(ws));
+    ws.on("error", reject);
+  });
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface TestSession {
+  ws: WebSocket;
+  graceTimer: ReturnType<typeof setTimeout> | null;
+  transport: { isReady: boolean };
+}
+type SessionsMap = Map<string, TestSession>;
+function sessionsOf(bridge: unknown): SessionsMap {
+  return (bridge as { sessions: SessionsMap }).sessions;
+}
+
+describe("duplicate session id — stale close must not tear down the replacement session", () => {
+  let tempDir = "";
+  let prevHome: string | undefined;
+  let prevCfgDir: string | undefined;
+  const clients: WebSocket[] = [];
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bridge-dup-session-"));
+    prevHome = process.env.HOME;
+    prevCfgDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.HOME = tempDir;
+    process.env.CLAUDE_CONFIG_DIR = path.join(tempDir, ".claude");
+  });
+
+  afterEach(() => {
+    for (const ws of clients) {
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+    }
+    clients.length = 0;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCfgDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prevCfgDir;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("a superseded connection's close event does not schedule cleanup for the replacement session", async () => {
+    const workspace = fs.mkdtempSync(path.join(tempDir, "ws-"));
+    const bridge = new Bridge(makeConfig(workspace));
+    try {
+      await bridge.start();
+      const port = bridge.getPort();
+      const sharedId = randomUUID();
+
+      // Connection A: takes the session id first. No disconnect yet, so it
+      // has no grace timer — the exact precondition that sends a second
+      // connection with the same id down the "fresh session" path instead
+      // of the resume path.
+      const wsA = await connect(port, sharedId);
+      clients.push(wsA);
+      await delay(50);
+
+      const sessions = sessionsOf(bridge);
+      const sessionAfterA = sessions.get(sharedId);
+      const serverWsA = sessionAfterA?.ws;
+      expect(serverWsA).toBeDefined();
+
+      // Connection B: presents the SAME session id while A is still live.
+      // This overwrites the map entry — the real, currently-unfixed
+      // behavior this test does not change (a duplicate/racing client
+      // sharing one session id is a client-side bug in itself); what
+      // matters here is what happens next.
+      // (Past the bridge's connection-storm throttle — MIN_CONNECTION_INTERVAL_MS.)
+      await delay(600);
+      const wsB = await connect(port, sharedId);
+      clients.push(wsB);
+      send(wsB, { jsonrpc: "2.0", id: 0, method: "initialize", params: {} });
+      await waitFor(wsB, (m) => m.id === 0);
+      send(wsB, { jsonrpc: "2.0", method: "notifications/initialized" });
+      await delay(50);
+
+      const sessionAfterB = sessions.get(sharedId);
+      const serverWsB = sessionAfterB?.ws;
+      expect(serverWsB).toBeDefined();
+      // The map entry was replaced by B's connection (a different
+      // server-side ws object than A's).
+      expect(serverWsB).not.toBe(serverWsA);
+      expect(sessionAfterB).not.toBe(sessionAfterA);
+
+      // Connection A (now superseded) closes.
+      await new Promise<void>((resolve) => {
+        wsA.on("close", () => resolve());
+        wsA.close();
+      });
+      await delay(50);
+
+      // The session map entry (B's session) must be untouched: still B's
+      // server-side ws, and crucially no grace timer was started for it —
+      // the bug would have scheduled B's session for teardown based on A's
+      // close, since both share the same session id key.
+      const sessionAfterAClose = sessions.get(sharedId);
+      expect(sessionAfterAClose?.ws).toBe(serverWsB);
+      expect(sessionAfterAClose?.graceTimer).toBeNull();
+
+      // B must still be fully usable — a live tool-dispatch round-trip.
+      expect(wsB.readyState).toBe(WebSocket.OPEN);
+      send(wsB, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+      const resp = await waitFor(wsB, (m) => m.id === 1);
+      expect(resp.error).toBeUndefined();
+      expect(resp.result).toBeDefined();
+    } finally {
+      await bridge.stop();
+    }
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -317,6 +317,21 @@ export class Bridge {
           this.logger.event("session_resumed", { sessionId: clientSessionId });
           // Re-attach close/error handlers to the new WebSocket
           ws.on("close", (code: number, reason: Buffer) => {
+            // Identity check: a THIRD connection could have reattached to
+            // this same session id (superseding this one) before this ws
+            // closes. Without this, this stale close event would look up
+            // the session by id, find the NEWER connection's session
+            // object, and schedule teardown (grace timer → cleanupSession)
+            // for a session that is still actively in use — killing the
+            // replacement based on an event from a connection it already
+            // replaced.
+            const current = this.sessions.get(clientSessionId);
+            if (current && current.ws !== ws) {
+              this.logger.info(
+                `Stale connection closed for session ${clientSessionId.slice(0, 8)} — a newer connection already replaced it; ignoring`,
+              );
+              return;
+            }
             this.lastDisconnectAt = new Date().toISOString();
             this.lastDisconnectCode = code;
             this.lastDisconnectReason = reason.toString() || null;
@@ -329,7 +344,7 @@ export class Bridge {
             this.logger.event("claude_disconnected", {
               sessionId: clientSessionId,
             });
-            const s = this.sessions.get(clientSessionId);
+            const s = current;
             if (s && !s.graceTimer) {
               s.graceTimer = setTimeout(() => {
                 this.cleanupSession(clientSessionId);
@@ -598,6 +613,20 @@ export class Bridge {
       }
 
       ws.on("close", (code: number, reason: Buffer) => {
+        // Identity check: two connections presenting the same
+        // X-Claude-Code-Session-Id (a duplicate/racing client) can both
+        // land here — the second overwrites this.sessions.get(sessionId)
+        // with ITS session object at the `this.sessions.set` above. When
+        // the FIRST (now-superseded) connection's socket later closes,
+        // this handler must not tear down the second connection's still-
+        // live session just because the map key matches.
+        const current = this.sessions.get(sessionId);
+        if (current && current.ws !== ws) {
+          this.logger.info(
+            `Stale connection closed for session ${sessionId.slice(0, 8)} — a newer connection already replaced it; ignoring`,
+          );
+          return;
+        }
         this.lastDisconnectAt = new Date().toISOString();
         this.lastDisconnectCode = code;
         this.lastDisconnectReason = reason.toString() || null;
@@ -608,7 +637,7 @@ export class Bridge {
           sessionId,
         });
         this.logger.event("claude_disconnected", { sessionId });
-        const s = this.sessions.get(sessionId);
+        const s = current;
         if (s && !s.graceTimer) {
           s.graceTimer = setTimeout(() => {
             this.cleanupSession(sessionId);


### PR DESCRIPTION
## Summary
Second MEDIUM item from the diagnostic-report triage (workflow review, confirmed CONFIRMED). Two connections presenting the same `X-Claude-Code-Session-Id` (a duplicate/racing client) both reach the fresh-session path in `src/bridge.ts` when the first has no grace timer yet — i.e. it's still actively connected, hasn't disconnected. The resume-path check at the top of the connection handler only fires when `existing.graceTimer` is truthy, so the second connection falls through and creates a brand-new session object, and its `this.sessions.set(sessionId, ...)` silently **overwrites** the map entry that pointed to the first connection's session.

When the FIRST (now-superseded) connection's own WebSocket later closes, its `"close"` handler looked up the session purely by id — `this.sessions.get(sessionId)` — with no check that the entry still pointed at **its own** `ws`. It found the second connection's still-live session object and started **that** session's grace timer, eventually scheduling `cleanupSession()` for a session whose actual WebSocket was never closed and remained in active use.

## Fix
Both `"close"` handlers in `src/bridge.ts` (the grace-period resume path and the fresh-session path) now check `current.ws === ws` before acting. A close event whose session-map entry has already been replaced by a newer connection now logs `"Stale connection closed ... ignoring"` and returns immediately instead of touching the replacement session's state.

## Test plan (bug-fix protocol: test-first)
- [x] Added an end-to-end regression test against the **real** `Bridge` class (mirrors `bridge-real-session-resumption.test.ts`'s harness — actual live WebSocket connections on a random port, not a mock): two connections share one session id, the first closes, and the test asserts the second's session is untouched (still its own `ws`, `graceTimer` stays `null`) and remains fully usable (`tools/list` round-trip succeeds)
- [x] **Confirmed this test FAILED against the old code** — the log line `"Grace period started for session ..."` fired, proving session B was scheduled for teardown triggered by A's stale close — before writing the fix
- [x] All 23 tests across the 6 bridge session-related test files pass (`bridge-duplicate-session-id`, `bridge-real-session-resumption`, `bridge-multi-session`, `bridge-session-restore`, `bridge-sessionid-persistence`, `bridge-session-resumption`)
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.tests.core.json --noEmit` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — full suite green except the 3 pre-existing, unrelated `tokenEfficiency.test.ts` environment-dependent flakes
- [x] `scripts/audit-lsp-tools.mjs`, `scripts/audit-docs-drift.mjs`, `scripts/audit-test-fixtures.mjs` all pass
- [x] `npx biome check` clean

## Next
One more MEDIUM item from the same triage queued: `kill-switch-scope-overstated` (dashboard UI claims the kill switch fans out to every running bridge, but only reaches one discovered bridge).