### PR TITLE
fix(drivers): drop unsupported codex --ask-for-approval, expand /v1 endpoints

### DIFF
--- a/src/adapters/__tests__/adapters.test.ts
+++ b/src/adapters/__tests__/adapters.test.ts
@@ -232,6 +232,32 @@ describe("OpenAIAdapter", () => {
 });
 
 describe("LocalAdapter (OpenAI-compat)", () => {
+  it("expands a dashboard-style /v1 endpoint to chat completions", async () => {
+    const fetchImpl = mockFetch({
+      choices: [
+        {
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+    const a = createLocalAdapter({
+      endpoint: "http://127.0.0.1:11434/v1",
+      fetchImpl,
+    });
+
+    await a.complete({
+      systemPrompt: "",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:11434/v1/chat/completions",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("does not require api key", async () => {
     const fetchImpl = mockFetch({
       choices: [

--- a/src/adapters/local.ts
+++ b/src/adapters/local.ts
@@ -13,6 +13,10 @@ import { OpenAIAdapter } from "./openai.js";
 const DEFAULT_ENDPOINT = "http://localhost:11434/v1/chat/completions";
 const DEFAULT_MODEL = "llama3";
 
+function normalizeEndpoint(endpoint: string): string {
+  return endpoint.replace(/\/v1\/?$/, "/v1/chat/completions");
+}
+
 export function createLocalAdapter(opts: {
   endpoint?: string;
   defaultModel?: string;
@@ -21,7 +25,7 @@ export function createLocalAdapter(opts: {
 }): ModelAdapter {
   return new OpenAIAdapter({
     adapterName: "local",
-    baseURL: opts.endpoint ?? DEFAULT_ENDPOINT,
+    baseURL: normalizeEndpoint(opts.endpoint ?? DEFAULT_ENDPOINT),
     defaultModel: opts.defaultModel ?? DEFAULT_MODEL,
     apiKey: opts.apiKey,
     requireApiKey: false,

--- a/src/drivers/codex/__tests__/subprocess.test.ts
+++ b/src/drivers/codex/__tests__/subprocess.test.ts
@@ -95,8 +95,7 @@ describe("CodexDriver: fail-closed defaults (no providerOptions)", () => {
     expect(args).toContain("--json");
     expect(args).toContain("--sandbox");
     expect(args[args.indexOf("--sandbox") + 1]).toBe("read-only");
-    expect(args).toContain("--ask-for-approval");
-    expect(args[args.indexOf("--ask-for-approval") + 1]).toBe("never");
+    expect(args).not.toContain("--ask-for-approval");
     expect(args).toContain("--ignore-user-config");
     expect(args).toContain("--ignore-rules");
     expect(args).toContain("--skip-git-repo-check");
@@ -144,7 +143,7 @@ describe("CodexDriver: explicit escalation via providerOptions", () => {
     expect(args[args.indexOf("--sandbox") + 1]).toBe("read-only");
   });
 
-  it("escalates approvalMode when explicitly requested", async () => {
+  it("does not pass the unsupported approvalMode flag", async () => {
     const driver = newDriver();
     await finishRun(
       driver.run(
@@ -152,7 +151,7 @@ describe("CodexDriver: explicit escalation via providerOptions", () => {
       ),
     );
     const args = spawnMock.mock.calls[0]![1] as string[];
-    expect(args[args.indexOf("--ask-for-approval") + 1]).toBe("on-request");
+    expect(args).not.toContain("--ask-for-approval");
   });
 
   it("enables network access only when explicitly requested", async () => {

--- a/src/drivers/codex/subprocess.ts
+++ b/src/drivers/codex/subprocess.ts
@@ -14,7 +14,6 @@ import { parseStreamLine, splitLines } from "./streamParser.js";
 const OUTPUT_CAP = 50 * 1024; // 50KB — matches the Claude subprocess driver's cap
 
 type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
-type ApprovalMode = "untrusted" | "on-request" | "never";
 
 /**
  * Scrub secrets from a string before storing or surfacing it. Same patterns
@@ -44,7 +43,6 @@ export function scrubSecrets(text: string): string {
  * explicitly escalates via providerOptions:
  *
  *   sandboxMode:    "read-only" (default) | "workspace-write" | "danger-full-access"
- *   approvalMode:   "never" (default) | "on-request" | "untrusted"
  *   networkAccess:  false (default) — passed as `-c sandbox.network_access=false`
  *   webSearch:      false (default) — omitting --search leaves Codex's own
  *                   default ("cached"); NOT the same as fully disabled, but
@@ -85,10 +83,6 @@ export class CodexDriver implements ProviderDriver {
       opts.sandboxMode === "danger-full-access"
         ? opts.sandboxMode
         : "read-only";
-    const approvalMode: ApprovalMode =
-      opts.approvalMode === "on-request" || opts.approvalMode === "untrusted"
-        ? opts.approvalMode
-        : "never";
     const networkAccess = opts.networkAccess === true;
     const webSearch = opts.webSearch === true;
 
@@ -98,8 +92,6 @@ export class CodexDriver implements ProviderDriver {
       "--json",
       "--sandbox",
       sandboxMode,
-      "--ask-for-approval",
-      approvalMode,
       "--ignore-user-config",
       "--ignore-rules",
       "--skip-git-repo-check",


### PR DESCRIPTION
Two unrelated driver fixes that were sitting uncommitted together.

**codex** — `--ask-for-approval` is not a flag the Codex CLI accepts, so every `codex exec` the driver spawned was rejected on argv parsing; the driver could not run at all. `codex exec` is non-interactive and already never prompts, so the removed `never` default was a no-op even if the flag had parsed.

⚠️ Worth a reviewer's eye: this makes `providerOptions.approvalMode` **inert for codex**. The only value that would have changed behaviour is an escalation (`on-request` / `untrusted`) the CLI has no way to honour in `exec` mode, so nothing is silently downgraded — but a caller passing it now gets no error either. The gemini driver's own `approvalMode` is unrelated and untouched.

**local adapter** — the dashboard connection form asks for an OpenAI-compat base URL, which every provider documents as ending at `/v1` (Ollama and vLLM both print exactly that). The adapter passed it through verbatim, so requests went to `/v1` instead of `/v1/chat/completions` and 404'd — while the hardcoded default, which spells out the full path, worked. A trailing `/v1` is now normalised to the chat-completions path.

36 tests pass locally; each fix has a test pinning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)