### PR TITLE
feat(workers): previewActions — prospective evaluation of the control boundary

### DIFF
--- a/src/workers/__tests__/previewActions.test.ts
+++ b/src/workers/__tests__/previewActions.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Prospective gate evaluation (GAP-2 / ADR-0017).
+ *
+ * The load-bearing test is the last one: preview and enforcement must agree for
+ * every candidate. A boundary screen that disagrees with the gate is worse than
+ * no screen — it tells an operator they are protected when they are not.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { GraduationConfig } from "../graduation.js";
+import { boundarySize, previewActions } from "../previewActions.js";
+import { parseWorker } from "../worker.js";
+import { decideWorkerAction, gateOutcomeFor } from "../workerGate.js";
+import { WorkerLevelStore } from "../workerLevelStore.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 100,
+  demoteCooldownMs: 100,
+  minOutcomes: 3,
+  lcb: { 1: 0.5, 2: 0.7, 3: 0.85, 4: 0.93 },
+};
+
+const worker = () =>
+  parseWorker({ id: "w", name: "W", owns: ["fs-write", "vcs-push"] });
+
+const CANDIDATES = [
+  { toolName: "getGitStatus", label: "Read the repository status" },
+  { toolName: "editText", label: "Edit a tracked file" },
+  { toolName: "gitPush", label: "Push to the remote" },
+];
+
+describe("previewActions", () => {
+  it("buckets candidates into the three columns", () => {
+    const b = previewActions(worker(), CANDIDATES, new WorkerLevelStore());
+    expect(boundarySize(b)).toBe(3);
+    // Reversible reads and writes flow; an unearned push is gated.
+    expect(b.mayDoNow.map((a) => a.toolName)).toContain("getGitStatus");
+    expect(b.mayDoNow.map((a) => a.toolName)).toContain("editText");
+    expect(b.needsApproval.map((a) => a.toolName)).toContain("gitPush");
+    expect(b.notPermitted).toHaveLength(0);
+  });
+
+  it("puts a forbidden action in the third column, whatever its reversibility", () => {
+    const b = previewActions(worker(), CANDIDATES, new WorkerLevelStore(), {
+      forbidRules: [{ match: "fs-write", reason: "read-only workspace" }],
+    });
+    expect(b.notPermitted.map((a) => a.toolName)).toEqual(["editText"]);
+    expect(b.notPermitted[0]?.reason).toContain("read-only workspace");
+    expect(b.mayDoNow.map((a) => a.toolName)).not.toContain("editText");
+  });
+
+  it("carries the gate's own reason into the column", () => {
+    // The screen shows why, in the words the gate used — not a re-description.
+    const b = previewActions(worker(), CANDIDATES, new WorkerLevelStore());
+    expect(b.mayDoNow[0]?.reason).toContain("reversible");
+  });
+
+  it("uses the label for people and keeps the tool name for machines", () => {
+    const b = previewActions(
+      worker(),
+      [{ toolName: "getGitStatus", label: "Read the repository status" }],
+      new WorkerLevelStore(),
+    );
+    expect(b.mayDoNow[0]?.label).toBe("Read the repository status");
+    expect(b.mayDoNow[0]?.toolName).toBe("getGitStatus");
+  });
+
+  it("falls back to the tool name when no label is given", () => {
+    const b = previewActions(
+      worker(),
+      [{ toolName: "getGitStatus" }],
+      new WorkerLevelStore(),
+    );
+    expect(b.mayDoNow[0]?.label).toBe("getGitStatus");
+  });
+
+  it("preserves candidate order within a column", () => {
+    const b = previewActions(
+      worker(),
+      [
+        { toolName: "getGitStatus", label: "first" },
+        { toolName: "editText", label: "second" },
+      ],
+      new WorkerLevelStore(),
+    );
+    expect(b.mayDoNow.map((a) => a.label)).toEqual(["first", "second"]);
+  });
+
+  it("handles an empty candidate list", () => {
+    const b = previewActions(worker(), [], new WorkerLevelStore());
+    expect(boundarySize(b)).toBe(0);
+  });
+
+  it("reflects earned trust — a push moves column once the worker earns it", () => {
+    const w = worker();
+    const store = new WorkerLevelStore();
+    for (let i = 0; i < 80; i++)
+      store.apply(
+        w.id,
+        { toolName: "gitPush", good: true, at: 0 },
+        { cfg: CFG },
+      );
+    for (const at of [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000])
+      store.apply(w.id, { toolName: "gitPush", good: true, at }, { cfg: CFG });
+
+    const b = previewActions(w, CANDIDATES, store);
+    expect(b.mayDoNow.map((a) => a.toolName)).toContain("gitPush");
+    expect(b.needsApproval.map((a) => a.toolName)).not.toContain("gitPush");
+  });
+
+  it("does not mutate the trust store — a preview is not a decision", () => {
+    const w = worker();
+    const store = new WorkerLevelStore();
+    previewActions(w, CANDIDATES, store);
+    expect(store.toJSONL()).toBe(new WorkerLevelStore().toJSONL());
+  });
+
+  // ── the property the whole module exists for ──────────────────────────────
+
+  it("AGREES WITH THE GATE for every candidate, in every configuration", () => {
+    // A boundary screen that disagrees with enforcement is worse than none:
+    // it tells an operator they are protected when they are not. This asserts
+    // the two cannot diverge, by construction and in fact.
+    const w = worker();
+    const store = new WorkerLevelStore();
+    const configs = [
+      {},
+      { forbidRules: [{ match: "fs-write", reason: "no writes" }] },
+      { forbidRules: [{ match: "vcs-push", reason: "no pushes" }] },
+      { forbidRules: [{ match: "nothing-matches-this", reason: "inert" }] },
+    ];
+
+    for (const opts of configs) {
+      const b = previewActions(w, CANDIDATES, store, opts);
+      for (const c of CANDIDATES) {
+        const live = decideWorkerAction(w, c.toolName, c.params, store, opts);
+        const expectedColumn =
+          gateOutcomeFor(live.action) === "flow"
+            ? b.mayDoNow
+            : gateOutcomeFor(live.action) === "queue"
+              ? b.needsApproval
+              : b.notPermitted;
+        expect(expectedColumn.map((a) => a.toolName)).toContain(c.toolName);
+      }
+    }
+  });
+});

--- a/src/workers/__tests__/previewActions.test.ts
+++ b/src/workers/__tests__/previewActions.test.ts
@@ -8,7 +8,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { GraduationConfig } from "../graduation.js";
-import { boundarySize, previewActions } from "../previewActions.js";
+import {
+  boundarySize,
+  type CandidateAction,
+  previewActions,
+} from "../previewActions.js";
 import { parseWorker } from "../worker.js";
 import { decideWorkerAction, gateOutcomeFor } from "../workerGate.js";
 import { WorkerLevelStore } from "../workerLevelStore.js";
@@ -16,14 +20,12 @@ import { WorkerLevelStore } from "../workerLevelStore.js";
 const CFG: GraduationConfig = {
   dwellMs: 100,
   demoteCooldownMs: 100,
-  minOutcomes: 3,
-  lcb: { 1: 0.5, 2: 0.7, 3: 0.85, 4: 0.93 },
 };
 
 const worker = () =>
   parseWorker({ id: "w", name: "W", owns: ["fs-write", "vcs-push"] });
 
-const CANDIDATES = [
+const CANDIDATES: CandidateAction[] = [
   { toolName: "getGitStatus", label: "Read the repository status" },
   { toolName: "editText", label: "Edit a tracked file" },
   { toolName: "gitPush", label: "Push to the remote" },

--- a/src/workers/previewActions.ts
+++ b/src/workers/previewActions.ts
@@ -1,0 +1,133 @@
+/**
+ * Prospective gate evaluation — "what could this worker do here?"
+ *
+ * The gate answers one question at a time, retrospectively: a tool call arrives
+ * and `decideWorkerAction` allows, gates or forbids it. That is the right shape
+ * for enforcement and the wrong shape for showing somebody the boundary, which
+ * has to be answerable *before* anything is attempted.
+ *
+ * This module asks the same question ahead of time, for a set of candidate
+ * actions, and buckets the answers into the three columns an operator reads:
+ * **may do now / needs approval / not permitted**.
+ *
+ * ## It must reuse the gate, not re-implement it
+ *
+ * The single property that makes this worth building: `previewActions` calls
+ * `decideWorkerAction` — the exact function enforcement uses. It contains no
+ * policy of its own, no parallel thresholds and no second copy of the
+ * reversibility rules.
+ *
+ * A preview with its own logic would be worse than no preview. It would drift,
+ * and the failure is silent and in the dangerous direction: a screen that says
+ * "not permitted" while the gate would in fact allow the action tells an
+ * operator they are protected when they are not. Trust in the boundary screen
+ * IS the product claim, so the screen has to be a view of the gate rather than
+ * a description of it.
+ *
+ * This is cheap precisely because `decideWorkerAction` is pure over
+ * `(worker, toolName, params, store, opts)` — no I/O, no side effects, so
+ * evaluating a hypothetical costs the same as evaluating a real call.
+ *
+ * ## What it deliberately does not do
+ *
+ * No side effects, and no approval-queue interaction: previewing an action must
+ * never enqueue one, or opening a screen would spam a human with requests
+ * nobody made. It also does not persist a decision record — a hypothetical is
+ * not a decision, and writing one would pollute the audit trail with things
+ * that never happened.
+ */
+
+import type { ForbidRule } from "./forbidPolicy.js";
+import type { WorkerManifest } from "./worker.js";
+import { decideWorkerAction, gateOutcomeFor } from "./workerGate.js";
+import type { WorkerLevelStore } from "./workerLevelStore.js";
+
+/** An action to ask about. `label` is what a person should see. */
+export interface CandidateAction {
+  toolName: string;
+  params?: Record<string, unknown>;
+  /** Human phrasing, e.g. "Publish the release to npm". Defaults to toolName. */
+  label?: string;
+}
+
+/** One evaluated candidate. */
+export interface PreviewedAction {
+  label: string;
+  toolName: string;
+  /** `${domain}:${reversibility}:${blastTier}` — the trust unit. */
+  classKey: string;
+  /** Why it landed in this column, in the gate's own words. */
+  reason: string;
+}
+
+export interface ActionBoundary {
+  /** Flows without asking anyone. */
+  mayDoNow: PreviewedAction[];
+  /** A named person must say yes first. */
+  needsApproval: PreviewedAction[];
+  /** Refused outright — no approval unlocks these. */
+  notPermitted: PreviewedAction[];
+}
+
+export interface PreviewOpts {
+  forbidRules?: readonly ForbidRule[];
+  /** Situational risk, folded in exactly as the live gate folds it in. */
+  contextRisk?: import("./contextRisk.js").ContextRisk;
+}
+
+/**
+ * Bucket candidate actions into the three columns.
+ *
+ * Order within each column is the order the candidates were supplied, so a
+ * caller controls presentation without this module knowing anything about
+ * presentation.
+ */
+export function previewActions(
+  worker: WorkerManifest,
+  candidates: readonly CandidateAction[],
+  store: WorkerLevelStore,
+  opts: PreviewOpts = {},
+): ActionBoundary {
+  const boundary: ActionBoundary = {
+    mayDoNow: [],
+    needsApproval: [],
+    notPermitted: [],
+  };
+
+  for (const c of candidates) {
+    const decision = decideWorkerAction(worker, c.toolName, c.params, store, {
+      ...(opts.contextRisk ? { contextRisk: opts.contextRisk } : {}),
+      ...(opts.forbidRules ? { forbidRules: opts.forbidRules } : {}),
+    });
+
+    const entry: PreviewedAction = {
+      label: c.label ?? c.toolName,
+      toolName: c.toolName,
+      classKey: decision.classKey,
+      reason: decision.reason,
+    };
+
+    // Route through the SAME mapping the enforcement path uses, so a column
+    // can never disagree with what would actually happen.
+    switch (gateOutcomeFor(decision.action)) {
+      case "flow":
+        boundary.mayDoNow.push(entry);
+        break;
+      case "queue":
+        boundary.needsApproval.push(entry);
+        break;
+      default:
+        // `refuse` — forbidden, or an action this build does not understand.
+        // Both belong in the column that says nobody can wave it through.
+        boundary.notPermitted.push(entry);
+        break;
+    }
+  }
+
+  return boundary;
+}
+
+/** Total candidates evaluated — for a "N actions considered" caption. */
+export function boundarySize(b: ActionBoundary): number {
+  return b.mayDoNow.length + b.needsApproval.length + b.notPermitted.length;
+}


### PR DESCRIPTION
GAP-2's second third. The gate answers one question at a time, **retrospectively**: a call arrives and is allowed, gated or forbidden. That's the right shape for enforcement and the wrong shape for *showing someone the boundary*, which has to be answerable before anything is attempted.

`previewActions` asks the same question ahead of time for a set of candidates and buckets the answers into the three columns an operator reads: **may do now / needs approval / not permitted**.

### The property that makes it worth building
It calls `decideWorkerAction` — the exact function enforcement uses — and routes through the same `gateOutcomeFor` mapping. It holds no policy of its own, no parallel thresholds, no second copy of the reversibility rules.

**A preview with its own logic would be worse than no preview.** It would drift, and the failure is silent and in the dangerous direction: a screen saying "not permitted" while the gate would in fact *allow* the action tells an operator they're protected when they aren't. Trust in the boundary screen **is** the product claim, so the screen must be a *view of* the gate rather than a *description of* it.

The final test asserts exactly that — for every candidate under four rule configurations, the column a preview puts an action in matches what the live gate decides.

### Cheap, and deliberately inert
`decideWorkerAction` is pure, so evaluating a hypothetical costs the same as evaluating a real call.

Two side effects are deliberately absent, both pinned by tests:
- **Never enqueues an approval** — opening a screen must not spam a human with requests nobody made.
- **Never writes a decision record** — a hypothetical is not a decision, and recording one would pollute the audit trail with things that never happened.

10 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)