### PR TITLE
fix(oauth): advertise RFC 9207 iss echo in discovery doc

### DIFF
--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -203,6 +203,22 @@ describe("OAuthServerImpl — discovery", () => {
     expect(body.grant_types_supported).toContain("authorization_code");
     expect(body.response_types_supported).toContain("code");
   });
+
+  it("advertises RFC 9207 iss echo, which handleAuthorize actually emits", () => {
+    const oauth = makeOAuth();
+    const res = new MockResponse();
+    oauth.handleDiscovery(res as unknown as http.ServerResponse);
+    const body = res.json() as Record<string, unknown>;
+    expect(body.authorization_response_iss_parameter_supported).toBe(true);
+  });
+
+  it("advertises CIMD support (SEP-991) so clients skip deprecated DCR", () => {
+    const oauth = makeOAuth();
+    const res = new MockResponse();
+    oauth.handleDiscovery(res as unknown as http.ServerResponse);
+    const body = res.json() as Record<string, unknown>;
+    expect(body.client_id_metadata_document_supported).toBe(true);
+  });
 });
 
 // ── GET /oauth/authorize ──────────────────────────────────────────────────────

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -12,7 +12,7 @@ import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
-import { OAuthServerImpl } from "../oauth.js";
+import { isValidCimdRedirectUri, OAuthServerImpl } from "../oauth.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -212,12 +212,21 @@ describe("OAuthServerImpl — discovery", () => {
     expect(body.authorization_response_iss_parameter_supported).toBe(true);
   });
 
-  it("advertises CIMD support (SEP-991) so clients skip deprecated DCR", () => {
+  // Regression guard: do NOT advertise CIMD until `isValidCimdRedirectUri`
+  // accepts loopback http (which `handleRegister` already permits) and
+  // `fetchCimd` validates the doc's own client_id + path component. Advertising
+  // it early makes conformant clients prefer a path that 400s for every
+  // native/CLI client whose redirect_uri is http://127.0.0.1/...
+  it("does not advertise CIMD while loopback redirect_uris would be rejected", () => {
     const oauth = makeOAuth();
     const res = new MockResponse();
     oauth.handleDiscovery(res as unknown as http.ServerResponse);
     const body = res.json() as Record<string, unknown>;
-    expect(body.client_id_metadata_document_supported).toBe(true);
+    expect(body.client_id_metadata_document_supported).toBeUndefined();
+    // The asymmetry this guards against, asserted directly:
+    expect(isValidCimdRedirectUri("http://127.0.0.1:3000/callback")).toBe(
+      false,
+    );
   });
 });
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -309,11 +309,17 @@ export class OAuthServerImpl implements OAuthServer {
       // AS mix-up attack; emitting it silently does nothing for clients that
       // can't tell whether its absence is meaningful.
       authorization_response_iss_parameter_supported: true,
-      // SEP-991 Client ID Metadata Documents. `handleAuthorize` resolves an
-      // https:// client_id via `fetchCimd`, so clients need not pre-register.
-      // Unadvertised, a conformant client skips CIMD and falls back to RFC 7591
-      // dynamic registration — which is deprecated as of MCP 2026-07-28.
-      client_id_metadata_document_supported: true,
+      // NOT advertised: `client_id_metadata_document_supported`. CIMD is
+      // implemented (`fetchCimd`) but `isValidCimdRedirectUri` rejects
+      // non-https redirect_uris, while `handleRegister` deliberately permits
+      // loopback http (RFC 8252). Advertising CIMD makes a conformant client
+      // prefer it over dynamic registration, so a native/CLI client whose only
+      // redirect_uri is `http://127.0.0.1/...` would get its doc filtered to
+      // empty and fail with invalid_client instead of registering successfully.
+      // Two unmet spec MUSTs also block it: `fetchCimd` never checks that the
+      // document's own `client_id` equals the fetch URL, nor that the client_id
+      // has a path component. Fix those and reconcile the two redirect-uri
+      // policies before advertising this.
     });
   }
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -303,6 +303,17 @@ export class OAuthServerImpl implements OAuthServer {
       code_challenge_methods_supported: ["S256"],
       token_endpoint_auth_methods_supported: ["none"],
       scopes_supported: SUPPORTED_SCOPES,
+      // RFC 9207 — we always echo `iss` on the authorization response (both the
+      // approve and deny paths). Advertising it lets a conformant client *reject*
+      // a response that arrives without `iss`, which is what actually closes the
+      // AS mix-up attack; emitting it silently does nothing for clients that
+      // can't tell whether its absence is meaningful.
+      authorization_response_iss_parameter_supported: true,
+      // SEP-991 Client ID Metadata Documents. `handleAuthorize` resolves an
+      // https:// client_id via `fetchCimd`, so clients need not pre-register.
+      // Unadvertised, a conformant client skips CIMD and falls back to RFC 7591
+      // dynamic registration — which is deprecated as of MCP 2026-07-28.
+      client_id_metadata_document_supported: true,
     });
   }
 


### PR DESCRIPTION
Advertises one capability the bridge already implements. Found while assessing the MCP `2026-07-28` revision against our OAuth mode.

### `authorization_response_iss_parameter_supported: true`
`handleAuthorize` already sets `iss` on both of its redirect paths — approve (`src/oauth.ts:623`) and deny (`:571`), the only two in the file; every error path terminates non-redirect. Without the discovery flag a conformant client cannot treat a *missing* `iss` as an error, so an authorization-server mix-up attacker just strips it. Emitting the parameter without advertising it closes nothing. Field name is RFC 9207 §3 verbatim.

### What this PR deliberately does NOT do
An earlier revision of this branch also advertised `client_id_metadata_document_supported`. That was wrong and has been reverted in `e1d70b14`:

- `isValidCimdRedirectUri` (`src/oauth.ts:152`) rejects any non-https `redirect_uri`, while `handleRegister` (`:367-368`) deliberately permits loopback http per RFC 8252. A CIMD document listing only `http://127.0.0.1:.../callback` — what native/CLI MCP clients use, and the spec's own worked example — filters to empty, `fetchCimd` returns `null`, and the client gets `invalid_client`/400.
- Advertising the capability makes a conformant client *prefer* CIMD over dynamic registration, so it would convert working clients into failing ones.
- Two spec MUSTs are also unmet: `fetchCimd` never checks the document's own `client_id` against the fetch URL, nor that `client_id` has a path component (`https://evil.com` is accepted).

The test asserts the field is **absent** and pins the loopback asymmetry, so re-advertising without first fixing the validator fails CI. Fixing CIMD properly (reconcile the two redirect-uri policies, add the `client_id` and path checks) is a separate PR.

### Scope
Metadata-only; no behavior change on any request path.

`npx vitest run src/__tests__/oauth.test.ts src/__tests__/oauth-cimd-ssrf.test.ts` → 80 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)