### PR TITLE
docs: record the forbid terminal state and the identity model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,12 +247,25 @@ The `src/workers/` subsystem implements a trust-ramp-aware autonomy gate for rec
 
 - **Worker identity**: a worker = a named recipe identity. Trust is per `(workerName × actionClassKey)` — never global. Competence demonstrated on reversible low-blast actions (reads, CI) cannot transfer to compensable or irreversible high-blast actions (git push, PR merge, file delete).
 - **Trust levels**: L0–L4, Bayesian Beta posterior + LCB threshold. `outcomeWeight` is blast-weighted so one high-blast failure outweighs many trivial successes.
-- **Gate formula**: `effectiveLevel = min(earned, autonomyCeiling, contextCeiling)`. The `contextCeiling` is a descending-only seam — signals can only lower autonomy, never raise it (NaN / out-of-range → no de-rate).
-- **Autonomy thresholds**: reversible actions bypass the gate unconditionally. Compensable actions unlock at effective L2. Irreversible actions require L4.
+- **Three terminal states**: `allow` | `gate` | `forbid` (ADR-0017). `forbid` is not a stronger gate — it means no earned trust and no human approval unlocks the action. It is evaluated FIRST in `decideWorkerAction`, ahead of the agent-step carve-out, the reversibility short-circuit and all trust maths, because any branch that runs earlier is a path around it. Consequence taken deliberately: a broad rule can stall every worker on its agent step — a loud, self-explaining failure, chosen over the silent alternative of permitting a banned action.
+- **Forbid rules**: `src/workers/forbidPolicy.ts`, passed via `AutonomyDecisionOpts.forbidRules`. Pattern language matches `WorkerManifest.owns` (domain | exact classKey | prefix). Empty/absent ⇒ nothing forbidden, so it is entirely opt-in. Unlike the roster, a malformed rule is NOT silently dropped — a deny-list that loses a rule fails *open*, so `parseForbidRules` reports what it could not parse.
+- **Gate formula**: `effectiveLevel = min(earned, autonomyCeiling, contextCeiling)`, applied only to actions that are not forbidden. The `contextCeiling` is a descending-only seam — signals can only lower autonomy, never raise it (NaN / out-of-range → no de-rate).
+- **Autonomy thresholds**: reversible actions bypass the gate unconditionally. Compensable actions unlock at effective L2. Irreversible actions require L4. None of these apply to a forbidden action.
+- **Decision records**: every decision persists to `~/.patchwork/worker_gate_decisions.jsonl` with `gatePolicyVersion` (now `worker-ramp-v1`) and an optional `actor` — a *snapshot* (id + kind + display name as it was), never a roster reference, so a rename or role change cannot rewrite history. Absent on pre-attribution records and never backfilled: "nobody recorded this" must stay distinguishable from "we do not know".
 - **Feature flag**: `PATCHWORK_FLAG_WORKER_AUTONOMY` (default off). With the flag off, the gate is a no-op — byte-identical to pre-ramp behavior. Requires `--driver subprocess`.
 - **Dogfood templates**: `templates/workers/` — three reference workers (release-notes, dependency-bump, triage-failing-tests).
 - **Monitoring**: `patchwork workers shadow` replays logs and shows per-worker × action-class trust dial + ramp-vs-gate divergences. `patchwork workers backtest` calibrates cold-start without touching live gate behavior.
 - **Full reference**: [docs/worker-autonomy-policy-gate.md](docs/worker-autonomy-policy-gate.md), [docs/runbooks/worker-autonomy-dogfood.md](docs/runbooks/worker-autonomy-dogfood.md).
+
+## Workspace Identity
+
+`src/identity/` — who may act in a workspace. Added because the bridge authenticated a single bearer token, so no persisted record could name a person and segregation of duties was *unenforceable*, not merely unimplemented.
+
+- **Roles**: `owner` | `admin` | `operator` | `approver` | `auditor` | `worker`. A member holds a SET of roles, never one — otherwise a single-admin workspace must choose between administering and approving, and the workaround is to quietly give `admin` the approve capability. So `admin` gets policy/members/systems but NOT `action.approve`; `auditor` gets reads and nothing else.
+- **Segregation of duties**: `canApproveAction(approver, preparedById)`. The self-approval check runs BEFORE the capability check — an owner holds `action.approve`, so testing capability first would report an owner approving their own work as allowed.
+- **Roster**: `members.json` (honours `PATCHWORK_HOME`), loaded once at bridge startup into `server.roster`. Fail-SOFT: missing/unreadable/malformed ⇒ one implicit owner, byte-identical to pre-identity behaviour. This is deliberately the opposite of ADR-0016's fail-closed — that gate decides *whether an action happens* (safe default: no); this decides *who you are on your own machine* (safe default: the status quo ante).
+- **Members are deactivated, never deleted** — deleting one would orphan every decision that names them.
+- **Not yet wired to authorisation.** Nothing consults the roster to permit or refuse a request; it exists so a decision record has a real member to name. Attributing a *gated* decision to its approving human additionally needs `ApprovalQueue` to become durable — it is currently an in-memory `Map` with a 5-minute TTL.
 
 ## Architecture Rules
 

--- a/docs/worker-autonomy-policy-gate.md
+++ b/docs/worker-autonomy-policy-gate.md
@@ -289,6 +289,72 @@ after a fast sequence of feature PRs even when each shipped green.
 
 ---
 
+## 7. The third terminal state — `forbid` (shipped 2026-08-03, ADR-0017)
+
+The gate had two outcomes: `allow` and `gate`. Both are escapable — `gate`
+by earning trust, or by a human clicking Approve. There was no way to say
+**never**.
+
+`forbid` is that third state. It means no level of earned trust and no human
+approval unlocks the action: it holds at L4 with an autonomy ceiling of 4, and
+it holds against an operator who approves it.
+
+### Why it is not an empty `reachableLevels()`
+
+The obvious implementation — have `reachableLevels()` return `[]` for a
+forbidden class — was rejected. It survives mechanically (`graduation.ts` guards
+`nextRung !== undefined`), but it encodes a hard policy as an emergent property
+of an empty array, and `[]` vs `[0]` is a distinction that will not survive
+maintenance. More importantly it conflates two different things:
+`reachableLevels` describes which rungs a class can *climb*, while `forbid` is
+an assertion about the *action*. They come apart exactly where it matters.
+
+So `forbid` is a policy predicate — `isForbidden(actionClass, rules)` in
+`src/workers/forbidPolicy.ts` — consulted before the trust maths.
+
+### Evaluation order, and the cost of getting it right
+
+`decideWorkerAction` settles forbid **first**: ahead of the agent-step
+carve-out, ahead of the reversibility short-circuit, ahead of every level
+comparison. Any branch that runs earlier is a path around it.
+
+That ordering means a broad rule (`match: "other"`, say) **can stall every
+worker on its agent step**. This is deliberate. That failure is loud and names
+the rule that fired; the alternative — letting a carve-out win — fails silently
+by permitting an action the operator declared must never happen. A safety
+control a carve-out can bypass is not one.
+
+### Rules
+
+Matching mirrors `WorkerManifest.owns`: a domain, an exact class key, or a
+prefix. Every rule carries a required `reason`, because a refusal without one
+is unusable in a receipt.
+
+Empty or absent rules forbid nothing, so an unconfigured workspace is
+byte-identical to the pre-forbid gate. Forbidding is entirely opt-in.
+
+**A deny-list fails in the opposite direction to a roster.** `identity/roster.ts`
+degrades a malformed `members.json` to a single implicit owner, because the safe
+default for *who you are* is the status quo ante. Silently dropping a malformed
+*forbid* rule fails **open** — the banned action becomes merely gated, and a
+human can then approve it. So `parseForbidRules` returns the positions it could
+not parse, and the caller is expected to shout rather than proceed quietly.
+
+### Compatibility
+
+`GATE_POLICY_VERSION` moved `worker-ramp-v0` → `worker-ramp-v1` with this
+change, which earns the bump on both counts ADR-0017 identifies: an enum
+widening (breaks exhaustive switches in older readers) and a genuine policy
+change. The optional `actor` field shipped *unversioned* by contrast, because a
+new optional field is genuinely additive.
+
+Readers were hardened first, in a separate change: `describeGateAction` names an
+unrecognised action instead of reporting it as "GATED (asked for approval)", and
+`gateOutcomeFor` maps an unknown action to **refuse**, so no build ever offers a
+value it does not understand to a human for approval.
+
+---
+
 ## See also
 
 - [docs/runbooks/worker-autonomy-dogfood.md](runbooks/worker-autonomy-dogfood.md) — operator runbook for the live dogfood campaign


### PR DESCRIPTION
The repo rule is that CLAUDE.md tracks architectural changes so future sessions have accurate context. Two things landed that it didn't describe — and one thing it *did* describe is now wrong.

### The stale line
> "Autonomy thresholds: reversible actions bypass the gate unconditionally."

That was true and isn't: a forbidden reversible action is refused. Left alone, it's the kind of confidently-stale statement that makes a future session reason correctly from a false premise.

### CLAUDE.md — Workers / Autonomy Gate
- Three terminal states, with `forbid` distinguished from "a stronger gate".
- The evaluation order and its deliberate cost — a broad rule can stall every worker on its agent step — stated up front rather than discovered.
- The **actor as a snapshot** and the **no-backfill** rule. Both are easy to "fix" wrongly: resolving the id at read time looks cleaner and would silently rewrite history.

### CLAUDE.md — new Workspace Identity section
Role set, why a member holds several roles rather than one, why the self-approval check precedes the capability check, and the roster's **fail-soft** stance with an explicit note that it's the opposite of ADR-0016 *on purpose* — otherwise it reads as an inconsistency worth correcting.

States plainly what is **not** wired: nothing consults the roster for authorisation, and attributing a gated decision to its approving human still needs a durable `ApprovalQueue`. Docs that overstate what's built are how the next session gets confidently wrong.

### docs/worker-autonomy-policy-gate.md — new §7
The reasoning that doesn't belong in CLAUDE.md: why `forbid` is a policy predicate rather than an empty `reachableLevels()`, the evaluation-order trade-off, rule matching, and why this change earns the `worker-ramp-v1` bump while the actor field shipped unversioned.

CLAUDE.md is loaded into every session's context, so it carries the rules; the reference doc carries the arguments.

Docs only. `audit-docs-drift` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)