### PR TITLE
fix(dashboard): correct kill-switch UI copy overstating its scope

### DIFF
--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -1132,10 +1132,12 @@ export default function SettingsPage() {
                     Safety
                   </h2>
                   <div className="stg-card-subtitle">
-                    Global write-tier kill switch. When engaged, every
+                    Write-tier kill switch for this bridge. When engaged, every
                     recipe step + connector tool tagged write-tier
-                    refuses to run on every running bridge. Use during
-                    an incident; release when safe.
+                    refuses to run on the bridge this dashboard is connected
+                    to. Use during an incident; release when safe. If you run
+                    multiple bridges, each has its own kill switch — this
+                    only affects the one this dashboard talks to.
                   </div>
                 </div>
               </div>
@@ -1147,7 +1149,7 @@ export default function SettingsPage() {
                       ? "Kill switch — ENGAGED (writes blocked)"
                       : "Kill switch — released (writes allowed)"
                   }
-                  help="Equivalent to running `patchwork kill-switch engage` / `release` from the CLI. Fans out to every running bridge."
+                  help="Equivalent to running `patchwork kill-switch engage` / `release` from the CLI. Affects only the single bridge this dashboard is connected to — a bridge on another host keeps running normally."
                   checked={ksEngaged}
                   disabled={ksLocked || ksSaving}
                   disabledReason={

--- a/dashboard/src/components/KillSwitchConfirmDialog.tsx
+++ b/dashboard/src/components/KillSwitchConfirmDialog.tsx
@@ -7,12 +7,13 @@ import { Dialog } from "@/components/Dialog";
  *   - KillSwitchBanner (release-only, shown when the switch is engaged)
  *   - settings/page.tsx Safety card ToggleRow (both engage + release)
  *
- * The kill-switch fans out to every connected bridge and blocks/unblocks
- * ALL write-tier tool calls — engaging or releasing it with a single
- * accidental click had no confirmation anywhere in the dashboard. This
- * dialog is an additional gate in front of the existing
- * `POST /api/bridge/kill-switch` call; it does not change that call's
- * shape or the locked/lockedReason handling.
+ * The kill-switch blocks/unblocks ALL write-tier tool calls on the single
+ * bridge this dashboard is connected to (see dashboard/src/lib/bridge.ts's
+ * findBridge() — one discovered bridge per dashboard instance, never a
+ * fan-out) — engaging or releasing it with a single accidental click had
+ * no confirmation anywhere in the dashboard. This dialog is an additional
+ * gate in front of the existing `POST /api/bridge/kill-switch` call; it
+ * does not change that call's shape or the locked/lockedReason handling.
  *
  * Renders nothing when `open=false`; consumers control open/close via state.
  */
@@ -30,12 +31,12 @@ const COPY: Record<
 > = {
   engage: {
     title: "Engage the kill-switch?",
-    body: "This disables ALL writes across every connected bridge — recipe runs, git pushes, file edits, everything — until released.",
+    body: "This disables ALL writes on this bridge — recipe runs, git pushes, file edits, everything — until released. If you run other bridges, they are unaffected.",
     confirmLabel: "Engage kill-switch",
   },
   release: {
     title: "Release the kill-switch?",
-    body: "This re-enables all writes across every connected bridge immediately.",
+    body: "This re-enables all writes on this bridge immediately.",
     confirmLabel: "Release kill-switch",
   },
 };

--- a/dashboard/src/components/__tests__/KillSwitchConfirmDialog.test.tsx
+++ b/dashboard/src/components/__tests__/KillSwitchConfirmDialog.test.tsx
@@ -4,21 +4,29 @@ import { describe, expect, it, vi } from "vitest";
 import { KillSwitchConfirmDialog } from "@/components/KillSwitchConfirmDialog";
 
 describe("<KillSwitchConfirmDialog/>", () => {
-  it("shows engage-specific copy", () => {
+  // Regression (diagnostic-report triage): the dialog previously claimed the
+  // kill-switch "fans out to every connected bridge" — but the dashboard
+  // proxy (dashboard/src/lib/bridge.ts's findBridge()) discovers and talks
+  // to exactly ONE bridge, never a fan-out. Pinning the corrected,
+  // single-bridge-scoped copy so this can't silently regress back to
+  // overstating the scope.
+  it("shows engage-specific copy scoped to this single bridge (not 'every connected bridge')", () => {
     render(<KillSwitchConfirmDialog open onClose={vi.fn()} onConfirm={vi.fn()} direction="engage" />);
     expect(screen.getByText("Engage the kill-switch?")).toBeInTheDocument();
     expect(
-      screen.getByText(/disables ALL writes across every connected bridge/i),
+      screen.getByText(/disables ALL writes on this bridge/i),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/every connected bridge/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Engage kill-switch" })).toBeInTheDocument();
   });
 
-  it("shows release-specific copy", () => {
+  it("shows release-specific copy scoped to this single bridge (not 'every connected bridge')", () => {
     render(<KillSwitchConfirmDialog open onClose={vi.fn()} onConfirm={vi.fn()} direction="release" />);
     expect(screen.getByText("Release the kill-switch?")).toBeInTheDocument();
     expect(
-      screen.getByText(/re-enables all writes across every connected bridge/i),
+      screen.getByText(/re-enables all writes on this bridge/i),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/every connected bridge/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Release kill-switch" })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
Third and last MEDIUM item from the diagnostic-report triage (workflow review, confirmed CONFIRMED). The settings-page Safety card, its `ToggleRow` help text, and `KillSwitchConfirmDialog`'s engage/release copy all claimed the kill switch "fans out to every connected/running bridge" — but the dashboard's `/api/bridge/kill-switch` proxy route (`dashboard/src/app/api/bridge/[...path]/route.ts`) calls `findBridge()` (`dashboard/src/lib/bridge.ts`), which discovers and returns **exactly one** bridge (local lock-file scan, or a single remote `PATCHWORK_BRIDGE_URL`/`PATCHWORK_BRIDGE_TOKEN` pair) — never a fan-out. A bridge on another host, or any bridge the dashboard isn't currently pointed at, keeps running and accepting writes completely unaffected by toggling this switch — a real safety-relevant gap between what the UI promises and what actually happens during an incident.

**Important scoping note**: the CLI's `patchwork kill-switch engage/release/status` is **NOT** part of this bug. I read its implementation (`src/index.ts` ~line 2100+) before touching anything — it genuinely does fan out via `findAllLiveBridges()`, looping over every live bridge lock file discoverable on the local host and POSTing to each. Its help text ("across every running bridge") is accurate and was left unchanged.

## Fix
Rewrote all three dashboard copy sites to accurately describe the single-bridge scope:
- Settings page Safety card subtitle
- `ToggleRow`'s `help` text
- `KillSwitchConfirmDialog`'s doc comment + engage/release body copy

All now say "the bridge this dashboard is connected to" / "on this bridge" instead of the false multi-bridge claim, with a note that other bridges (if any) are unaffected.

## Test plan (bug-fix protocol: test-first, adapted for a copy/docs bug)
- [x] Updated `KillSwitchConfirmDialog.test.tsx`'s assertions to match the corrected copy, plus added a negative assertion (`queryByText(/every connected bridge/i)).not.toBeInTheDocument()`) so the overstated claim can't silently reappear — this is the regression guard for a UI-copy bug, playing the same role a failing-test-first would for a logic bug
- [x] All 6 tests in `KillSwitchConfirmDialog.test.tsx` pass; full dashboard suite (115 files, 1176 tests) green
- [x] Dashboard `npx tsc --noEmit` clean
- [x] `npx next lint` on changed files — no warnings/errors
- [x] `npm run lint` (dashboard) — only pre-existing warnings in unrelated files

## Status
This closes out all 3 MEDIUM items from the diagnostic-report triage (`oauth-refresh-race` #1209, `duplicate-session-id-teardown` #1210, this PR), on top of the 5 CONFIRMED/HIGH items already merged (#1204-#1208). Remaining from the original report: `spawnDepth` recursive-spawn protection (pre-existing, driver-agnostic tech debt, tracked separately), `oauth-mcp-session-cors` (REFUTED — already fixed by an earlier change), and `mocked-replay-real-io` (a documented, intentional limitation rather than a hidden bug).