### PR TITLE
docs(adr): correct a stale approval-TTL claim in ADR-0017

### DIFF
--- a/docs/adr/0017-decision-record-actor-and-forbid.md
+++ b/docs/adr/0017-decision-record-actor-and-forbid.md
@@ -148,9 +148,16 @@ reader-side fallback ships before the first `forbid` record — which it now has
 - Segregation of duties becomes expressible. It is not delivered by this ADR —
   this only makes the record able to hold the fact.
 - This does **not** make approvals durable. `ApprovalQueue` holds its entries in
-  an in-memory `Map` with a five-minute TTL, so an approver identity captured
-  there does not survive a restart. Durable approval storage is a separate
-  prerequisite, and until it lands the actor field is only as persistent as the
-  gate-decision log that carries it.
+  an in-memory `Map`, so an approver identity captured there does not survive a
+  restart. Durable approval storage is a separate prerequisite, and until it
+  lands the actor field is only as persistent as the gate-decision log that
+  carries it.
+
+  *(Corrected 2026-08-03: this bullet originally said "with a five-minute TTL".
+  That was already stale when written — #1214 replaced the flat 5-minute expiry
+  with risk-tiered, live-configurable timeouts, defaulting to low 5 min /
+  medium 1 h / high 4 h. The durability gap is real; the TTL characterisation
+  was not. The claim came from a planning note rather than from the code, which
+  is the mistake worth remembering.)*
 - `"worker-ramp-v1"` becomes the floor for any future gate-policy change; the
   next one bumps to `v2` rather than adding a second version field.

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -106,7 +106,9 @@ export interface GateDecisionRecord {
    * For an autonomous allow this is the worker itself. For a gated decision it
    * becomes the approving human once the approval path carries an identity —
    * which it cannot yet, because `ApprovalQueue` holds its entries in memory
-   * with a 5-minute TTL.
+   * and they do not survive a restart. (Its TTLs are risk-tiered and
+   * configurable since #1214 — low 5 min / medium 1 h / high 4 h — so expiry is
+   * not the blocker; durability is.)
    */
   actor?: GateDecisionActor;
   /** The gate-policy version (thresholds/constants) that produced this row.


### PR DESCRIPTION
ADR-0017 and a JSDoc comment both said `ApprovalQueue` holds entries *"with a 5-minute TTL"*. **That was already untrue when written.**

#1214 replaced the flat 5-minute expiry with risk-tiered, live-configurable timeouts. `DEFAULT_TTL_MS` is **low 5 min / medium 1 h / high 4 h**, overridable per tier, with `--approval-timeout-high none` for an unbounded hold. `approvalQueue.ts` says so directly — the tiers *"(including high) shared one flat 5-minute TTL"* **before** that change.

### What stands
The substantive point is unchanged: the queue is an in-memory `Map`, so a pending approval — and any approver identity attached to it — doesn't survive a restart. **Durability** is the blocker for attributing a gated decision to its approving human. **Expiry is not.**

That distinction matters for planning: it makes the remaining work smaller and differently shaped than "the TTL is wrong for humans" implied.

### Recorded, not silently edited
The correction is a dated note inside the ADR, since the original is merged and someone may have read it.

Worth naming the mistake plainly: the claim came from a planning note rather than from the code, and I repeated it across several commit messages and PR descriptions without checking it once. The gap analysis it came from predates #1214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)