### PR TITLE
docs(connectors): record why 12 webhook verifiers have no ingress path

### DIFF
--- a/src/connectors/airtable.ts
+++ b/src/connectors/airtable.ts
@@ -739,6 +739,22 @@ export function clearTokens(): void {
  * @param hmacHeader - Value of the `X-Airtable-Content-MAC` header (hex)
  * @param macSecretBase64 - The macSecretBase64 returned by createWebhook()
  * @returns true if the signature is valid
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads `x-airtable-content-mac`.
+ * A provider signs with ITS secret under ITS header, so its delivery is
+ * rejected at the outer gate before this could ever run. That is a feature
+ * gap, not a hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyAirtableWebhook(
   rawBody: Buffer | string,

--- a/src/connectors/caldiy.ts
+++ b/src/connectors/caldiy.ts
@@ -129,6 +129,22 @@ export function clearTokens(): void {
  *
  * Returns true only when the signature matches; returns false on any
  * mismatch or malformed input. Never throws.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads Cal.com's signature
+ * header. A provider signs with ITS secret under ITS header, so its delivery
+ * is rejected at the outer gate before this could ever run. That is a feature
+ * gap, not a hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyCalDiyWebhook(
   rawBody: string | Buffer,

--- a/src/connectors/circleci.ts
+++ b/src/connectors/circleci.ts
@@ -515,6 +515,22 @@ export class CircleCIConnector extends BaseConnector {
  * @param signatureHeader  Value of the `circleci-signature` header
  * @param signingSecret    The signing secret configured on the webhook
  * @returns true if the signature is valid, false otherwise
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads `circleci-signature`. A
+ * provider signs with ITS secret under ITS header, so its delivery is rejected
+ * at the outer gate before this could ever run. That is a feature gap, not a
+ * hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyCircleCIWebhook(
   rawBody: Buffer | string,

--- a/src/connectors/grafana.ts
+++ b/src/connectors/grafana.ts
@@ -411,6 +411,22 @@ export class GrafanaConnector extends BaseConnector {
  * Verify a Grafana 12+ alerting webhook signature.
  * Grafana signs the raw body with HMAC-SHA256 and sends the hex digest
  * in the X-Grafana-Alerting-Signature header (optionally prefixed "sha256=").
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads Grafana's signature
+ * header. A provider signs with ITS secret under ITS header, so its delivery
+ * is rejected at the outer gate before this could ever run. That is a feature
+ * gap, not a hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyGrafanaWebhook(
   rawBody: string | Buffer,

--- a/src/connectors/monday.ts
+++ b/src/connectors/monday.ts
@@ -864,6 +864,22 @@ export async function deleteWebhook(
  *                           incoming request (may be undefined/null).
  * @param signingSecret    - The webhook signing secret configured on Monday.
  * @returns true when the header matches the secret.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads monday.com's auth header.
+ * A provider signs with ITS secret under ITS header, so its delivery is
+ * rejected at the outer gate before this could ever run. That is a feature
+ * gap, not a hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyMondayWebhook(
   _rawBody: string,

--- a/src/connectors/paystack.ts
+++ b/src/connectors/paystack.ts
@@ -562,6 +562,22 @@ class PaystackApiError extends Error {
  * @param signature  Value of the `x-paystack-signature` header
  * @param secretKey  Paystack secret key used to sign events
  * @returns true if the signature matches, false otherwise
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads `x-paystack-signature`. A
+ * provider signs with ITS secret under ITS header, so its delivery is rejected
+ * at the outer gate before this could ever run. That is a feature gap, not a
+ * hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyPaystackWebhook(
   rawBody: Buffer | string,

--- a/src/connectors/pipedrive.ts
+++ b/src/connectors/pipedrive.ts
@@ -500,6 +500,22 @@ export class PipedriveConnector extends BaseConnector {
  * Verify a Pipedrive v2 webhook signature.
  * Pipedrive sends HMAC-SHA256 of the raw body signed with your client secret,
  * delivered in the `x-pipedrive-signature` header.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads Pipedrive's auth header. A
+ * provider signs with ITS secret under ITS header, so its delivery is rejected
+ * at the outer gate before this could ever run. That is a feature gap, not a
+ * hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyPipedriveWebhook(
   rawBody: string | Buffer,

--- a/src/connectors/resend.ts
+++ b/src/connectors/resend.ts
@@ -458,6 +458,22 @@ export class ResendConnector extends BaseConnector {
  * The signature header may contain multiple space-separated "v1,<base64>" values.
  *
  * Returns true if any of the provided signatures match.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads `svix-signature`. A
+ * provider signs with ITS secret under ITS header, so its delivery is rejected
+ * at the outer gate before this could ever run. That is a feature gap, not a
+ * hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyResendWebhook(
   rawBody: string,

--- a/src/connectors/supabase.ts
+++ b/src/connectors/supabase.ts
@@ -95,6 +95,23 @@ export function clearTokens(): void {
  * Verify a Supabase database webhook signature.
  * Supabase sends HMAC-SHA256 of the raw body in `x-supabase-webhook-secret`.
  * Uses constant-time comparison to prevent timing attacks.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads
+ * `x-supabase-webhook-secret`. A provider signs with ITS secret under ITS
+ * header, so its delivery is rejected at the outer gate before this could ever
+ * run. That is a feature gap, not a hole: the gate fails closed, nothing is
+ * accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifySupabaseWebhook(
   rawBody: string | Buffer,

--- a/src/connectors/todoist.ts
+++ b/src/connectors/todoist.ts
@@ -115,6 +115,22 @@ export function clearTokens(): void {
  * Verify a Todoist webhook payload.
  * Todoist signs the raw request body with HMAC-SHA256 and sends the result
  * as a base64-encoded value in the `X-Todoist-Hmac-SHA256` header.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads Todoist's HMAC header. A
+ * provider signs with ITS secret under ITS header, so its delivery is rejected
+ * at the outer gate before this could ever run. That is a feature gap, not a
+ * hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyTodoistWebhook(
   rawBody: string | Buffer,

--- a/src/connectors/vercel.ts
+++ b/src/connectors/vercel.ts
@@ -390,6 +390,22 @@ export class VercelConnector extends BaseConnector {
 /**
  * Vercel signs webhook payloads with HMAC-SHA1 over the raw body using the
  * client secret. The signature arrives as the `x-vercel-signature` header.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads `x-vercel-signature`. A
+ * provider signs with ITS secret under ITS header, so its delivery is rejected
+ * at the outer gate before this could ever run. That is a feature gap, not a
+ * hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyVercelWebhook(
   rawBody: string | Buffer,

--- a/src/connectors/woocommerce.ts
+++ b/src/connectors/woocommerce.ts
@@ -198,6 +198,22 @@ export function clearTokens(): void {
  * Verify an incoming WooCommerce webhook.
  * WooCommerce signs with HMAC-SHA256 over the raw body using the webhook secret,
  * then base64-encodes the digest. Delivered in X-WC-Webhook-Signature header.
+ *
+ * NO INGRESS PATH — deliberate, do not "clean up". Audited 2026-08-02 (#1216):
+ * this function is complete and correct, but nothing in `src/` outside this
+ * file calls it. `POST /hooks/*` (`src/server.ts`) accepts exactly two
+ * credentials — a Bearer token, or `X-Hub-Signature-256` HMAC'd with the
+ * bridge's own `--webhook-secret` — and never reads `x-wc-webhook-signature`.
+ * A provider signs with ITS secret under ITS header, so its delivery is
+ * rejected at the outer gate before this could ever run. That is a feature
+ * gap, not a hole: the gate fails closed, nothing is accepted-but-unverified.
+ *
+ * Wiring it up needs per-connector signing-secret storage (today there is one
+ * global `--webhook-secret`), header dispatch in the gate with the same
+ * multi-value/missing fail-closed handling as `readSingleSignatureHeader`,
+ * raw-body preservation per route, and a decision on whether provider
+ * verification replaces or supplements the bearer gate. Deferred until a user
+ * actually wants this provider's webhooks; do one connector end-to-end first.
  */
 export function verifyWooCommerceWebhook(
   rawBody: string | Buffer,


### PR DESCRIPTION
Closes #1216 — as **documented won't-do**, not built.

The twelve `verify*Webhook` functions can't run because `POST /hooks/*` reads exactly two credentials (Bearer, or `X-Hub-Signature-256` HMAC'd with the bridge's own `--webhook-secret`) and no provider-specific header. A provider signs with its own secret under its own header, so its delivery is rejected at the outer gate. That's a feature gap, not a hole — the gate fails closed.

No user wants any of these providers' webhooks, and wiring them up needs per-connector signing-secret storage, per-route raw-body preservation, and a decision on whether provider verification replaces or supplements the bearer gate. So each verifier gets a `NO INGRESS PATH` note — same treatment as the `elicit()` note in #1218 — stating the gap, why the code must not be deleted as dead, and what wiring it would take. A future audit re-finds the reasoning instead of re-deriving it or deleting working code.

Comment only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)