### PR TITLE
feat(gate): attribute autonomous allows to the worker that acted

### DIFF
--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -254,6 +254,18 @@ describe("buildWorkerAutonomyGate", () => {
     // and a real policy change — the two things that earn a bump.
     expect(gated?.gatePolicyVersion).toBe("worker-ramp-v1");
     expect(allowed?.reversibility).toBe("reversible");
+
+    // An autonomous ALLOW is attributed to the worker — it is the party that
+    // acted, and nobody else was involved.
+    expect(allowed?.actor).toEqual(
+      expect.objectContaining({ id: expect.any(String), kind: "worker" }),
+    );
+    // A GATED decision is deliberately NOT attributed. The approving human is
+    // unknown at this point and cannot be known until the approval path carries
+    // an identity, so naming anyone here would be a lie. Absence means "nobody
+    // recorded this" (ADR-0017), which must stay distinguishable from a
+    // synthesized "unknown".
+    expect(gated?.actor).toBeUndefined();
   });
 
   it("a throwing recordGateDecision never blocks the gate (fail-soft)", async () => {

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -212,6 +212,23 @@ export async function buildWorkerAutonomyGate(
           ...(contextRisk?.reasons && {
             contextRiskReasons: contextRisk.reasons,
           }),
+          // Attribute an autonomous ALLOW to the worker: it is the party that
+          // acted, and nobody else was involved. Deliberately absent on the
+          // other two paths, because attributing them would be a lie:
+          //   - `gate` — the approving human is not known here, and cannot be
+          //     until the approval path carries an identity (ApprovalQueue is
+          //     an in-memory Map with a 5-minute TTL).
+          //   - `forbid` — nobody acted. Workspace policy refused, and naming
+          //     the worker would read as though it did something.
+          // An absent actor means "nobody recorded this", which ADR-0017 keeps
+          // deliberately distinguishable from a synthesized "unknown".
+          ...(decision.action === "allow" && {
+            actor: {
+              id: worker.id,
+              kind: "worker" as const,
+              ...(worker.name ? { displayName: worker.name } : {}),
+            },
+          }),
           reason: decision.reason,
           gatePolicyVersion: GATE_POLICY_VERSION,
         });


### PR DESCRIPTION
The `actor` field shipped in #1232 with **no writer** — the same complete-but-uncalled state documented on `elicit()`, which is how a capability quietly rots. This gives it its first real caller.

An autonomous **allow** is attributed to the worker: it's the party that acted, and nobody else was involved.

### The other two paths are deliberately left unattributed
Naming anyone would be a lie:

- **`gate`** — the approving human isn't known at this point, and can't be until the approval path carries an identity. `ApprovalQueue` is an in-memory `Map` with a 5-minute TTL, so there's nothing durable to attribute to yet.
- **`forbid`** — nobody acted. Workspace policy refused, and naming the worker would read as though it had done something.

Absence therefore keeps meaning *"nobody recorded this"*, which ADR-0017 holds distinguishable from a synthesized "unknown".

Tests assert both halves: an allow carries a worker actor, and a gated decision carries none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)