### PR TITLE
feat(approvals): risk-tiered approval timeouts, live-configurable

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -39,6 +39,15 @@
     },
     "recipesDir": { "type": "string" },
     "approvalGate": { "type": "string", "enum": ["off", "high", "all"] },
+    "approvalTimeouts": {
+      "type": "object",
+      "properties": {
+        "low": { "type": "integer", "minimum": 0 },
+        "medium": { "type": "integer", "minimum": 0 },
+        "high": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
     "enableTimeOfDayAnomaly": { "type": "boolean" },
     "managedSettingsPath": { "type": "string" },
     "recipes": {

--- a/dashboard/src/app/approvals/[callId]/page.tsx
+++ b/dashboard/src/app/approvals/[callId]/page.tsx
@@ -34,7 +34,8 @@ interface PendingRecord {
   summary?: string;
   params?: Record<string, unknown>;
   sessionId?: string;
-  expiresAt?: number;
+  /** `null` = no configured expiry for this tier. */
+  expiresAt?: number | null;
   riskSignals?: RiskSignal[];
   personalSignals?: PersonalSignal[];
 }

--- a/dashboard/src/app/approvals/_components/CountdownTimer.tsx
+++ b/dashboard/src/app/approvals/_components/CountdownTimer.tsx
@@ -1,14 +1,21 @@
 "use client";
 import { useEffect, useState } from "react";
 
-export function CountdownTimer({ expiresAt }: { expiresAt: number }) {
+export function CountdownTimer({ expiresAt }: { expiresAt: number | null }) {
   const [remaining, setRemaining] = useState(() =>
-    Math.max(0, expiresAt - Date.now()),
+    expiresAt === null ? null : Math.max(0, expiresAt - Date.now()),
   );
 
   useEffect(() => {
-    // Don't start the interval when expiresAt is falsy (0 or not set) or
-    // already expired — remaining was initialised to 0 and nothing will change.
+    // No deadline for this tier — nothing to count down. Distinct from
+    // `remaining === 0` ("Expired"): a null-expiry high-risk approval must
+    // never render as expired just because it has no timer.
+    if (expiresAt === null) {
+      setRemaining(null);
+      return;
+    }
+    // Don't start the interval when expiresAt is falsy (0) or already
+    // expired — remaining was initialised to 0 and nothing will change.
     if (!expiresAt || expiresAt <= Date.now()) return;
 
     const id = setInterval(() => {
@@ -20,6 +27,14 @@ export function CountdownTimer({ expiresAt }: { expiresAt: number }) {
     }, 1000);
     return () => clearInterval(id);
   }, [expiresAt]);
+
+  if (remaining === null) {
+    return (
+      <span className="countdown" title="No approval deadline for this risk tier">
+        No expiry
+      </span>
+    );
+  }
 
   if (remaining === 0) {
     return (
@@ -58,7 +73,9 @@ export function CountdownTimer({ expiresAt }: { expiresAt: number }) {
             ? { color: "var(--warn)", fontWeight: 600 }
             : undefined
       }
-      title={`Expires at ${new Date(expiresAt).toLocaleTimeString()}`}
+      // Reached only when `remaining` is a positive number, which is only
+      // ever derived from a non-null `expiresAt` — safe to assert here.
+      title={`Expires at ${new Date(expiresAt as number).toLocaleTimeString()}`}
     >
       {label}
     </span>

--- a/dashboard/src/app/approvals/page.tsx
+++ b/dashboard/src/app/approvals/page.tsx
@@ -58,7 +58,8 @@ interface Pending {
   summary?: string;
   params?: Record<string, unknown>;
   sessionId?: string;
-  expiresAt?: number;
+  /** `null` = this tier has no configured expiry (e.g. high-risk by default) — never counts as "Expired". `undefined` = older payload shape, fall back to the low-tier default window. */
+  expiresAt?: number | null;
   riskSignals?: RiskSignal[];
   personalSignals?: PersonalSignal[];
 }
@@ -192,7 +193,12 @@ const ApprovalCard = memo(function ApprovalCard({
     clearTimeout(paramsCopyTimerRef.current);
   }, []);
 
-  const expires = p.expiresAt ?? p.requestedAt + DEFAULT_TTL_MS;
+  // `null` is an explicit "no expiry" from the backend (e.g. high-tier by
+  // default) — must NOT fall back to DEFAULT_TTL_MS, or a no-deadline
+  // high-risk approval would show a fake 5-minute countdown and pressure
+  // the reviewer into rubber-stamping it. Only genuinely missing
+  // (`undefined`, an older payload shape) falls back.
+  const expires = p.expiresAt === undefined ? p.requestedAt + DEFAULT_TTL_MS : p.expiresAt;
   const primary = primaryParam(p.toolName, p.params);
   const hasParams = p.params && Object.keys(p.params).length > 0;
   const match = matchRule(p.toolName, rules);
@@ -217,9 +223,11 @@ const ApprovalCard = memo(function ApprovalCard({
   // to re-render every second even though the countdown UI is owned by
   // a leaf <CountdownTimer> that ticks itself. Now a single setTimeout
   // schedules the boolean flip and unmounts. Perf audit 2026-05-19.
-  const [expired, setExpired] = useState(() => Date.now() >= expires);
+  const [expired, setExpired] = useState(
+    () => expires !== null && Date.now() >= expires,
+  );
   useEffect(() => {
-    if (expired) return;
+    if (expired || expires === null) return;
     const remaining = expires - Date.now();
     if (remaining <= 0) {
       setExpired(true);

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -20,6 +20,7 @@ interface StatusResponse {
     port?: number;
     workspace?: string;
     approvalGate?: string;
+    approvalTimeouts?: Partial<Record<"low" | "medium" | "high", number>> | null;
     enableTimeOfDayAnomaly?: boolean;
     fullMode?: boolean;
     driver?: string;
@@ -45,6 +46,59 @@ interface StatusResponse {
 }
 
 type ApiKeyProvider = "anthropic" | "openai" | "google" | "xai";
+
+type ApprovalTier = "low" | "medium" | "high";
+
+// Mirrors ApprovalQueue.DEFAULT_TTL_MS in src/approvalQueue.ts — shown as
+// the placeholder for an un-overridden tier. Not read from the server on
+// every keystroke; if the bridge's actual defaults ever diverge from this,
+// the placeholder is cosmetic only (the backend is the source of truth).
+const APPROVAL_TIER_DEFAULT_DISPLAY: Record<ApprovalTier, string> = {
+  low: "5m",
+  medium: "1h",
+  high: "4h",
+};
+
+/** Render an ms value the same way the CLI duration syntax reads: "none" for no expiry, else the largest clean unit. */
+function msToDurationDraft(ms: number): string {
+  if (ms === 0) return "none";
+  if (ms % 3_600_000 === 0) return `${ms / 3_600_000}h`;
+  if (ms % 60_000 === 0) return `${ms / 60_000}m`;
+  if (ms % 1_000 === 0) return `${ms / 1_000}s`;
+  return String(ms);
+}
+
+const MAX_APPROVAL_TIMEOUT_MS = 2_147_483_647; // Node's setTimeout ceiling — mirrors src/config.ts
+
+/**
+ * Parse one tier's draft text field. Empty string means "no override
+ * entered" — send `null` (this tier had a saved override the user just
+ * cleared) or omit the key (never had one) depending on the caller's dirty
+ * check. `"none"`/`"infinite"` = no expiry (`0`). Mirrors
+ * src/config.ts's `parseApprovalTimeout`, duplicated here rather than
+ * imported since that module pulls in Node-only deps (node:child_process)
+ * unsuitable for a browser bundle.
+ */
+function parseTierDraft(
+  raw: string,
+): { ok: true; ms: number } | { ok: false; error: string } {
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "none" || trimmed === "infinite") return { ok: true, ms: 0 };
+  const m = /^(\d+)(s|m|h)?$/.exec(trimmed);
+  if (!m) {
+    return {
+      ok: false,
+      error: 'must be "none", an integer (ms), or e.g. "30s"/"5m"/"2h"',
+    };
+  }
+  const n = Number(m[1]);
+  const unitMs = { s: 1_000, m: 60_000, h: 3_600_000 } as const;
+  const ms = m[2] ? n * unitMs[m[2] as "s" | "m" | "h"] : n;
+  if (ms > MAX_APPROVAL_TIMEOUT_MS) {
+    return { ok: false, error: "exceeds the max representable timeout (~24.8 days)" };
+  }
+  return { ok: true, ms };
+}
 
 type SectionId =
   | "s-bridge"
@@ -202,6 +256,44 @@ export default function SettingsPage() {
   const [gateSaving, setGateSaving] = useState(false);
   const [gateSaveMsg, setGateSaveMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
+  // Risk-tiered approval timeouts. Each field is a free-text draft in the
+  // same duration syntax as the CLI (`--approval-timeout-<tier>`): "none",
+  // a bare ms integer, or "30s"/"5m"/"2h". Empty = "no override" (falls
+  // back to ApprovalQueue.DEFAULT_TTL_MS); saving an emptied field that
+  // WAS previously overridden sends an explicit `null` to clear it.
+  const [tmoDraft, setTmoDraft] = useState<Record<ApprovalTier, string>>({
+    low: "",
+    medium: "",
+    high: "",
+  });
+  // Two separate refs, exactly mirroring gateValueRef (latest server
+  // truth, always overwritten) / gatePendingRef (the user's live draft,
+  // never touched by the sync effect) — NOT one conflated ref. Mutating a
+  // single ref for both roles inside the sync path made the dirty check
+  // compare a draft against a baseline that had already been silently
+  // rebased to the new server value in the same tick, defeating the
+  // "leave an in-progress edit alone" guarantee.
+  //
+  // tmoDraftRef mirrors tmoDraft state via the effect below (read-only
+  // snapshot for the poll tick, which can't safely read component state
+  // inside a plain callback without going stale). tmoServerRef mirrors the
+  // last value read from /status, independent of what the user is typing.
+  const tmoDraftRef = useRef<Record<ApprovalTier, string>>({
+    low: "",
+    medium: "",
+    high: "",
+  });
+  const tmoServerRef = useRef<Record<ApprovalTier, string>>({
+    low: "",
+    medium: "",
+    high: "",
+  });
+  useEffect(() => {
+    tmoDraftRef.current = tmoDraft;
+  }, [tmoDraft]);
+  const [tmoSaving, setTmoSaving] = useState(false);
+  const [tmoMsg, setTmoMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
   const [todayAnomaly, setTodayAnomaly] = useState(false);
   const [todayAnomalySaving, setTodayAnomalySaving] = useState(false);
   const [todayAnomalyErr, setTodayAnomalyErr] = useState<string | null>(null);
@@ -279,6 +371,46 @@ export default function SettingsPage() {
         // their draft alone — they're mid-edit.
         if (gatePendingRef.current === prevGateValue) {
           setGatePending(gv);
+        }
+
+        {
+          // Plain reads/writes on refs, computed BEFORE any setState call —
+          // deliberately not done inside a setTmoDraft functional updater.
+          // React may invoke an updater more than once (StrictMode dev
+          // double-invoke, or a bailed-out replay), and mutating a ref as
+          // a side effect of an "impure" updater can silently rebase the
+          // dirty-check baseline against itself on a second invocation,
+          // masking a concurrent edit. Doing it here, once, in the plain
+          // effect body, has no such hazard.
+          const serverTimeouts = data.patchwork?.approvalTimeouts ?? null;
+          const tiers: ApprovalTier[] = ["low", "medium", "high"];
+          const prevServer = tmoServerRef.current;
+          const currentDraft = tmoDraftRef.current;
+          const nextDraft = { ...currentDraft };
+          let changed = false;
+          const nextServer: Record<ApprovalTier, string> = {
+            low: "",
+            medium: "",
+            high: "",
+          };
+          for (const tier of tiers) {
+            const ms = serverTimeouts?.[tier];
+            const synced = ms === undefined ? "" : msToDurationDraft(ms);
+            nextServer[tier] = synced;
+            // Same dirty check as the gate control: only adopt the new
+            // server value if the draft still matches the PREVIOUS server
+            // value (i.e. the user hasn't typed anything since the last
+            // sync) — mirrors `gatePendingRef.current === prevGateValue`.
+            if (currentDraft[tier] === prevServer[tier] && nextDraft[tier] !== synced) {
+              nextDraft[tier] = synced;
+              changed = true;
+            }
+          }
+          tmoServerRef.current = nextServer;
+          if (changed) {
+            tmoDraftRef.current = nextDraft;
+            setTmoDraft(nextDraft);
+          }
         }
 
         setTodayAnomaly(Boolean(data.patchwork?.enableTimeOfDayAnomaly));
@@ -585,6 +717,70 @@ export default function SettingsPage() {
       setGateSaveMsg({ ok: false, text: e instanceof Error ? e.message : String(e) });
     } finally {
       setGateSaving(false);
+    }
+  }
+
+  /**
+   * Save every tier whose draft has diverged from what was last synced.
+   * An emptied field that HAD a synced value sends `null` (explicit clear
+   * → falls back to ApprovalQueue.DEFAULT_TTL_MS server-side); an emptied
+   * field that never had one is simply omitted — no-op, not a payload key.
+   * Aborts before sending anything if any dirty field fails to parse, so a
+   * typo in one tier can't silently drop the others.
+   */
+  async function saveApprovalTimeouts() {
+    const tiers: ApprovalTier[] = ["low", "medium", "high"];
+    const payload: Partial<Record<ApprovalTier, number | null>> = {};
+    for (const tier of tiers) {
+      const draft = tmoDraft[tier];
+      const synced = tmoServerRef.current[tier];
+      if (draft === synced) continue; // untouched
+      if (draft.trim() === "") {
+        payload[tier] = null; // explicit clear
+        continue;
+      }
+      const parsed = parseTierDraft(draft);
+      if (!parsed.ok) {
+        setTmoMsg({ ok: false, text: `${tier}: ${parsed.error}` });
+        return;
+      }
+      payload[tier] = parsed.ms;
+    }
+    if (Object.keys(payload).length === 0) {
+      setTmoMsg({ ok: false, text: "No changes to save." });
+      return;
+    }
+
+    setTmoSaving(true);
+    setTmoMsg(null);
+    try {
+      const res = await fetch(apiPath("/api/bridge/settings"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ approvalTimeouts: payload }),
+        signal: abortRef.current?.signal,
+      });
+      if (res.ok) {
+        // Adopt the saved drafts as the new synced baseline — normalizes
+        // e.g. "5M" → the canonical "5m" on the next /status tick instead
+        // of leaving the raw typed text as a false "still dirty" state.
+        for (const tier of Object.keys(payload) as ApprovalTier[]) {
+          const v = payload[tier];
+          const display = v === null || v === undefined ? "" : msToDurationDraft(v);
+          tmoServerRef.current = { ...tmoServerRef.current, [tier]: display };
+          setTmoDraft((prev) => ({ ...prev, [tier]: display }));
+        }
+        setTmoMsg({ ok: true, text: "Saved." });
+        flashSaved();
+      } else {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setTmoMsg({ ok: false, text: body.error ?? `Error ${res.status}` });
+      }
+    } catch (e) {
+      if (isAbortError(e)) return;
+      setTmoMsg({ ok: false, text: e instanceof Error ? e.message : String(e) });
+    } finally {
+      setTmoSaving(false);
     }
   }
 
@@ -1058,6 +1254,67 @@ export default function SettingsPage() {
                   {gateSaveMsg && (
                     <span className="stg-msg" data-ok={String(gateSaveMsg.ok)}>
                       {gateSaveMsg.text}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <div className="stg-section-padded">
+                <label htmlFor="approval-timeout-low" className="stg-label">
+                  Approval timeouts
+                </label>
+                <p className="stg-help">
+                  How long a queued approval waits before it auto-expires,
+                  per risk tier. A short timeout on a high-risk action
+                  pressures the reviewer to rubber-stamp it — set a longer
+                  window, or <code>none</code> to hold until decided.
+                  Accepts <code>none</code>, an integer (ms), or{" "}
+                  <code>30s</code>/<code>5m</code>/<code>2h</code>. Leave
+                  blank to use the default. Takes effect for approvals
+                  queued after saving — anything already pending keeps its
+                  original deadline.
+                </p>
+                {(["low", "medium", "high"] as ApprovalTier[]).map((tier) => (
+                  <div className="stg-gate-row" key={tier}>
+                    <label
+                      htmlFor={`approval-timeout-${tier}`}
+                      style={{ minWidth: "5rem", textTransform: "capitalize" }}
+                    >
+                      {tier}
+                    </label>
+                    <input
+                      id={`approval-timeout-${tier}`}
+                      type="text"
+                      className="stg-input"
+                      disabled={tmoSaving}
+                      value={tmoDraft[tier]}
+                      placeholder={`default: ${APPROVAL_TIER_DEFAULT_DISPLAY[tier]}`}
+                      onChange={(e) => {
+                        setTmoMsg(null);
+                        const v = e.target.value;
+                        setTmoDraft((prev) => ({ ...prev, [tier]: v }));
+                      }}
+                    />
+                  </div>
+                ))}
+                <div className="stg-gate-row">
+                  <button
+                    type="button"
+                    disabled={
+                      tmoSaving ||
+                      (["low", "medium", "high"] as ApprovalTier[]).every(
+                        (tier) => tmoDraft[tier] === tmoServerRef.current[tier],
+                      )
+                    }
+                    onClick={saveApprovalTimeouts}
+                    className="stg-save-btn"
+                    aria-label="Save approval timeouts"
+                  >
+                    {tmoSaving ? "Saving…" : "Save"}
+                  </button>
+                  {tmoMsg && (
+                    <span className="stg-msg" data-ok={String(tmoMsg.ok)}>
+                      {tmoMsg.text}
                     </span>
                   )}
                 </div>

--- a/docs/adr/0006-approval-gate-design.md
+++ b/docs/adr/0006-approval-gate-design.md
@@ -142,7 +142,8 @@ gains an optional `approvalToken` (256-bit hex, `crypto.randomBytes(32)`):
 - Delivered in the push notification payload.
 - Single-use: cleared from the queue entry after first validation, regardless of outcome.
 - Validated with `crypto.timingSafeEqual` (timing-safe).
-- Expires when the queue entry expires (default 5 min TTL).
+- Expires when the queue entry expires (per-tier TTL — see the risk-tiered
+  timeout amendment below; no longer a single flat 5 min for every tier).
 
 ### Phone-path bearer bypass
 
@@ -157,3 +158,120 @@ on these two paths, bearer auth is skipped and token validation is delegated to
 - The push notification call is fire-and-forget: it never delays or blocks the approval flow.
 - Disabling `pushServiceUrl` at runtime drops token generation for new requests immediately.
 - Phone-path tokens and bridge tokens are independent — compromise of one does not affect the other.
+
+## Amendment: Risk-Tiered Approval Timeout (2026-07-24)
+
+### Problem
+
+Every queued approval — regardless of `RiskTier` — shared one flat 5-minute
+TTL (`ApprovalQueue`'s `setTimeout`, hardcoded). This is a documented
+anti-pattern ("approval fatigue"): a short countdown on a *high-risk* action
+(`gitPush`, `npm publish`, PR merge) pressures the reviewer into
+rubber-stamping to beat the clock, defeating the point of gating it at all.
+Conversely, a flat window that's too generous for *low-risk* reads wastes a
+queue slot needlessly. See `aipatternbook.com/approval-fatigue` and
+`developersdigest.tech`'s "Approval Fatigue Is an Agent Security Bug" for the
+broader pattern this follows.
+
+### Decision
+
+`ApprovalQueue` resolves its expiry TTL per `RiskTier` (`low`/`medium`/`high`)
+instead of one process-wide constant (`src/approvalQueue.ts`,
+`ApprovalQueue.DEFAULT_TTL_MS`):
+
+```
+low    → 5 min   (fail-fast — matches the pre-amendment behavior)
+medium → 60 min
+high   → 4 hours
+```
+
+A tier's configured value of `0` (or CLI/config `"none"`/`"infinite"`) means
+**no expiry** — the entry is held until a human explicitly approves/rejects
+or the originating caller cancels. **A fired timer always resolves
+`"expired"`, never `"approved"`** — timeouts cannot silently escalate
+privilege regardless of tier; "no expiry" only removes the forced-fail path,
+it never adds a forced-allow path.
+
+**Compatibility note:** before this amendment, `high` shared the same 5-min
+window as everything else — an unattended high-risk approval failed closed
+quickly. The new 4-hour default is a deliberate fail-safe tradeoff: long
+enough to not pressure a reviewer, still bounded so an unattended approval
+eventually fails closed rather than hanging forever by default. Operators
+who want a genuinely unbounded hold opt in explicitly via
+`--approval-timeout-high none` (or the equivalent dashboard/config value).
+
+### Configuration surfaces
+
+- **CLI**: `--approval-timeout-<low|medium|high> <duration>` at bridge
+  startup. Duration accepts `"none"`/`"infinite"`, a bare ms integer, or
+  `"30s"`/`"5m"`/`"2h"`. Rejected above ~24.8 days
+  (`MAX_APPROVAL_TIMEOUT_MS`, Node's `setTimeout` ceiling) — Node silently
+  fires a timer immediately past that instead of waiting, which would
+  otherwise silently defeat a long intended window.
+- **`~/.patchwork/config.json`**: `approvalTimeouts: {low, medium, high}`
+  (ms). Loaded non-fatally — a corrupted/malformed value is dropped per-tier
+  with a warning (`sanitizeApprovalTimeouts`, `src/config.ts`) rather than
+  crashing the bridge, since this file is dashboard-writable.
+- **`POST /settings`** (runtime, no restart): `{ approvalTimeouts: {low?,
+  medium?, high?} }`, same validation as the CLI plus one addition — a
+  tier's value of **`null`** explicitly clears that tier's override back to
+  `DEFAULT_TTL_MS` (distinct from omitting the key, which leaves whatever is
+  already saved untouched). Merges into the existing per-tier map rather
+  than replacing it wholesale, mirroring `cfg.dashboard`'s existing
+  partial-update convention. Applied live via `ApprovalQueue.setTtlByTier()`
+  — **only affects entries queued after the change**; anything already
+  pending keeps the deadline it was given at enqueue time. Dashboard control
+  lives in the "Approval policy" settings card, same duration syntax as the
+  CLI, with the same in-progress-edit-survives-a-poll dirty-tracking the
+  `approvalGate` select already uses.
+
+### Consequences
+
+**Positive:**
+
+- Matches documented best practice for risk-tiered HITL timeouts — not
+  novel, catching up to how GitHub Actions environment-protection wait
+  timers and similar agent-oversight guides already recommend tiering.
+- `expiresAt` on a pending entry (`src/approvalQueue.ts`) is now a real
+  computed field (`number | null`), not implicitly re-derived at every call
+  site — webhook/push payloads and the dashboard countdown all read the
+  same value instead of three independently-hardcoded `+5min` assumptions
+  (one of which, in the dashboard, was found to be actively wrong for `null`
+  during this work — see below).
+
+**Negative / risks accepted:**
+
+- **A no-expiry (`0`/`"none"`) high-tier approval can sit indefinitely** if
+  the reviewer walks away and never decides. Accepted tradeoff — the kill
+  switch (ADR-0013) remains the fail-safe of last resort for "operator is
+  gone and something sensitive is open," and the *default* is bounded (4h),
+  so this only bites operators who explicitly opted into unbounded holds.
+- **Dashboard `expiresAt === null` handling was a live bug during
+  development**, not just a design risk: the countdown component's `??`
+  fallback treated an explicit "no expiry" `null` the same as "missing
+  field," rendering a fake 5-minute countdown for every high-tier approval
+  and immediately reading "Expired" (since `Math.max(0, null - Date.now())`
+  coerces to `0`). Fixed by threading `number | null` through
+  `CountdownTimer`, `approvals/page.tsx`, and `approvals/[callId]/page.tsx`
+  explicitly, with a distinct "No expiry" badge state.
+- **Settings-page dirty-tracking pitfall**: an early version of the
+  dashboard's per-tier duration inputs mutated a ref as a side effect
+  inside a `setState` functional updater to track "last synced from
+  server" vs. "user's in-progress draft" in one combined ref. Since React
+  may invoke a state updater more than once (dev double-invoke, bailed-out
+  replays), this could rebase the dirty-check baseline against itself
+  mid-edit and silently drop or misapply a concurrent change. Fixed by
+  splitting into two refs — mirroring the existing `gateValueRef` /
+  `gatePendingRef` split for the `approvalGate` control exactly — and doing
+  the ref mutation as a plain statement outside any updater callback.
+
+### Audit rules (new)
+
+- Any new call site that computes an approval's display deadline must read
+  `PendingApproval.expiresAt` (or `ApprovalQueue.peek()`) rather than
+  re-deriving `requestedAt + <assumed constant>` — the constant is
+  config-dependent per tier and can be `null`.
+- Any new per-tier config surface (CLI, config file, or `/settings`) must
+  reject/clamp values above `MAX_APPROVAL_TIMEOUT_MS`, not just type-check
+  them — Node's `setTimeout` fails silently (fires immediately), not with a
+  thrown error, above that ceiling.

--- a/docs/mobile-oversight-mvp.md
+++ b/docs/mobile-oversight-mvp.md
@@ -135,7 +135,7 @@ Add a per-callId approval token issued at queue time and delivered in the push n
 
 ### Security properties
 
-- Short-lived: expires with the queue TTL (5 min default).
+- Short-lived: expires with the queue TTL — per-risk-tier since the [risk-tiered timeout amendment](adr/0006-approval-gate-design.md) (was a flat 5 min for every tier at MVP time).
 - Single-use: prevents replay after approval/rejection.
 - Not guessable: 256-bit random, timing-safe comparison.
 - Separate from bridge token: phone never receives the master bridge token.

--- a/docs/mobile-oversight.md
+++ b/docs/mobile-oversight.md
@@ -204,7 +204,11 @@ When Claude Code queues a tool call:
    can review risk signals and params before deciding.
 
 The approval token embedded in the notification is **single-use** and expires with the queue
-TTL (default 5 minutes). After expiry, the call is automatically rejected.
+entry. The TTL is per risk tier, not a flat window — defaults are 5 min (low), 60 min (medium),
+4 hours (high), configurable via `--approval-timeout-<tier>` or the settings dashboard; see
+[ADR-0006's risk-tiered timeout amendment](adr/0006-approval-gate-design.md). After expiry, the
+call resolves as `"expired"` and does not execute — expiry never auto-approves, regardless of
+tier.
 
 ---
 

--- a/documents/platform-docs.md
+++ b/documents/platform-docs.md
@@ -647,6 +647,14 @@ Glob specifiers (`Bash(npm run *)`) are matched via `evaluateRules` — never re
 | `high` | Queue only high-tier tools (`classifyTool` = `"high"`: writes, network, exec). |
 | `all` | Queue every tool that survives allow/deny short-circuits. |
 
+### Risk-tiered approval timeout
+
+A queued approval's auto-expiry TTL is per-`RiskTier` (`low`/`medium`/`high`), not one flat window — a short fail-fast timeout on a low-risk call defeats the point of the gate for a high-risk one (npm publish, PR merge, force-push), pressuring the reviewer into rubber-stamping to beat the clock. Config via `--approval-timeout-<low|medium|high> <duration>` (CLI) or `approvalTimeouts: {low, medium, high}` (ms) in `~/.patchwork/config.json`; duration accepts `"none"`/`"infinite"` (no expiry — held until a human decides), a bare millisecond integer, or `"30s"`/`"5m"`/`"2h"`.
+
+Defaults (`ApprovalQueue.DEFAULT_TTL_MS` in `src/approvalQueue.ts`): `low` = 5 min, `medium` = 60 min, `high` = 4 hours. A fired timer always resolves `"expired"` — timeouts never auto-*approve*, regardless of tier. `expiresAt` on a pending entry is `null` only when the tier is explicitly configured with `0`/`"none"`/`"infinite"` (a true unbounded hold, opt-in); the dashboard renders a "No expiry" badge instead of a countdown in that case.
+
+**Compatibility note:** before this feature, every tier — including `high` — shared one flat 5-minute TTL. The `high` tier's *default* is now 4 hours instead of 5 minutes, a deliberate fail-safe tradeoff: long enough that a reviewer isn't pressured into rubber-stamping a high-risk action, but still bounded so an unattended approval eventually fails closed rather than hanging forever. Set `--approval-timeout-high none` to opt into a genuinely unbounded hold instead. `parseApprovalTimeout` (and the patchwork-config-file loader) reject/clamp any configured value above ~24.8 days (`Number`'s ceiling for Node's `setTimeout`), since Node silently fires the timer almost immediately past that instead of waiting.
+
 ### Risk signals
 
 High-tier queued items carry `riskSignals` — advisory badges surfaced in the dashboard. Detected patterns:
@@ -699,7 +707,7 @@ When `pushServiceUrl` is configured, the bridge dispatches a push notification a
 | `pushServiceToken` | `PATCHWORK_PUSH_TOKEN` | Bearer token for relay auth |
 | `pushServiceBaseUrl` | `PATCHWORK_PUSH_BASE_URL` | Public HTTPS URL of this bridge (phone calls back here) |
 
-**Phone-path auth:** each queued call gets a per-callId `approvalToken` (256-bit hex, single-use, timing-safe) delivered in the push payload. The phone POSTs to `POST /approve/:callId` or `POST /reject/:callId` with an `x-approval-token` header — no bridge bearer token needed. Token expires with the queue TTL (default 5 min).
+**Phone-path auth:** each queued call gets a per-callId `approvalToken` (256-bit hex, single-use, timing-safe) delivered in the push payload. The phone POSTs to `POST /approve/:callId` or `POST /reject/:callId` with an `x-approval-token` header — no bridge bearer token needed. Token expires with the queue entry, whose TTL is now per-`RiskTier` (see "Risk-tiered approval timeout" above) — not a flat 5 min for every tier.
 
 **Invariants:**
 - `approvalToken` is never returned by `GET /approvals` — only via push.

--- a/src/__tests__/approvalQueue.test.ts
+++ b/src/__tests__/approvalQueue.test.ts
@@ -183,6 +183,89 @@ describe("ApprovalQueue", () => {
     q.clear();
     await expect(promise).resolves.toBe("expired");
   });
+
+  it("per-tier ttlMs applies a different window per RiskTier", async () => {
+    vi.useFakeTimers();
+    try {
+      const q = new ApprovalQueue({ ttlMs: { low: 1000, medium: 5000 } });
+      const low = q.request({ toolName: "a", params: {}, tier: "low" });
+      const medium = q.request({ toolName: "b", params: {}, tier: "medium" });
+
+      vi.advanceTimersByTime(1500);
+      await expect(low.promise).resolves.toBe("expired");
+      expect(q.size()).toBe(1); // medium entry still pending
+
+      vi.advanceTimersByTime(4000);
+      await expect(medium.promise).resolves.toBe("expired");
+      expect(q.size()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a tier with ttlMs 0 never auto-expires (held until decided)", async () => {
+    vi.useFakeTimers();
+    try {
+      const q = new ApprovalQueue({ ttlMs: { high: 0 } });
+      const { callId, promise } = q.request({
+        toolName: "gitPush",
+        params: {},
+        tier: "high",
+      });
+
+      vi.advanceTimersByTime(365 * 24 * 60 * 60 * 1000); // a full year
+      expect(q.size()).toBe(1);
+
+      q.approve(callId);
+      await expect(promise).resolves.toBe("approved");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("defaults to DEFAULT_TTL_MS per tier when no ttlMs override given", () => {
+    const q = new ApprovalQueue();
+    // high defaults to a long-but-bounded window (4h), not unbounded — see
+    // the compatibility note on ApprovalQueue.DEFAULT_TTL_MS.
+    const high = q.request({ toolName: "gitPush", params: {}, tier: "high" });
+    const highExpiresAt = q.peek(high.callId)?.expiresAt;
+    expect(highExpiresAt).not.toBeNull();
+    expect(highExpiresAt).toBeGreaterThan(
+      Date.now() + 3 * 60 * 60_000, // well past 3h out
+    );
+
+    const low = q.request({ toolName: "a", params: {}, tier: "low" });
+    expect(q.peek(low.callId)?.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("an explicit ttlMs of 0 for a tier (e.g. --approval-timeout-high none) opts into true unbounded hold", async () => {
+    vi.useFakeTimers();
+    try {
+      const q = new ApprovalQueue({ ttlMs: { high: 0 } });
+      const { callId } = q.request({
+        toolName: "gitPush",
+        params: {},
+        tier: "high",
+      });
+      expect(q.peek(callId)?.expiresAt).toBeNull();
+      vi.advanceTimersByTime(365 * 24 * 60 * 60 * 1000);
+      expect(q.size()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a bare number ttlMs still applies uniformly to every tier (back-compat)", async () => {
+    vi.useFakeTimers();
+    try {
+      const q = new ApprovalQueue({ ttlMs: 1000 });
+      const high = q.request({ toolName: "gitPush", params: {}, tier: "high" });
+      vi.advanceTimersByTime(1500);
+      await expect(high.promise).resolves.toBe("expired");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ─── Cancellation — audit 2026-05-17 ────────────────────────────────────────

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -29,6 +29,11 @@ const mockedExecFileSync = vi.mocked(execFileSync);
 
 afterEach(() => {
   vi.clearAllMocks();
+  // sanitizeApprovalTimeouts' tests spy on console.warn — restore it here
+  // too so a failing test can't leave console.warn silenced for the rest
+  // of the file (the inline warn.mockRestore() already does this on the
+  // happy path, but this is the backstop).
+  vi.restoreAllMocks();
 });
 
 describe("findEditor", () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -19,7 +19,9 @@ import {
   findEditor,
   ideNameFromEditor,
   isInterpreterCommand,
+  parseApprovalTimeout,
   parseConfig,
+  sanitizeApprovalTimeouts,
   saveBridgeConfigDriver,
 } from "../config.js";
 
@@ -566,5 +568,110 @@ describe("parseConfig --automation-allow-private-webhooks", () => {
       "--automation-allow-private-webhooks",
     );
     expect(config.automationAllowPrivateWebhooks).toBe(true);
+  });
+});
+
+describe("parseApprovalTimeout", () => {
+  it("parses a bare millisecond integer", () => {
+    expect(parseApprovalTimeout("1500", "--x")).toBe(1500);
+  });
+
+  it("parses s/m/h duration suffixes", () => {
+    expect(parseApprovalTimeout("30s", "--x")).toBe(30_000);
+    expect(parseApprovalTimeout("5m", "--x")).toBe(5 * 60_000);
+    expect(parseApprovalTimeout("2h", "--x")).toBe(2 * 3_600_000);
+  });
+
+  it('"none" and "infinite" both mean no expiry (0)', () => {
+    expect(parseApprovalTimeout("none", "--x")).toBe(0);
+    expect(parseApprovalTimeout("infinite", "--x")).toBe(0);
+    expect(parseApprovalTimeout("NONE", "--x")).toBe(0);
+  });
+
+  it("rejects garbage with the flag name in the error", () => {
+    expect(() =>
+      parseApprovalTimeout("banana", "--approval-timeout-high"),
+    ).toThrow(/--approval-timeout-high/);
+  });
+
+  it("rejects negative numbers, decimals, and whitespace-only input", () => {
+    expect(() => parseApprovalTimeout("-5", "--x")).toThrow();
+    expect(() => parseApprovalTimeout("5.5m", "--x")).toThrow();
+    expect(() => parseApprovalTimeout("   ", "--x")).toThrow();
+    expect(() => parseApprovalTimeout("", "--x")).toThrow();
+  });
+
+  it("rejects a duration exceeding Node's setTimeout max (~24.8 days)", () => {
+    expect(() => parseApprovalTimeout("30d", "--x")).toThrow(); // "d" unit unsupported anyway
+    expect(() => parseApprovalTimeout("2147483648", "--x")).toThrow(
+      /exceeds the max/,
+    );
+    // Just at the boundary is fine.
+    expect(parseApprovalTimeout("2147483647", "--x")).toBe(2_147_483_647);
+  });
+});
+
+describe("parseConfig --approval-timeout-<tier>", () => {
+  it("defaults approvalTimeouts to null when no flags are passed", () => {
+    const config = cfg("--workspace", "/tmp");
+    expect(config.approvalTimeouts).toBeNull();
+  });
+
+  it("sets a single tier's override", () => {
+    const config = cfg("--workspace", "/tmp", "--approval-timeout-low", "30s");
+    expect(config.approvalTimeouts).toEqual({ low: 30_000 });
+  });
+
+  it("accumulates multiple tier overrides", () => {
+    const config = cfg(
+      "--workspace",
+      "/tmp",
+      "--approval-timeout-low",
+      "30s",
+      "--approval-timeout-high",
+      "none",
+    );
+    expect(config.approvalTimeouts).toEqual({ low: 30_000, high: 0 });
+  });
+
+  it("throws on an invalid duration", () => {
+    expect(() =>
+      cfg("--workspace", "/tmp", "--approval-timeout-medium", "banana"),
+    ).toThrow(/--approval-timeout-medium/);
+  });
+});
+
+describe("sanitizeApprovalTimeouts", () => {
+  it("passes through valid integer ms values", () => {
+    expect(sanitizeApprovalTimeouts({ low: 1000, high: 0 })).toEqual({
+      low: 1000,
+      high: 0,
+    });
+  });
+
+  it("drops non-numeric, negative, decimal, and oversized values, keeping the rest", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        sanitizeApprovalTimeouts({
+          low: 1000,
+          medium: "not a number",
+          high: -1,
+        }),
+      ).toEqual({ low: 1000 });
+      expect(
+        sanitizeApprovalTimeouts({ low: 1.5, medium: 2_147_483_648 }),
+      ).toBeNull();
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("returns null for non-object / empty input", () => {
+    expect(sanitizeApprovalTimeouts(null)).toBeNull();
+    expect(sanitizeApprovalTimeouts(undefined)).toBeNull();
+    expect(sanitizeApprovalTimeouts("garbage")).toBeNull();
+    expect(sanitizeApprovalTimeouts({})).toBeNull();
   });
 });

--- a/src/__tests__/helpers/fixtures.ts
+++ b/src/__tests__/helpers/fixtures.ts
@@ -42,6 +42,7 @@ export function makeConfig(overrides: Partial<Config> = {}): Config {
     automationAllowPrivateWebhooks: false,
     toolRateLimit: 60,
     approvalGate: "off",
+    approvalTimeouts: null,
     enableTimeOfDayAnomaly: false,
     managedSettingsPath: null,
     approvalWebhookUrl: null,

--- a/src/__tests__/server-settings.test.ts
+++ b/src/__tests__/server-settings.test.ts
@@ -1078,3 +1078,296 @@ describe("POST /settings — push/ntfy persistence", () => {
     expect(persisted.pushServiceBaseUrl).toBe("https://bridge.example.com");
   });
 });
+
+describe("POST /settings — approvalTimeouts", () => {
+  afterEach(async () => {
+    const { resetApprovalQueueForTests } = await import("../approvalQueue.js");
+    resetApprovalQueueForTests();
+  });
+
+  it("rejects a non-object value", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalTimeouts: "banana" }),
+    );
+    expect(status).toBe(400);
+    expect(JSON.parse(body).error).toMatch(/must be an object/);
+  });
+
+  it("rejects an unknown tier key", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalTimeouts: { extreme: 1000 } }),
+    );
+    expect(status).toBe(400);
+    expect(JSON.parse(body).error).toMatch(/unknown key "extreme"/);
+  });
+
+  it("rejects a negative, decimal, or oversized per-tier value", async () => {
+    for (const bad of [-1, 1.5, 2_147_483_648]) {
+      const { status, body } = await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ approvalTimeouts: { low: bad } }),
+      );
+      expect(status).toBe(400);
+      expect(JSON.parse(body).error).toMatch(/approvalTimeouts\.low/);
+    }
+  });
+
+  it("does not require a restart (live-mutated field)", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalTimeouts: { low: 30_000 } }),
+    );
+    expect(status).toBe(200);
+    expect(JSON.parse(body).restartRequired).toBe(false);
+  });
+
+  it("applies live to the shared ApprovalQueue — a fresh entry uses the new TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const { getApprovalQueue } = await import("../approvalQueue.js");
+
+      await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ approvalTimeouts: { low: 1000 } }),
+      );
+
+      const { promise } = getApprovalQueue().request({
+        toolName: "a",
+        params: {},
+        tier: "low",
+      });
+      vi.advanceTimersByTime(1500);
+      await expect(promise).resolves.toBe("expired");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retroactively change an already-pending entry's deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const { getApprovalQueue } = await import("../approvalQueue.js");
+      // Default `low` TTL is 5 min — enqueue before the settings change.
+      const { promise } = getApprovalQueue().request({
+        toolName: "a",
+        params: {},
+        tier: "low",
+      });
+
+      await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ approvalTimeouts: { low: 1000 } }),
+      );
+
+      // If the new 1s TTL applied retroactively, this would already be
+      // "expired" — it must still be pending at the ORIGINAL 5-min TTL.
+      vi.advanceTimersByTime(1500);
+      expect(getApprovalQueue().size()).toBe(1);
+      vi.advanceTimersByTime(5 * 60_000);
+      await expect(promise).resolves.toBe("expired");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("merges into existing tiers rather than resetting untouched ones", async () => {
+    vi.useFakeTimers();
+    try {
+      const { getApprovalQueue } = await import("../approvalQueue.js");
+
+      await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ approvalTimeouts: { low: 1000 } }),
+      );
+      await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ approvalTimeouts: { high: 2000 } }),
+      );
+
+      // `low` from the first call must survive the second call, which only
+      // touched `high`.
+      const low = getApprovalQueue().request({
+        toolName: "a",
+        params: {},
+        tier: "low",
+      });
+      vi.advanceTimersByTime(1500);
+      await expect(low.promise).resolves.toBe("expired");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("an explicit null clears a tier's override back to DEFAULT_TTL_MS", async () => {
+    vi.useFakeTimers();
+    try {
+      const { getApprovalQueue } = await import("../approvalQueue.js");
+
+      await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ approvalTimeouts: { low: 1000 } }),
+      );
+      // Confirm the override is live before clearing it.
+      const before = getApprovalQueue().request({
+        toolName: "a",
+        params: {},
+        tier: "low",
+      });
+      vi.advanceTimersByTime(1500);
+      await expect(before.promise).resolves.toBe("expired");
+
+      const { status } = await makeRequest(
+        {
+          method: "POST",
+          path: "/settings",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${TOKEN}`,
+          },
+        },
+        JSON.stringify({ approvalTimeouts: { low: null } }),
+      );
+      expect(status).toBe(200);
+
+      // Back to the 5-min default — must NOT expire at the old 1s override.
+      const after = getApprovalQueue().request({
+        toolName: "a",
+        params: {},
+        tier: "low",
+      });
+      vi.advanceTimersByTime(1500);
+      expect(getApprovalQueue().size()).toBe(1);
+      void after;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a non-number, non-null tier value", async () => {
+    const { status, body } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalTimeouts: { medium: "1h" } }),
+    );
+    expect(status).toBe(400);
+    expect(JSON.parse(body).error).toMatch(/approvalTimeouts\.medium/);
+  });
+
+  it("persists to patchwork config and appears in the audit log", async () => {
+    const pw = await import("../patchworkConfig.js");
+    const saveSpy = vi.mocked(pw.saveConfig);
+    saveSpy.mockClear();
+    const { ActivityLog } = await import("../activityLog.js");
+    const log = new ActivityLog();
+    server!.activityLog = log;
+    const events: Array<{
+      event: string;
+      metadata?: Record<string, unknown>;
+    }> = [];
+    log.subscribe((_kind, entry) => {
+      if ("event" in entry) {
+        events.push({ event: entry.event, metadata: entry.metadata });
+      }
+    });
+
+    const { status } = await makeRequest(
+      {
+        method: "POST",
+        path: "/settings",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${TOKEN}`,
+        },
+      },
+      JSON.stringify({ approvalTimeouts: { medium: 45_000 } }),
+    );
+
+    expect(status).toBe(200);
+    const persisted = saveSpy.mock.calls[0]![0] as unknown as Record<
+      string,
+      unknown
+    >;
+    // toMatchObject, not toEqual: the mocked loadConfig() returns the same
+    // shared object reference across tests in this file (not a fresh
+    // per-call read like the real disk-backed loader), so earlier tests'
+    // merged tiers can still be present here — this test only cares that
+    // ITS tier made it into the persisted payload.
+    expect(persisted.approvalTimeouts).toMatchObject({ medium: 45_000 });
+
+    const change = events.find((e) => e.event === "settings.change");
+    expect(change).toBeDefined();
+    const fields = change!.metadata?.fields as string[];
+    expect(fields).toContain("approvalTimeouts");
+  });
+});

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -505,7 +505,8 @@ async function dispatchApprovalWebhook(
     tier: string;
     callId: string;
     requestedAt: number;
-    expiresAt: number;
+    /** `null` when this tier has no configured expiry. */
+    expiresAt: number | null;
     summary?: string;
   },
 ): Promise<void> {
@@ -543,7 +544,10 @@ async function dispatchApprovalWebhook(
       body: JSON.stringify({
         ...payload,
         requestedAt: new Date(payload.requestedAt).toISOString(),
-        expiresAt: new Date(payload.expiresAt).toISOString(),
+        expiresAt:
+          payload.expiresAt === null
+            ? null
+            : new Date(payload.expiresAt).toISOString(),
       }),
       signal: controller.signal,
     });
@@ -573,7 +577,8 @@ async function dispatchPushNotification(
     tier: string;
     callId: string;
     requestedAt: number;
-    expiresAt: number;
+    /** `null` when this tier has no configured expiry. */
+    expiresAt: number | null;
     summary?: string;
     riskSignals?: RiskSignal[];
     approvalToken: string;
@@ -914,13 +919,24 @@ export function enqueueApprovalWithDispatch(
   );
   recordApprovalPrompted();
 
+  // Read back the entry's actual resolved deadline rather than assuming a
+  // fixed 5-minute window — tiers can have different (or no) timeout per
+  // the risk-tiered approval config. `null` means "no expiry" for this tier.
+  //
+  // Safe against the entry expiring between request() and this peek(): this
+  // function is synchronous end-to-end (no `await` before this line), and
+  // an entry's setTimeout callback cannot fire mid-synchronous-execution —
+  // it needs an event-loop turn. If an `await` is ever introduced above
+  // this line, that guarantee breaks and this comment must move with it.
+  const expiresAt = deps.queue.peek(callId)?.expiresAt ?? null;
+
   if (deps.webhookUrl) {
     dispatchApprovalWebhook(deps.webhookUrl, {
       toolName,
       tier,
       callId,
       requestedAt: now,
-      expiresAt: now + 5 * 60_000,
+      expiresAt,
       summary,
     }).catch(() => {});
   }
@@ -934,7 +950,7 @@ export function enqueueApprovalWithDispatch(
         tier,
         callId,
         requestedAt: now,
-        expiresAt: now + 5 * 60_000,
+        expiresAt,
         summary,
         riskSignals,
         approvalToken,

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -36,6 +36,14 @@ export interface PendingApproval {
   params: Record<string, unknown>;
   tier: RiskTier;
   requestedAt: number;
+  /**
+   * Wall-clock deadline for auto-`"expired"` resolution, or `null` when this
+   * tier has no configured expiry (entry is held until a human decides).
+   * Computed once at enqueue time from the resolved per-tier TTL — callers
+   * (webhook/push dispatch, dashboard) should read this rather than
+   * re-deriving a timeout, since the actual value is config-dependent.
+   */
+  expiresAt: number | null;
   sessionId?: string;
   summary?: string;
   riskSignals?: RiskSignal[];
@@ -90,7 +98,8 @@ export type ApprovalDecision =
 
 interface Entry extends PendingApproval {
   resolve: (d: ApprovalDecision) => void;
-  timer: ReturnType<typeof setTimeout>;
+  /** Null when the resolved TTL for this entry's tier is "no expiry" (held until decided). */
+  timer: ReturnType<typeof setTimeout> | null;
   /**
    * Stable key derived from `(sessionId, toolName, params)`. Multiple `request()`
    * calls with the same key share the entry's promise instead of creating a
@@ -191,11 +200,66 @@ export class ApprovalQueue {
     string,
     { decision: ApprovalDecision; at: number }
   >();
-  private readonly ttlMs: number;
+  /**
+   * Per-tier approval timeout, ms. A tier's value of `0` means "no expiry" —
+   * the entry is held (never auto-`"expired"`) until a human decides or the
+   * caller cancels. Defaults follow the risk-tiered-timeout design: short
+   * fail-fast window for low-risk calls, longer window for medium, and a
+   * long-but-bounded window for high-risk calls (npm publish, PR merge,
+   * force-push) so a slow reviewer isn't pressured into rubber-stamping.
+   * Never auto-*approves* on timeout regardless of tier — a fired timer
+   * always resolves "expired".
+   *
+   * COMPATIBILITY NOTE: before risk-tiered timeouts existed, every tier
+   * (including high) shared one flat 5-minute TTL. This raises the *default*
+   * high-tier window to 4 hours — a deliberate fail-safe tradeoff (a
+   * high-risk approval left unattended still eventually fails closed,
+   * rather than either rubber-stamping under a 5-min countdown or hanging
+   * forever by default). Operators who want a genuinely unbounded hold can
+   * opt in explicitly via `--approval-timeout-high none`.
+   */
+  private ttlByTier: Record<RiskTier, number>;
   private readonly listeners = new Set<() => void>();
 
-  constructor(opts: { ttlMs?: number } = {}) {
-    this.ttlMs = opts.ttlMs ?? 5 * 60_000;
+  static readonly DEFAULT_TTL_MS: Record<RiskTier, number> = {
+    low: 5 * 60_000,
+    medium: 60 * 60_000,
+    high: 4 * 60 * 60_000,
+  };
+
+  constructor(
+    opts: { ttlMs?: number | Partial<Record<RiskTier, number>> } = {},
+  ) {
+    if (typeof opts.ttlMs === "number") {
+      // Back-compat: a bare number applies uniformly to every tier, matching
+      // the pre-risk-tiered-timeout behavior exactly.
+      this.ttlByTier = {
+        low: opts.ttlMs,
+        medium: opts.ttlMs,
+        high: opts.ttlMs,
+      };
+    } else {
+      this.ttlByTier = { ...ApprovalQueue.DEFAULT_TTL_MS, ...opts.ttlMs };
+    }
+  }
+
+  /** Resolved timeout in ms for a tier, or `0` meaning "no expiry". */
+  private resolveTtl(tier: RiskTier): number {
+    return this.ttlByTier[tier] ?? ApprovalQueue.DEFAULT_TTL_MS[tier];
+  }
+
+  /**
+   * Replace the per-tier timeout overrides at runtime (e.g. from
+   * `POST /settings`). Takes the same shape as the constructor's object
+   * form — tiers not present fall back to `DEFAULT_TTL_MS`, not to
+   * whatever was previously configured, so the caller's `overrides` is
+   * always the complete authoritative desired state (pass `null` to reset
+   * every tier to its default). Only affects entries `request()`-ed after
+   * this call; already-pending entries keep their already-computed
+   * `expiresAt` and running timer.
+   */
+  setTtlByTier(overrides: Partial<Record<RiskTier, number>> | null): void {
+    this.ttlByTier = { ...ApprovalQueue.DEFAULT_TTL_MS, ...(overrides ?? {}) };
   }
 
   /** Subscribe to queue changes (enqueue + resolve). Returns unsubscribe fn. */
@@ -215,7 +279,7 @@ export class ApprovalQueue {
   }
 
   request(
-    input: Omit<PendingApproval, "callId" | "requestedAt">,
+    input: Omit<PendingApproval, "callId" | "requestedAt" | "expiresAt">,
     opts: { withToken?: boolean; signal?: AbortSignal } = {},
   ): {
     callId: string;
@@ -266,20 +330,29 @@ export class ApprovalQueue {
     const promise = new Promise<ApprovalDecision>((res) => {
       resolveFn = res;
     });
-    const timer = setTimeout(() => {
-      const entry = this.entries.get(callId);
-      if (!entry) return;
-      this.entries.delete(callId);
-      this.inflight.delete(entry.inflightKey);
-      entry.resolve("expired");
-      for (const r of entry.pendingPromises) r("expired");
-      this.notify();
-    }, this.ttlMs);
-    if (typeof timer === "object" && "unref" in timer) timer.unref();
+    const ttl = this.resolveTtl(input.tier);
+    // ttl === 0 means "no expiry" for this tier (opt-in only — no tier
+    // defaults to this) — hold the entry until a human decides or the
+    // caller cancels. Never auto-approve; the only way off this path is
+    // cancel()/approve()/reject().
+    const timer =
+      ttl > 0
+        ? setTimeout(() => {
+            const entry = this.entries.get(callId);
+            if (!entry) return;
+            this.entries.delete(callId);
+            this.inflight.delete(entry.inflightKey);
+            entry.resolve("expired");
+            for (const r of entry.pendingPromises) r("expired");
+            this.notify();
+          }, ttl)
+        : null;
+    if (timer && typeof timer === "object" && "unref" in timer) timer.unref();
 
     this.entries.set(callId, {
       callId,
       requestedAt,
+      expiresAt: ttl > 0 ? requestedAt + ttl : null,
       resolve: resolveFn,
       timer,
       approvalToken,
@@ -416,6 +489,7 @@ export class ApprovalQueue {
         params: e.params,
         tier: e.tier,
         requestedAt: e.requestedAt,
+        expiresAt: e.expiresAt,
         sessionId: e.sessionId,
         summary: e.summary,
         riskSignals: e.riskSignals,
@@ -430,10 +504,28 @@ export class ApprovalQueue {
     return this.entries.size;
   }
 
+  /** Look up a single pending entry's public fields (e.g. for webhook/push payloads that need `expiresAt`). */
+  peek(callId: string): PendingApproval | undefined {
+    const e = this.entries.get(callId);
+    if (!e) return undefined;
+    return {
+      callId: e.callId,
+      toolName: e.toolName,
+      params: e.params,
+      tier: e.tier,
+      requestedAt: e.requestedAt,
+      expiresAt: e.expiresAt,
+      sessionId: e.sessionId,
+      summary: e.summary,
+      riskSignals: e.riskSignals,
+      personalSignals: e.personalSignals,
+    };
+  }
+
   /** Clear all pending entries (test hook, also on bridge shutdown). */
   clear(): void {
     for (const entry of this.entries.values()) {
-      clearTimeout(entry.timer);
+      if (entry.timer) clearTimeout(entry.timer);
       entry.resolve("expired");
       // Wake up any duplicate callers who joined this entry via dedup —
       // their promises would otherwise hang forever after shutdown /
@@ -451,7 +543,7 @@ export class ApprovalQueue {
   private resolveEntry(callId: string, decision: ApprovalDecision): boolean {
     const entry = this.entries.get(callId);
     if (!entry) return false;
-    clearTimeout(entry.timer);
+    if (entry.timer) clearTimeout(entry.timer);
     this.entries.delete(callId);
     this.inflight.delete(entry.inflightKey);
     // Record the decision in the short-lived `recentlyDecided` map so a
@@ -501,8 +593,28 @@ const RECENTLY_DECIDED_TTL_MS = 60_000;
 
 /** Process-wide singleton — dashboard + bridge share one queue. */
 let singleton: ApprovalQueue | undefined;
-export function getApprovalQueue(): ApprovalQueue {
-  if (!singleton) singleton = new ApprovalQueue();
+/**
+ * `opts` only takes effect the first time this is called for the process
+ * (i.e. when the singleton is constructed) — later calls ignore it and
+ * return the existing instance. `Bridge`'s constructor calls this with the
+ * resolved `config.approvalTimeouts` before any other code path can reach a
+ * bare `getApprovalQueue()`, so the configured timeouts always win.
+ */
+export function getApprovalQueue(opts?: {
+  ttlMs?: Partial<Record<RiskTier, number>>;
+}): ApprovalQueue {
+  if (!singleton) {
+    singleton = new ApprovalQueue(opts);
+  } else if (opts?.ttlMs) {
+    // Not a bug today — Bridge's constructor is the only caller that ever
+    // passes `opts`, and it runs before any other code path can reach
+    // getApprovalQueue(). But if that invariant ever breaks (a second entry
+    // point, an import-order change), silently discarding a caller's
+    // configured timeouts would be a confusing way to find out. Surface it.
+    console.warn(
+      "[approvalQueue] getApprovalQueue() called with ttlMs after the singleton already exists — ignoring; the queue's timeouts were already fixed by an earlier caller.",
+    );
+  }
   return singleton;
 }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -214,6 +214,12 @@ export class Bridge {
   private tokenUsageTracker: TokenUsageTracker;
 
   constructor(private config: Config) {
+    // Seed the process-wide ApprovalQueue singleton with the configured
+    // per-risk-tier timeouts before any other code path can reach a bare
+    // getApprovalQueue() (which would otherwise lock in the hardcoded
+    // defaults). Must be the first call in the constructor — see
+    // getApprovalQueue()'s doc comment in approvalQueue.ts.
+    getApprovalQueue({ ttlMs: config.approvalTimeouts ?? undefined });
     this.logger = new Logger(config.verbose, config.jsonl);
     this.lockFile = new LockFileManager(this.logger);
     const configDir =
@@ -1745,6 +1751,7 @@ export class Bridge {
     this.server.managedSettingsPath =
       this.config.managedSettingsPath ?? undefined;
     this.server.approvalGate = this.config.approvalGate ?? "off";
+    this.server.approvalTimeouts = this.config.approvalTimeouts ?? undefined;
     this.server.approvalWebhookUrl =
       this.config.approvalWebhookUrl ?? undefined;
     this.server.onApprovalDecision = (event, meta) =>
@@ -1877,6 +1884,7 @@ export class Bridge {
           return {
             workspace: this.config.workspace,
             approvalGate: this.server.approvalGate,
+            approvalTimeouts: this.server.approvalTimeouts ?? null,
             enableTimeOfDayAnomaly: this.server.enableTimeOfDayAnomaly,
             fullMode: this.config.fullMode,
             driver: this.config.driver,

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,76 @@ import {
   defaultConfigPath as patchworkConfigPath,
 } from "./patchworkConfig.js";
 
+/**
+ * Node's setTimeout silently fires almost immediately (with a runtime
+ * warning) for any delay exceeding a signed 32-bit int of ms (~24.8 days) —
+ * it does NOT throw or clamp to "wait longer". A configured tier timeout
+ * above this would silently defeat the operator's intent to give a
+ * long-lived review window; reject it at parse time instead. Use
+ * `"none"`/`"infinite"` for genuinely unbounded holds.
+ */
+export const MAX_APPROVAL_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Unlike the CLI flag path (`parseApprovalTimeout`, which throws on bad
+ * input), `approvalTimeouts` loaded from `~/.patchwork/config.json` is
+ * dashboard-writable and read at every startup — a malformed or corrupted
+ * value there must not crash the bridge. Drop invalid per-tier entries
+ * (logging why) rather than let a bad float/negative/oversized number reach
+ * `ApprovalQueue`'s raw `setTimeout` call.
+ */
+export function sanitizeApprovalTimeouts(
+  raw: unknown,
+): Partial<Record<"low" | "medium" | "high", number>> | null {
+  if (!raw || typeof raw !== "object") return null;
+  const out: Partial<Record<"low" | "medium" | "high", number>> = {};
+  for (const tier of ["low", "medium", "high"] as const) {
+    const v = (raw as Record<string, unknown>)[tier];
+    if (v === undefined) continue;
+    if (
+      typeof v !== "number" ||
+      !Number.isInteger(v) ||
+      v < 0 ||
+      v > MAX_APPROVAL_TIMEOUT_MS
+    ) {
+      console.warn(
+        `[config] Ignoring invalid approvalTimeouts.${tier} in patchwork config (must be an integer ms between 0 and ${MAX_APPROVAL_TIMEOUT_MS}): ${JSON.stringify(v)}`,
+      );
+      continue;
+    }
+    out[tier] = v;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Parse a `--approval-timeout-<tier>` CLI value into ms. `0` means "no
+ * expiry" for that tier — never auto-expire the held approval.
+ *
+ * Accepts: `"none"` / `"infinite"` (no expiry), a bare integer (ms), or a
+ * duration string with a single `s`/`m`/`h` suffix (e.g. `"30s"`, `"5m"`,
+ * `"2h"`).
+ */
+export function parseApprovalTimeout(raw: string, flagName: string): number {
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "none" || trimmed === "infinite") return 0;
+  const match = /^(\d+)(s|m|h)?$/.exec(trimmed);
+  if (!match) {
+    throw new Error(
+      `${flagName} must be "none", "infinite", a millisecond integer, or a duration like "30s"/"5m"/"2h" (got "${raw}")`,
+    );
+  }
+  const n = Number(match[1]);
+  const unitMs = { s: 1_000, m: 60_000, h: 3_600_000 } as const;
+  const ms = match[2] ? n * unitMs[match[2] as "s" | "m" | "h"] : n;
+  if (ms > MAX_APPROVAL_TIMEOUT_MS) {
+    throw new Error(
+      `${flagName} exceeds the max representable timeout (~24.8 days / ${MAX_APPROVAL_TIMEOUT_MS}ms) — Node's setTimeout fires almost immediately past this, silently defeating a longer intended window. Use "none"/"infinite" for an unbounded hold instead (got "${raw}").`,
+    );
+  }
+  return ms;
+}
+
 export interface Config {
   workspace: string;
   workspaceFolders: string[];
@@ -61,6 +131,17 @@ export interface Config {
   managedSettingsPath: string | null;
   /** Patchwork: outbound webhook URL for approval queue notifications (from dashboard.webhookUrl in patchwork config). */
   approvalWebhookUrl: string | null;
+  /**
+   * Patchwork: per-risk-tier approval timeout override, in ms. A tier's
+   * value of `0` means "no expiry" — the queued approval is held until a
+   * human decides (never auto-approved). Tiers not present here fall back
+   * to `ApprovalQueue.DEFAULT_TTL_MS` (low=5min, medium=60min, high=4h).
+   * Set per-tier via `--approval-timeout-<low|medium|high> <dur>`
+   * (accepts `"none"`/`"infinite"` for no expiry, a bare ms integer, or a
+   * duration like `30s`/`5m`/`2h`) or `approvalTimeouts` in
+   * `~/.patchwork/config.json`. See docs on risk-tiered approval timeouts.
+   */
+  approvalTimeouts: Partial<Record<"low" | "medium" | "high", number>> | null;
   /**
    * Patchwork mobile-oversight push relay (FCM/APNS gateway). Seeded from
    * `~/.patchwork/config.json`; previously only set by POST /settings, so
@@ -568,6 +649,11 @@ export function parseConfig(argv: string[]): Config {
   let approvalGate: "off" | "high" | "all" =
     (fileConfig as { approvalGate?: "off" | "high" | "all" }).approvalGate ??
     "off";
+  let approvalTimeouts: Partial<
+    Record<"low" | "medium" | "high", number>
+  > | null = sanitizeApprovalTimeouts(
+    (fileConfig as { approvalTimeouts?: unknown }).approvalTimeouts,
+  );
   let enableTimeOfDayAnomaly: boolean =
     (fileConfig as { enableTimeOfDayAnomaly?: boolean })
       .enableTimeOfDayAnomaly ?? false;
@@ -588,6 +674,12 @@ export function parseConfig(argv: string[]): Config {
         !(fileConfig as { approvalGate?: string }).approvalGate
       ) {
         approvalGate = pw.approvalGate;
+      }
+      if (
+        pw.approvalTimeouts &&
+        !(fileConfig as { approvalTimeouts?: unknown }).approvalTimeouts
+      ) {
+        approvalTimeouts = sanitizeApprovalTimeouts(pw.approvalTimeouts);
       }
       pushServiceUrl = pw.pushServiceUrl ?? null;
       pushServiceToken = pw.pushServiceToken ?? null;
@@ -788,6 +880,24 @@ export function parseConfig(argv: string[]): Config {
           );
         }
         approvalGate = val;
+        break;
+      }
+      case "--approval-timeout-low":
+      case "--approval-timeout-medium":
+      case "--approval-timeout-high": {
+        // args[i] matched one of the three case labels above, so it's
+        // always a string here; requireArg needs the flag name for its
+        // own error message before we've consumed the value arg.
+        const flagName = args[i] ?? "--approval-timeout";
+        const tier = flagName.slice("--approval-timeout-".length) as
+          | "low"
+          | "medium"
+          | "high";
+        const val = requireArg(args, ++i, flagName);
+        approvalTimeouts = {
+          ...approvalTimeouts,
+          [tier]: parseApprovalTimeout(val, flagName),
+        };
         break;
       }
       case "--enable-time-of-day-anomaly": {
@@ -1196,6 +1306,7 @@ Environment Variables:
     automationPolicyPath,
     automationAllowPrivateWebhooks,
     approvalGate,
+    approvalTimeouts,
     enableTimeOfDayAnomaly,
     managedSettingsPath,
     approvalWebhookUrl,

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -50,6 +50,14 @@ export interface PatchworkConfig {
   /** Approval gate level — mirrors CLI --approval-gate. Persisted so dashboard changes survive restart. */
   approvalGate?: "off" | "high" | "all";
   /**
+   * Per-risk-tier approval timeout override, in ms — mirrors CLI
+   * `--approval-timeout-<low|medium|high>`. A tier's value of `0` means
+   * "no expiry" (held until a human decides). Unset tiers fall back to
+   * `ApprovalQueue.DEFAULT_TTL_MS`. Persisted so dashboard changes survive
+   * restart.
+   */
+  approvalTimeouts?: Partial<Record<"low" | "medium" | "high", number>>;
+  /**
    * Opt-in toggle for personalSignals heuristic 10 (time-of-day anomaly).
    * Mirrors CLI --enable-time-of-day-anomaly. Persisted so dashboard
    * changes survive restart. Default false — h10 is off until the user

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ import {
   handleClaudeAuthComplete,
   handleClaudeAuthStart,
 } from "./claudeAuthHttp.js";
-import { saveBridgeConfigDriver } from "./config.js";
+import { MAX_APPROVAL_TIMEOUT_MS, saveBridgeConfigDriver } from "./config.js";
 import {
   tryHandleConnectorRoute,
   tryHandlePublicConnectorRoute,
@@ -445,6 +445,16 @@ export class Server extends EventEmitter<ServerEvents> {
   public webhookSecret: string | null = null;
   /** Patchwork: live approval gate level — mutated by POST /settings, read by bridge per-session setup. */
   public approvalGate: "off" | "high" | "all" = "off";
+  /**
+   * Patchwork: live per-risk-tier approval timeout override — mutated by
+   * POST /settings, pushed into the shared ApprovalQueue via
+   * `setTtlByTier()`. `undefined` per-tier falls back to
+   * `ApprovalQueue.DEFAULT_TTL_MS`. Only affects entries queued AFTER the
+   * change; already-pending entries keep their originally-computed deadline.
+   */
+  public approvalTimeouts:
+    | Partial<Record<"low" | "medium" | "high", number>>
+    | undefined = undefined;
   /** Patchwork: outbound webhook URL for approval notifications (from dashboard.webhookUrl in config). */
   public approvalWebhookUrl: string | undefined = undefined;
   /** Patchwork: push relay service URL — when set, per-callId approval tokens are generated. */
@@ -1843,6 +1853,7 @@ export class Server extends EventEmitter<ServerEvents> {
         const parsed = await readJsonBody<{
           webhookUrl?: string;
           approvalGate?: string;
+          approvalTimeouts?: Record<string, unknown>;
           enableTimeOfDayAnomaly?: boolean;
           driver?: string;
           model?: string;
@@ -1872,6 +1883,7 @@ export class Server extends EventEmitter<ServerEvents> {
               respondIfUnknownBodyKeys(res, body, [
                 "webhookUrl",
                 "approvalGate",
+                "approvalTimeouts",
                 "enableTimeOfDayAnomaly",
                 "driver",
                 "model",
@@ -1922,6 +1934,61 @@ export class Server extends EventEmitter<ServerEvents> {
             ) {
               respond400('approvalGate must be "off", "high", or "all"');
               return;
+            }
+
+            // approvalTimeouts — per-tier override, ms. Unlike the lenient
+            // sanitizer used when reading a possibly-stale config file
+            // (src/config.ts's sanitizeApprovalTimeouts, which drops bad
+            // entries with a warning), a live /settings POST is rejected
+            // outright on any invalid entry — Phase 1's "reject before any
+            // side effect" contract applies to this field too.
+            const timeoutsRaw = body.approvalTimeouts;
+            // A tier's value of `null` explicitly clears that tier's
+            // override (delete the key so it falls back to
+            // ApprovalQueue.DEFAULT_TTL_MS) — distinct from omitting the
+            // key entirely, which means "leave whatever is already saved
+            // for this tier untouched". Without this, the dashboard would
+            // have no way to un-set an override once saved.
+            let approvalTimeoutsValidated:
+              | Partial<Record<"low" | "medium" | "high", number | null>>
+              | undefined;
+            if (timeoutsRaw !== undefined) {
+              if (typeof timeoutsRaw !== "object" || timeoutsRaw === null) {
+                respond400("approvalTimeouts must be an object");
+                return;
+              }
+              const allowedTiers = ["low", "medium", "high"] as const;
+              const unknownTierKey = Object.keys(timeoutsRaw).find(
+                (k) =>
+                  !allowedTiers.includes(k as (typeof allowedTiers)[number]),
+              );
+              if (unknownTierKey) {
+                respond400(
+                  `approvalTimeouts has unknown key "${unknownTierKey}" — only low/medium/high allowed`,
+                );
+                return;
+              }
+              approvalTimeoutsValidated = {};
+              for (const tier of allowedTiers) {
+                const v = (timeoutsRaw as Record<string, unknown>)[tier];
+                if (v === undefined) continue;
+                if (v === null) {
+                  approvalTimeoutsValidated[tier] = null;
+                  continue;
+                }
+                if (
+                  typeof v !== "number" ||
+                  !Number.isInteger(v) ||
+                  v < 0 ||
+                  v > MAX_APPROVAL_TIMEOUT_MS
+                ) {
+                  respond400(
+                    `approvalTimeouts.${tier} must be an integer ms between 0 and ${MAX_APPROVAL_TIMEOUT_MS} (0 = no expiry), or null to clear the override`,
+                  );
+                  return;
+                }
+                approvalTimeoutsValidated[tier] = v;
+              }
             }
 
             // enableTimeOfDayAnomaly
@@ -2124,6 +2191,26 @@ export class Server extends EventEmitter<ServerEvents> {
             if (gateRaw !== undefined) {
               cfg.approvalGate = gateRaw as "off" | "high" | "all";
             }
+            if (approvalTimeoutsValidated !== undefined) {
+              // Merge into the existing per-tier map — same convention as
+              // `cfg.dashboard` above (partial updates preserve untouched
+              // keys). A dashboard control that only lets the user edit one
+              // tier must not silently reset the other two to their default.
+              const merged: Partial<Record<"low" | "medium" | "high", number>> =
+                { ...cfg.approvalTimeouts };
+              for (const [tier, v] of Object.entries(
+                approvalTimeoutsValidated,
+              )) {
+                const key = tier as "low" | "medium" | "high";
+                if (v === null) {
+                  delete merged[key]; // explicit clear → fall back to DEFAULT_TTL_MS
+                } else if (v !== undefined) {
+                  merged[key] = v;
+                }
+              }
+              cfg.approvalTimeouts =
+                Object.keys(merged).length > 0 ? merged : undefined;
+            }
             if (body.enableTimeOfDayAnomaly !== undefined) {
               cfg.enableTimeOfDayAnomaly = body.enableTimeOfDayAnomaly;
             }
@@ -2265,6 +2352,15 @@ export class Server extends EventEmitter<ServerEvents> {
                 }
               }
             }
+            if (approvalTimeoutsValidated !== undefined) {
+              // Push the merged (not delta) map read back from `cfg` so
+              // live state and disk agree, then apply it to the shared
+              // queue — only entries request()-ed from here on are
+              // affected; already-pending ones keep their computed
+              // deadline (see setTtlByTier's doc comment).
+              this.approvalTimeouts = cfg.approvalTimeouts;
+              getApprovalQueue().setTtlByTier(cfg.approvalTimeouts ?? null);
+            }
             if (body.enableTimeOfDayAnomaly !== undefined) {
               this.enableTimeOfDayAnomaly = body.enableTimeOfDayAnomaly;
             }
@@ -2312,6 +2408,8 @@ export class Server extends EventEmitter<ServerEvents> {
               const changes: Record<string, unknown> = {};
               if (hasWebhookUpdate) changes.webhookUrl = webhookRaw || "";
               if (gateRaw !== undefined) changes.approvalGate = gateRaw;
+              if (approvalTimeoutsValidated !== undefined)
+                changes.approvalTimeouts = approvalTimeoutsValidated;
               if (body.enableTimeOfDayAnomaly !== undefined)
                 changes.enableTimeOfDayAnomaly = body.enableTimeOfDayAnomaly;
               if (driverRaw !== undefined) changes.driver = driverRaw;


### PR DESCRIPTION
## Summary
- Replace the single flat 5-minute approval-queue TTL with a per-`RiskTier` timeout (`low`=5min, `medium`=60min, `high`=4h by default) — a short countdown on a high-risk action (npm publish, PR merge, force-push) pressures the reviewer into rubber-stamping to beat the clock, which defeats the point of gating it at all.
- Configurable via CLI (`--approval-timeout-<low|medium|high> <duration>`), `~/.patchwork/config.json`, and now **live** via `POST /settings` — no bridge restart required, mirroring how `approvalGate` already works. A tier can be set to `"none"`/`0` for an unbounded hold; a fired timer always resolves `"expired"`, never `"approved"`, regardless of tier.
- Amends ADR-0006 with the full design rationale and sweeps stale "5 min TTL" claims out of `documents/platform-docs.md`, `docs/mobile-oversight.md`, and `docs/mobile-oversight-mvp.md`.

## Bugs found and fixed along the way
- Dashboard countdown treated an explicit "no expiry" `null` the same as a missing field, rendering a fake 5-minute countdown that immediately read "Expired" for every high-tier approval.
- An early version of the settings-page dirty-tracking mutated a ref as a side effect inside a `setState` functional updater — since React can invoke an updater more than once, this could silently rebase the dirty-check baseline mid-edit. Fixed by splitting into two refs, mirroring the existing `gateValueRef`/`gatePendingRef` pattern exactly.
- `parseApprovalTimeout` had no upper bound — a configured duration above Node's `setTimeout` ceiling (~24.8 days) would silently fire almost immediately instead of waiting. Now rejected at parse time (CLI, config-file loader, and the `/settings` validator all agree on the same bound).

## Test plan
- [x] `npx tsc --noEmit` clean (bridge + dashboard)
- [x] `npx biome check` / `next lint` clean
- [x] 269 bridge-side tests pass across `approvalQueue`, `config`, `approvalHttp`, `server-settings`, `mobileOversight.e2e`, `patchworkConfig` test files (many new: per-tier TTL, no-expiry hold, bounds/validation, live `/settings` merge + null-clear + audit log)
- [ ] Manual click-through of the new "Approval timeouts" control in the dashboard settings page (not yet done — no existing RTL test file for this page either; flagged as a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)