### PR TITLE
feat(recipes): prompt for missing required vars over MCP elicitation

### DIFF
--- a/src/__tests__/recipeOrchestration.test.ts
+++ b/src/__tests__/recipeOrchestration.test.ts
@@ -210,6 +210,113 @@ describe("RecipeOrchestration", () => {
     }
   });
 
+  // #1217 — inline elicitation for missing required vars. The halt above stays
+  // the fallback; these pin that the prompt can only ever ADD a human's answer.
+  const withRequiredVarRecipe = async (
+    run: (server: any, fireStub: any) => Promise<void>,
+  ) => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "ro-test-"));
+    const ymlPath = join(tmpDir, "bar.yaml");
+    writeFileSync(
+      ymlPath,
+      "trigger:\n  inputs:\n    - name: issueId\n      required: true\n      description: The issue to triage\nsteps: []\n",
+    );
+    try {
+      const { loadRecipePrompt, findYamlRecipePath } = await import(
+        "../recipesHttp.js"
+      );
+      vi.mocked(loadRecipePrompt).mockReturnValue(null as never);
+      vi.mocked(findYamlRecipePath).mockReturnValue(ymlPath as never);
+
+      const fireStub = vi.fn().mockResolvedValue({ ok: true, taskId: "y3" });
+      const server = makeServer();
+      const ro = new RecipeOrchestration({
+        server,
+        getOrchestrator: () => ({ enqueue: vi.fn(), runAndWait: vi.fn() }),
+        recipeOrchestrator: makeRecipeOrchestrator({ fire: fireStub }),
+        recipeRunLog: null,
+        workdir: "/tmp/ws",
+        logger: {},
+      });
+      ro.wireServerFns();
+      await run(server, fireStub);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  };
+
+  it("#1217: runRecipeFn fires when the operator supplies a missing var inline", async () => {
+    await withRequiredVarRecipe(async (server, fireStub) => {
+      server.elicitFn = vi.fn().mockResolvedValue({
+        action: "accept",
+        content: { issueId: "1217" },
+      });
+
+      const result = await (server.runRecipeFn as any)("bar");
+      expect(result).toEqual({ ok: true, taskId: "y3" });
+      // The answer must reach the run, not just unblock the gate.
+      expect(fireStub).toHaveBeenCalledWith(
+        expect.objectContaining({
+          seedContext: expect.objectContaining({ issueId: "1217" }),
+        }),
+      );
+      // The recipe author's own wording is what the operator sees.
+      const [, schema] = (server.elicitFn as any).mock.calls[0];
+      expect(schema.required).toEqual(["issueId"]);
+      expect(schema.properties.issueId.description).toBe("The issue to triage");
+    });
+  });
+
+  it("#1217: declining the prompt halts exactly as before", async () => {
+    await withRequiredVarRecipe(async (server, fireStub) => {
+      server.elicitFn = vi.fn().mockResolvedValue({ action: "decline" });
+      const result = await (server.runRecipeFn as any)("bar");
+      expect(result).toEqual({
+        ok: false,
+        error: "missing_required_vars:issueId",
+      });
+      expect(fireStub).not.toHaveBeenCalled();
+    });
+  });
+
+  it("#1217: a failing elicit (no WS client) halts rather than throwing", async () => {
+    await withRequiredVarRecipe(async (server, fireStub) => {
+      server.elicitFn = vi
+        .fn()
+        .mockRejectedValue(new Error("No active MCP client connected"));
+      const result = await (server.runRecipeFn as any)("bar");
+      expect(result).toEqual({
+        ok: false,
+        error: "missing_required_vars:issueId",
+      });
+      expect(fireStub).not.toHaveBeenCalled();
+    });
+  });
+
+  it("#1217: no elicitFn (HTTP/stdio/webhook/scheduler) is byte-identical to before", async () => {
+    await withRequiredVarRecipe(async (server, fireStub) => {
+      server.elicitFn = null;
+      const result = await (server.runRecipeFn as any)("bar");
+      expect(result).toEqual({
+        ok: false,
+        error: "missing_required_vars:issueId",
+      });
+      expect(fireStub).not.toHaveBeenCalled();
+    });
+  });
+
+  it("#1217: a caller-supplied var is never re-prompted", async () => {
+    await withRequiredVarRecipe(async (server, fireStub) => {
+      server.elicitFn = vi.fn();
+      const result = await (server.runRecipeFn as any)("bar", {
+        issueId: "already-set",
+      });
+      expect(result).toEqual({ ok: true, taskId: "y3" });
+      expect(server.elicitFn).not.toHaveBeenCalled();
+      expect(fireStub).toHaveBeenCalled();
+    });
+  });
+
   it('L5: runRecipeFn — required:"false" (string) must not block execution', async () => {
     // Bug: `!required` check treated the string "false" as truthy → vars
     // with required:"false" were incorrectly treated as mandatory.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -168,6 +168,20 @@ export class Bridge {
   private activityLog: ActivityLog;
   private authToken: string;
   private sessions = new Map<string, AgentSession>();
+
+  /**
+   * The most recently connected live WebSocket session, or null if there is
+   * none. Used to route `server.elicitFn` (#1217) — with several agents
+   * attached, the newest is the one a human is most likely sitting in front of.
+   */
+  private newestConnectedSession(): AgentSession | null {
+    let newest: AgentSession | null = null;
+    for (const session of this.sessions.values()) {
+      if (session.ws.readyState !== WebSocket.OPEN) continue;
+      if (!newest || session.connectedAt > newest.connectedAt) newest = session;
+    }
+    return newest;
+  }
   private fileLock = new FileLock();
   private probes: ProbeResults | null = null;
   private ready = false;
@@ -601,6 +615,18 @@ export class Bridge {
 
       transport.attach(ws);
       this.sessions.set(sessionId, session);
+      // #1217: expose an elicitation channel to the HTTP-side code (recipe
+      // orchestration) that has no transport of its own. Resolved lazily at
+      // call time rather than pinned to this session, so a reconnect or a
+      // second agent doesn't leave a stale closure pointing at a dead socket;
+      // `elicit()` itself rejects if the socket it picks isn't OPEN.
+      this.server.elicitFn = (message, requestedSchema) => {
+        const target = this.newestConnectedSession();
+        if (!target) {
+          return Promise.reject(new Error("No active MCP client connected"));
+        }
+        return target.transport.elicit(message, requestedSchema);
+      };
       this.logger.info(
         `Claude Code connected (session ${sessionId.slice(0, 8)}) — ${this.sessions.size} active session${this.sessions.size === 1 ? "" : "s"}`,
       );
@@ -1009,6 +1035,10 @@ export class Bridge {
     session.transport.detach();
     session.openedFiles.clear();
     this.sessions.delete(id);
+    // #1217: with no WS session left there is nobody to elicit from. Clearing
+    // this is what makes the recipe-orchestration caller fall straight through
+    // to its existing halt instead of waiting out an elicitation timeout.
+    if (!this.newestConnectedSession()) this.server.elicitFn = null;
 
     const errorPart =
       errorCount > 0

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -13,6 +13,10 @@ import type { ClaudeOrchestrator } from "./claudeOrchestrator.js";
 import { truncateUtf8Bytes } from "./drivers/outputCap.js";
 import { loadConfig } from "./patchworkConfig.js";
 import { getConfigDisabledNames } from "./recipes/disabledMarkers.js";
+import {
+  elicitMissingVars,
+  type MissingVarDeclaration,
+} from "./recipes/elicitMissingVars.js";
 import { summariseHalts } from "./recipes/haltCategory.js";
 import { summariseJudgments } from "./recipes/judgeSummary.js";
 import type { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
@@ -956,11 +960,41 @@ export class RecipeOrchestration {
       // Enforce required vars server-side. Browser-side HTML `required` attr is
       // bypassable (webhooks, scheduler, direct API calls). Return named missing
       // vars so the dashboard can surface them without parsing the YAML itself.
-      const missingRequired = checkRequiredVars(ymlPath, mergedVars);
-      if (missingRequired.length > 0) {
+      let effectiveVars = mergedVars;
+      let missingDeclarations = missingRequiredVarDeclarations(
+        ymlPath,
+        effectiveVars,
+      );
+
+      // #1217: before halting, offer the operator an inline prompt over MCP
+      // elicitation. Strictly additive — `elicit()` is WS-only, so this does
+      // nothing for Streamable-HTTP/stdio clients, dashboard POSTs, webhooks or
+      // the scheduler, all of which fall through to the halt below exactly as
+      // before. `elicitMissingVars` can only ADD human-typed values and never
+      // throws, so the halt stays fail-closed: a var nobody answered is still
+      // missing on the recheck.
+      if (missingDeclarations.length > 0 && server.elicitFn) {
+        const supplied = await elicitMissingVars({
+          recipeName: name,
+          declarations: missingDeclarations,
+          elicit: server.elicitFn,
+          onWarn: (msg) => this.deps.logger?.warn?.(msg),
+        });
+        if (Object.keys(supplied).length > 0) {
+          effectiveVars = { ...effectiveVars, ...supplied };
+          missingDeclarations = missingRequiredVarDeclarations(
+            ymlPath,
+            effectiveVars,
+          );
+        }
+      }
+
+      if (missingDeclarations.length > 0) {
         return {
           ok: false,
-          error: `missing_required_vars:${missingRequired.join(",")}`,
+          error: `missing_required_vars:${missingDeclarations
+            .map((d) => d.name)
+            .join(",")}`,
         };
       }
 
@@ -970,7 +1004,7 @@ export class RecipeOrchestration {
         taskIdPrefix: `yaml-recipe-${name}`,
         triggerSourceSuffix: `recipe:${name}`,
         logLabel: `"${name}"`,
-        seedContext: mergedVars,
+        seedContext: effectiveVars,
       });
     };
   }
@@ -1884,10 +1918,19 @@ export function collectUnknownToolIds(yaml: string): string[] {
 // back-compat with existing import sites (e.g. commands/recipe.ts).
 export { applyTriggerInputDefaults };
 
-function checkRequiredVars(
+/**
+ * Required vars the caller did not supply, with each var's declared
+ * `description` where the recipe gave one.
+ *
+ * Returning declarations rather than bare names is what lets the elicitation
+ * prompt (#1217) show the author's own wording for a var instead of just its
+ * key. The halt message below maps these back down to bare names, which is
+ * the only shape the dashboard has ever parsed.
+ */
+export function missingRequiredVarDeclarations(
   ymlPath: string,
   vars?: Record<string, string>,
-): string[] {
+): MissingVarDeclaration[] {
   let parsed: unknown;
   try {
     parsed = parseYaml(readFileSync(ymlPath, "utf-8"));
@@ -1898,7 +1941,8 @@ function checkRequiredVars(
     | Record<string, unknown>
     | null
     | undefined;
-  const missing: string[] = [];
+  const missing: MissingVarDeclaration[] = [];
+  const seen = new Set<string>();
   for (const key of ["inputs", "vars"] as const) {
     const arr = trigger?.[key];
     if (!Array.isArray(arr)) continue;
@@ -1916,8 +1960,19 @@ function checkRequiredVars(
           required !== "");
       if (typeof name !== "string" || !isRequired) continue;
       const val = vars?.[name];
-      if (val === undefined || val === null || String(val).trim() === "")
-        missing.push(name);
+      if (val !== undefined && val !== null && String(val).trim() !== "")
+        continue;
+      // A var declared under BOTH inputs and vars must not be prompted twice —
+      // the elicitation schema would carry a duplicate required key.
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const description = (item as { description?: unknown }).description;
+      missing.push({
+        name,
+        ...(typeof description === "string" && description.trim() !== ""
+          ? { description }
+          : {}),
+      });
     }
   }
   return missing;

--- a/src/recipes/__tests__/elicitMissingVars.test.ts
+++ b/src/recipes/__tests__/elicitMissingVars.test.ts
@@ -1,0 +1,155 @@
+/**
+ * #1217 — inline prompting for a recipe's missing required vars.
+ *
+ * The invariant every test here defends: this path may only ever ADD values a
+ * human typed. Any other outcome must leave the caller's existing
+ * `missing_required_vars` halt untouched.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildMissingVarsMessage,
+  buildMissingVarsSchema,
+  elicitMissingVars,
+} from "../elicitMissingVars.js";
+
+const DECLS = [
+  { name: "repo", description: "owner/name to file against" },
+  { name: "team" },
+];
+
+describe("buildMissingVarsSchema", () => {
+  it("marks every prompted var required", () => {
+    // An optional property would let a client return an 'accept' with the var
+    // still absent, which downstream reads as answered.
+    const schema = buildMissingVarsSchema(DECLS);
+    expect(schema.required).toEqual(["repo", "team"]);
+    expect(schema.type).toBe("object");
+  });
+
+  it("carries the recipe author's description through when there is one", () => {
+    const props = buildMissingVarsSchema(DECLS).properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.repo).toEqual({
+      type: "string",
+      description: "owner/name to file against",
+    });
+    expect(props.team).toEqual({ type: "string" });
+  });
+});
+
+describe("buildMissingVarsMessage", () => {
+  it("names the recipe and the vars", () => {
+    const msg = buildMissingVarsMessage("triage", DECLS);
+    expect(msg).toContain("triage");
+    expect(msg).toContain("repo, team");
+  });
+});
+
+describe("elicitMissingVars", () => {
+  it("returns the values the user supplied on accept", async () => {
+    const elicit = vi.fn().mockResolvedValue({
+      action: "accept",
+      content: { repo: "Oolab-labs/patchwork-os", team: "Engineering" },
+    });
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: DECLS, elicit }),
+    ).resolves.toEqual({
+      repo: "Oolab-labs/patchwork-os",
+      team: "Engineering",
+    });
+  });
+
+  it("returns nothing when the user declines", async () => {
+    const elicit = vi.fn().mockResolvedValue({ action: "decline" });
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: DECLS, elicit }),
+    ).resolves.toEqual({});
+  });
+
+  it("returns nothing when the user cancels", async () => {
+    const elicit = vi.fn().mockResolvedValue({ action: "cancel" });
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: DECLS, elicit }),
+    ).resolves.toEqual({});
+  });
+
+  it("swallows a rejected elicit (no client / timeout) rather than throwing", async () => {
+    // The caller's halt is the fallback; an exception here would turn a clean
+    // 'missing_required_vars' into an unhandled failure.
+    const onWarn = vi.fn();
+    const elicit = vi
+      .fn()
+      .mockRejectedValue(new Error("No active MCP client connected"));
+    await expect(
+      elicitMissingVars({
+        recipeName: "triage",
+        declarations: DECLS,
+        elicit,
+        onWarn,
+      }),
+    ).resolves.toEqual({});
+    expect(onWarn).toHaveBeenCalledOnce();
+  });
+
+  it("drops blank and whitespace-only answers", async () => {
+    // The required-vars check treats whitespace as missing, so accepting one
+    // here would only fail the caller's recheck a line later.
+    const elicit = vi.fn().mockResolvedValue({
+      action: "accept",
+      content: { repo: "   ", team: "Engineering" },
+    });
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: DECLS, elicit }),
+    ).resolves.toEqual({ team: "Engineering" });
+  });
+
+  it("drops non-string answers", async () => {
+    const elicit = vi.fn().mockResolvedValue({
+      action: "accept",
+      content: { repo: 42, team: null },
+    });
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: DECLS, elicit }),
+    ).resolves.toEqual({});
+  });
+
+  it("ignores keys it never asked for", async () => {
+    // A client answering with extra keys must not be able to inject vars the
+    // recipe never declared into the run context.
+    const elicit = vi.fn().mockResolvedValue({
+      action: "accept",
+      content: { repo: "a/b", team: "T", GITHUB_TOKEN: "leaked" },
+    });
+    const out = await elicitMissingVars({
+      recipeName: "triage",
+      declarations: DECLS,
+      elicit,
+    });
+    expect(out).toEqual({ repo: "a/b", team: "T" });
+    expect(out).not.toHaveProperty("GITHUB_TOKEN");
+  });
+
+  it("does not call the client at all when nothing is missing", async () => {
+    const elicit = vi.fn();
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: [], elicit }),
+    ).resolves.toEqual({});
+    expect(elicit).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a bare content object from a client that omits `action`", async () => {
+    const elicit = vi.fn().mockResolvedValue({ repo: "a/b", team: "T" });
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: DECLS, elicit }),
+    ).resolves.toEqual({ repo: "a/b", team: "T" });
+  });
+
+  it("returns nothing for a non-object result", async () => {
+    const elicit = vi.fn().mockResolvedValue("ok");
+    await expect(
+      elicitMissingVars({ recipeName: "triage", declarations: DECLS, elicit }),
+    ).resolves.toEqual({});
+  });
+});

--- a/src/recipes/elicitMissingVars.ts
+++ b/src/recipes/elicitMissingVars.ts
@@ -1,0 +1,147 @@
+/**
+ * Inline prompting for a recipe's missing required vars, over MCP elicitation.
+ *
+ * The first in-repo caller of `McpTransport.elicit()` (#1217). Deliberately the
+ * LOW-STAKES caller: a run that would halt with `missing_required_vars:foo,bar`
+ * asks the operator for `foo`/`bar` inline instead. The approval prompt — the
+ * other candidate — was passed over because inlining an approve/deny decision
+ * moves the human's decision point inside the prompt-injection blast radius.
+ * Supplying a missing input carries no such authority.
+ *
+ * Design constraints, all of which the caller relies on:
+ *
+ *  - **Additive, never a replacement.** `elicit()` requires an active WS client,
+ *    so Streamable-HTTP and stdio sessions can never use this path. Every
+ *    failure mode — no client, client declines, client has no elicitation
+ *    support, timeout, malformed answer — returns `{}` and lets the caller fall
+ *    through to the existing `missing_required_vars` halt unchanged.
+ *  - **Fail-closed is preserved.** This function can only ever ADD values that a
+ *    human typed. It never invents a value, never accepts a blank, and never
+ *    reduces the missing set on its own. A run that would have halted still
+ *    halts unless a human actually answered.
+ *  - **No partial credit.** A caller must re-run its own required-vars check on
+ *    the merged result rather than trusting this to have filled everything.
+ */
+
+/**
+ * The `elicit()` shape this module needs, injected so the recipe layer neither
+ * imports nor reaches for a transport instance (they are per-session and owned
+ * by the bridge).
+ */
+export type ElicitFn = (
+  message: string,
+  requestedSchema: Record<string, unknown>,
+) => Promise<unknown>;
+
+/** A declared-but-unsupplied var, as surfaced to the operator. */
+export interface MissingVarDeclaration {
+  name: string;
+  /** `description` from the recipe's `trigger.inputs[]`/`vars[]` entry, if any. */
+  description?: string;
+}
+
+/**
+ * Build the `requestedSchema` for a set of missing vars: one required string
+ * property per var. Kept separate from the request so it can be asserted
+ * directly — a schema that marks a var optional would let a client return an
+ * answer with the var still absent, which reads as "answered" downstream.
+ */
+export function buildMissingVarsSchema(
+  declarations: MissingVarDeclaration[],
+): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  for (const { name, description } of declarations) {
+    properties[name] = {
+      type: "string",
+      ...(description ? { description } : {}),
+    };
+  }
+  return {
+    type: "object",
+    properties,
+    required: declarations.map((d) => d.name),
+  };
+}
+
+/** Human-readable prompt text. Named the recipe so the operator has context. */
+export function buildMissingVarsMessage(
+  recipeName: string,
+  declarations: MissingVarDeclaration[],
+): string {
+  const names = declarations.map((d) => d.name).join(", ");
+  const plural = declarations.length === 1 ? "value" : "values";
+  return `Recipe "${recipeName}" needs ${plural} for: ${names}`;
+}
+
+/**
+ * Read the answer object out of whatever the client returned.
+ *
+ * MCP elicitation results are `{ action, content }`. Only `action: "accept"`
+ * counts — `"decline"` and `"cancel"` are the user saying no, which must land
+ * in the same halt as never having asked. A bare object with no `action` is
+ * tolerated for older/looser clients, since the per-value validation below is
+ * what actually protects us.
+ */
+function extractAccepted(result: unknown): Record<string, unknown> | null {
+  if (!result || typeof result !== "object") return null;
+  const obj = result as Record<string, unknown>;
+  if (typeof obj.action === "string") {
+    if (obj.action !== "accept") return null;
+    const content = obj.content;
+    return content && typeof content === "object"
+      ? (content as Record<string, unknown>)
+      : null;
+  }
+  return obj;
+}
+
+/**
+ * Ask the connected MCP client for the missing vars.
+ *
+ * @returns a map of ONLY the vars the human actually supplied a non-blank
+ * string for. `{}` on every failure path — this never throws, and never
+ * returns a key it was not asked for.
+ */
+export async function elicitMissingVars(opts: {
+  recipeName: string;
+  declarations: MissingVarDeclaration[];
+  elicit: ElicitFn;
+  /** Optional; defaults to `elicit()`'s own 5-minute timeout. */
+  timeoutMs?: number;
+  onWarn?: (message: string) => void;
+}): Promise<Record<string, string>> {
+  const { recipeName, declarations, elicit, onWarn } = opts;
+  if (declarations.length === 0) return {};
+
+  let result: unknown;
+  try {
+    result = await elicit(
+      buildMissingVarsMessage(recipeName, declarations),
+      buildMissingVarsSchema(declarations),
+    );
+  } catch (err) {
+    // No WS client, no elicitation support, decline, disconnect, or timeout.
+    // All identical from here: the caller halts exactly as it did before.
+    onWarn?.(
+      `[recipe] could not prompt for missing vars (${recipeName}): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return {};
+  }
+
+  const answers = extractAccepted(result);
+  if (!answers) return {};
+
+  const supplied: Record<string, string> = {};
+  for (const { name } of declarations) {
+    const value = answers[name];
+    // Only strings count. A number/boolean/null would stringify into something
+    // the operator did not type, and a blank is the same as unanswered — the
+    // required-vars check treats whitespace-only as missing, so accepting one
+    // here would just fail the recheck one line later.
+    if (typeof value !== "string" || value.trim() === "") continue;
+    supplied[name] = value;
+  }
+  return supplied;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -209,6 +209,25 @@ export class Server extends EventEmitter<ServerEvents> {
   public setRecipeTrustFn:
     | ((name: string, level: string) => { ok: boolean; error?: string })
     | null = null;
+  /**
+   * Patchwork (#1217): ask the connected MCP client a question inline, via
+   * `McpTransport.elicit()`. Set by the bridge to resolve against the most
+   * recently connected WebSocket session, and left `null` whenever no such
+   * session exists — `elicit()` is WS-only, so Streamable-HTTP and stdio
+   * clients can never serve one.
+   *
+   * Every caller must treat this as a best-effort ADDITIONAL channel: a
+   * rejection (no client, declined, timed out) has to land in the same branch
+   * as never having asked. Today's only caller is the missing-required-vars
+   * prompt in `recipeOrchestration.ts`, deliberately chosen over the approval
+   * prompt because supplying an input carries no authority to approve.
+   */
+  public elicitFn:
+    | ((
+        message: string,
+        requestedSchema: Record<string, unknown>,
+      ) => Promise<unknown>)
+    | null = null;
   /** Patchwork: set by bridge to generate a recipe YAML draft from a natural-language prompt. */
   public generateRecipeFn:
     | ((prompt: string) => Promise<{


### PR DESCRIPTION
Closes #1217 — the first in-repo caller for `McpTransport.elicit()`.

Picked the **low-stakes** caller of the two the issue proposed. The recipe approval prompt was passed over on the issue's own threat-model argument: inlining an approve/deny decision moves the human's decision point inside the prompt-injection blast radius. Supplying a missing input carries no comparable authority.

### Behaviour
A manual run that would halt with `missing_required_vars:foo` now asks the operator for `foo` inline first, showing the recipe author's own `description` for the var.

### Constraints from the issue, held by construction
- **Additive, never a replacement.** `elicit()` needs an active WS client, so Streamable-HTTP, stdio, dashboard POSTs, webhooks and the scheduler take the untouched path — `server.elicitFn` is null for them and the halt is byte-identical to before.
- **Fail-closed preserved.** `elicitMissingVars` never throws and can only *add* human-typed values. No client, decline, cancel, timeout, blank, non-string or malformed answer all return `{}` and land in the existing halt. The required-vars check is re-run on the merged vars rather than trusting the prompt to have filled everything.
- A client cannot inject vars the recipe never declared — only keys that were asked for are read back.

### Notes
- `checkRequiredVars` generalised to `missingRequiredVarDeclarations` so the prompt can carry descriptions; the halt message still maps down to bare names, the only shape the dashboard has ever parsed.
- `server.elicitFn` resolves lazily to the newest live WS session rather than pinning a closure at connect time (no stale socket after a reconnect / second agent), and is cleared when the last session goes so a caller falls straight through instead of waiting out a 5-minute timeout.

17 tests — unit coverage of every rejection path, plus end-to-end `runRecipeFn` tests for accept / decline / elicit-rejects / no-`elicitFn` / already-supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)