### PR TITLE
fix(dashboard): render inbox bodies statically, hide frontmatter, unstick edit rail

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -8538,6 +8538,12 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
   gap: 14px;
   animation: layoutHeadIn 200ms ease both;
 }
+/* Edit and Plan place the rail above a full-width body. It must scroll away
+   with that body; leaving the dossier's sticky positioning active turns the
+   full-width rail into an overlay that obscures the editor. */
+.rd-rail.rd-rail-static {
+  position: static;
+}
 .rd-crumb { margin-bottom: 6px; }
 .rd-rail .nm {
   font-size: var(--fs-2xl);

--- a/dashboard/src/app/inbox/__tests__/page.test.tsx
+++ b/dashboard/src/app/inbox/__tests__/page.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Reproduce a failed/stalled Next dynamic chunk: the shell, metadata, and
+// actions render, but the lazy markdown component never replaces its empty
+// loading placeholder.
+vi.mock("next/dynamic", () => ({
+  default: (_loader: unknown, options?: { loading?: () => React.ReactNode }) =>
+    function StalledDynamicImport() {
+      return options?.loading?.() ?? null;
+    },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/hooks/useBridgeFetch", () => ({
+  useBridgeFetch: () => ({
+    data: {
+      items: [
+        {
+          name: "credit-review.md",
+          path: "/tmp/credit-review.md",
+          modifiedAt: "2026-07-29T10:00:00.000Z",
+          preview: "Detailed credit review",
+          provenance: { recipe: "credit-review", runSeq: 42 },
+        },
+      ],
+    },
+    error: undefined,
+    loading: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useSearchHotkey", () => ({
+  useSearchHotkey: () => ({ current: null }),
+}));
+
+vi.mock("@/components/Toast", () => ({
+  useToast: () => ({ info: vi.fn(), success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("@/components/MessageMarkdown", () => ({
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+import InboxPage from "../page";
+
+describe("Inbox message body", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            name: "credit-review.md",
+            modifiedAt: "2026-07-29T10:00:00.000Z",
+            provenance: { recipe: "credit-review", runSeq: 42 },
+            content: "## Recommendation\n\nApprove with a 1.2× DSCR covenant.",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+  });
+
+  it("renders fetched recipe markdown even when a dynamic chunk cannot load", async () => {
+    render(<InboxPage />);
+
+    // The surrounding reader proves this is the screenshot regression, not a
+    // detail-fetch failure: metadata/actions are present while the body was blank.
+    expect(await screen.findByText("Replay recipe")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Approve with a 1\.2× DSCR covenant\./),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import dynamic from "next/dynamic";
 import Link from "next/link";
 import { apiPath } from "@/lib/api";
 import { inboxItemKey } from "@/lib/entityKey";
@@ -10,6 +9,7 @@ import { EmptyState, ErrorState, HintCard, RelationStrip } from "@/components/pa
 import { RecipeChip, RunChip } from "@/components/patchwork/entity";
 import { SkeletonList } from "@/components/Skeleton";
 import { InboxDeliveryCard } from "@/components/InboxDeliveryCard";
+import MessageMarkdown from "@/components/MessageMarkdown";
 import { useToast } from "@/components/Toast";
 import { useBridgeFetch } from "@/hooks/useBridgeFetch";
 import { useSearchHotkey } from "@/hooks/useSearchHotkey";
@@ -17,15 +17,6 @@ import { useSearchHotkey } from "@/hooks/useSearchHotkey";
 function isFilterCategory(v: string | null): v is FilterCategory {
   return v === "All" || v === "Morning Briefs" || v === "Recipe Outputs" || v === "Agent Reports";
 }
-
-// react-markdown + its rehype/remark plugins ship ~80KB gzipped of
-// mdast/hast/micromark machinery. They're only needed to render the
-// currently-selected message body — split into a lazy chunk so the
-// inbox list view loads without them.
-const MessageMarkdown = dynamic(() => import("@/components/MessageMarkdown"), {
-  ssr: false,
-  loading: () => <div aria-busy="true" />,
-});
 
 type FilterCategory = "All" | "Morning Briefs" | "Recipe Outputs" | "Agent Reports";
 

--- a/dashboard/src/app/recipes/[...name]/__tests__/layout.scroll.test.tsx
+++ b/dashboard/src/app/recipes/[...name]/__tests__/layout.scroll.test.tsx
@@ -1,0 +1,54 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ pathname: "/recipes/private-credit-review-demo/edit" }));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    use: (value: Promise<{ name: string[] }> & { testValue?: { name: string[] } }) => value.testValue,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+}));
+
+vi.mock("@/hooks/useBridgeFetch", () => ({
+  useBridgeFetch: () => ({
+    data: [
+      {
+        name: "private-credit-review-demo",
+        description: "Reviews a private credit workbook.",
+        enabled: true,
+      },
+    ],
+  }),
+}));
+
+vi.mock("../_components/RailContext", () => ({ useRailData: () => null }));
+
+import RecipeDetailLayout from "../layout";
+
+describe("RecipeDetailLayout scroll behavior", () => {
+  beforeEach(() => {
+    mocks.pathname = "/recipes/private-credit-review-demo/edit";
+  });
+
+  it("does not make the full-width recipe rail sticky above the editor", async () => {
+    const params = Object.assign(Promise.resolve({ name: ["private-credit-review-demo", "edit"] }), {
+      testValue: { name: ["private-credit-review-demo", "edit"] },
+    });
+    render(
+      <RecipeDetailLayout params={params}>
+        <div>Recipe editor</div>
+      </RecipeDetailLayout>,
+    );
+
+    const rail = await screen.findByRole("complementary");
+    expect(rail).toHaveClass("rd-rail-static");
+    expect(screen.getByText("Recipe editor")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/app/recipes/[...name]/layout.tsx
+++ b/dashboard/src/app/recipes/[...name]/layout.tsx
@@ -110,7 +110,7 @@ function RecipeRail({
   }, [name, connectors]);
 
   return (
-    <aside className="rd-rail card">
+    <aside className={`rd-rail card${isEditRoute || isPlanRoute ? " rd-rail-static" : ""}`}>
       <div>
         <div className="muted rd-crumb">
           <RecipeBreadcrumb name={name} />

--- a/dashboard/src/components/MessageMarkdown.tsx
+++ b/dashboard/src/components/MessageMarkdown.tsx
@@ -9,6 +9,13 @@ import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 
+function stripFrontmatter(content: string): string {
+  return content.replace(
+    /^\uFEFF?---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/,
+    "",
+  );
+}
+
 export default function MessageMarkdown({
   content,
   components,
@@ -22,7 +29,7 @@ export default function MessageMarkdown({
       rehypePlugins={[rehypeSanitize]}
       components={components}
     >
-      {content}
+      {stripFrontmatter(content)}
     </ReactMarkdown>
   );
 }

--- a/dashboard/src/components/__tests__/MessageMarkdown.test.tsx
+++ b/dashboard/src/components/__tests__/MessageMarkdown.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import MessageMarkdown from "../MessageMarkdown";
+
+describe("MessageMarkdown", () => {
+  it("hides recipe provenance frontmatter while rendering the report body", () => {
+    render(
+      <MessageMarkdown
+        content={`---
+recipe: private-credit-review-demo
+runSeq: 11800
+trigger: manual
+deliveredAt: 2026-07-29T14:00:00.000Z
+---
+
+# Private Credit Review
+
+Approve with conditions.`}
+        components={{}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Private Credit Review" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Approve with conditions.")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/recipe: private-credit-review-demo/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/runSeq: 11800/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Three rendering fixes found while reviewing recipe output in the inbox.

**Blank message bodies.** Inbox bodies were lazy-loaded via `next/dynamic`. When that chunk stalls or fails, the shell, metadata and actions all render while the body stays an empty loading placeholder — the message looks delivered-but-blank, which is worse than slow. The ~80KB gzipped the split saved isn't worth a failure mode that silently hides the entire payload, so the import is static again. The new test mocks a never-resolving dynamic import to pin that the body survives it.

**Raw frontmatter in reports.** Recipe outputs carry a provenance block (`recipe`, `runSeq`, `trigger`, `deliveredAt`). ReactMarkdown has no frontmatter plugin wired here, so it rendered the `---` fence and its keys as body text at the top of every report. Now stripped before rendering — the delivery card already shows that metadata in its own chrome.

**Rail overlapping the editor.** The recipe Edit and Plan routes place the rail above a full-width body rather than beside it, where the dossier layout's sticky positioning turns it into an overlay that covers the editor as you scroll. Those two routes opt into `position: static`.

3 new tests, one per fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)