### PR TITLE
feat(dashboard): the three-column control boundary

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -10545,3 +10545,55 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 [data-theme="dark"] .ty-team-quiet,
 [data-theme="dark"] .ty-brief-toolbar { border-top-color: var(--line-2); }
 [data-theme="dark"] .ty-count { background: var(--recess); }
+
+/* ── Control boundary (three-column authority view) ────────────────────────
+   Semantic colour is deliberately NOT the only signal: each column carries a
+   title and a subtitle, so the three states are readable without colour, in
+   greyscale, and by anyone who cannot distinguish the hues. */
+.cb { display: flex; flex-direction: column; gap: 12px; }
+.cb-head { display: flex; flex-direction: column; gap: 2px; }
+.cb-title { font-size: 16px; font-weight: 600; }
+.cb-count { font-size: 12px; color: var(--ink-3); }
+.cb-cols {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+.cb-col {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.cb-col > header {
+  padding: 10px 13px 9px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.cb-col-title { font-weight: 700; font-size: 13px; }
+.cb-col-sub { font-size: 11.5px; color: var(--ink-3); }
+.cb-col--ok > header { background: var(--ok-soft); border-bottom-color: var(--ok); }
+.cb-col--ok .cb-col-title { color: var(--ok-text); }
+.cb-col--warn > header { background: var(--warn-soft); border-bottom-color: var(--warn); }
+.cb-col--warn .cb-col-title { color: var(--warn-text); }
+.cb-col--err > header { background: var(--err-soft); border-bottom-color: var(--err); }
+.cb-col--err .cb-col-title { color: var(--err); }
+.cb-col ul { list-style: none; margin: 0; padding: 4px 0; }
+.cb-col li {
+  padding: 8px 13px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.cb-col li:last-child { border-bottom: 0; }
+.cb-label { font-size: 13px; }
+.cb-why { font-size: 11.5px; color: var(--ink-3); }
+.cb-empty { margin: 0; padding: 12px 13px; font-size: 12.5px; color: var(--ink-3); }
+@media (max-width: 900px) {
+  .cb-cols { grid-template-columns: 1fr; }
+}

--- a/dashboard/src/components/ControlBoundary.tsx
+++ b/dashboard/src/components/ControlBoundary.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * The control boundary — what a worker may do now, what needs a person, and
+ * what it may never do.
+ *
+ * This is the screen the product is sold on: everything before it, a chatbot
+ * could fake. A list of proposed actions is just text. A statement about
+ * *authority* — including one column that no approval can unlock — is not.
+ *
+ * Presentational only, deliberately. It renders what the bridge computed and
+ * decides nothing itself. The bridge's `previewActions` evaluates candidates
+ * through `decideWorkerAction`, the exact function enforcement uses, so a
+ * column here cannot disagree with what would actually happen. If this
+ * component ever grew its own rules, that guarantee would quietly die: a screen
+ * that says "not permitted" while the gate would allow the action tells an
+ * operator they are protected when they are not.
+ *
+ * So: no filtering, no re-bucketing, no inference from tool names. Render the
+ * three lists as given.
+ */
+
+/** One evaluated action. Mirrors the bridge's `PreviewedAction` JSON shape. */
+export interface BoundaryAction {
+  label: string;
+  toolName: string;
+  classKey: string;
+  /** Why it is in this column, in the gate's own words. */
+  reason: string;
+}
+
+export interface ActionBoundary {
+  mayDoNow: BoundaryAction[];
+  needsApproval: BoundaryAction[];
+  notPermitted: BoundaryAction[];
+}
+
+type ColumnKind = "ok" | "warn" | "err";
+
+const COLUMNS: ReadonlyArray<{
+  key: keyof ActionBoundary;
+  kind: ColumnKind;
+  title: string;
+  sub: string;
+  empty: string;
+}> = [
+  {
+    key: "mayDoNow",
+    kind: "ok",
+    title: "May do now",
+    sub: "No sign-off needed",
+    empty: "Nothing flows without approval here.",
+  },
+  {
+    key: "needsApproval",
+    kind: "warn",
+    title: "Needs approval",
+    sub: "A named person must say yes",
+    empty: "Nothing is waiting on a person.",
+  },
+  {
+    key: "notPermitted",
+    kind: "err",
+    // Wording matters: "not permitted" and "no approval unlocks" say different
+    // things, and only the second distinguishes this column from the middle one.
+    title: "Not permitted",
+    sub: "No approval can unlock these",
+    empty: "Nothing is forbidden for this worker.",
+  },
+];
+
+export default function ControlBoundary({
+  boundary,
+  workerName,
+}: {
+  boundary: ActionBoundary;
+  workerName?: string;
+}) {
+  const total =
+    boundary.mayDoNow.length +
+    boundary.needsApproval.length +
+    boundary.notPermitted.length;
+
+  return (
+    <section className="cb" aria-label="Control boundary">
+      <header className="cb-head">
+        <h3 className="cb-title">
+          What {workerName ?? "this worker"} may do
+        </h3>
+        <span className="cb-count">
+          {total} action{total === 1 ? "" : "s"} considered · evaluated before
+          anything was attempted
+        </span>
+      </header>
+
+      <div className="cb-cols">
+        {COLUMNS.map((col) => {
+          const items = boundary[col.key];
+          return (
+            <div key={col.key} className={`cb-col cb-col--${col.kind}`}>
+              <header>
+                <span className="cb-col-title">{col.title}</span>
+                <span className="cb-col-sub">{col.sub}</span>
+              </header>
+              {items.length === 0 ? (
+                <p className="cb-empty">{col.empty}</p>
+              ) : (
+                <ul>
+                  {items.map((a) => (
+                    <li key={`${a.toolName}:${a.classKey}:${a.label}`}>
+                      <span className="cb-label">{a.label}</span>
+                      <span className="cb-why">{a.reason}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/components/__tests__/ControlBoundary.test.tsx
+++ b/dashboard/src/components/__tests__/ControlBoundary.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ControlBoundary, {
+  type ActionBoundary,
+} from "../ControlBoundary";
+
+const boundary: ActionBoundary = {
+  mayDoNow: [
+    {
+      label: "Read the ledger",
+      toolName: "file_read",
+      classKey: "fs-read:reversible:low",
+      reason: "reversible (low blast) — undoable, flows un-gated",
+    },
+  ],
+  needsApproval: [
+    {
+      label: "Publish the release",
+      toolName: "npmPublish",
+      classKey: "publish:irreversible:high",
+      reason: "irreversible + unearned (effective L0 < L4) — gated for approval",
+    },
+  ],
+  notPermitted: [
+    {
+      label: "Force-push to main",
+      toolName: "gitPush",
+      classKey: "vcs-push:compensable:high",
+      reason: "forbidden by workspace policy (rule `vcs-push`): never from a worker",
+    },
+  ],
+};
+
+const empty: ActionBoundary = {
+  mayDoNow: [],
+  needsApproval: [],
+  notPermitted: [],
+};
+
+describe("ControlBoundary", () => {
+  it("renders all three columns with their headings", () => {
+    render(<ControlBoundary boundary={boundary} />);
+    expect(screen.getByText("May do now")).toBeInTheDocument();
+    expect(screen.getByText("Needs approval")).toBeInTheDocument();
+    expect(screen.getByText("Not permitted")).toBeInTheDocument();
+  });
+
+  it("distinguishes 'not permitted' from 'needs approval' in words, not only colour", () => {
+    // The two columns are only meaningfully different if the third says no
+    // approval unlocks it. Colour alone does not carry that, and does not
+    // survive greyscale, a projector, or a colour-blind reader.
+    render(<ControlBoundary boundary={boundary} />);
+    expect(
+      screen.getByText("No approval can unlock these"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("A named person must say yes")).toBeInTheDocument();
+  });
+
+  it("puts each action in the column the bridge assigned it", () => {
+    const { container } = render(<ControlBoundary boundary={boundary} />);
+    const forbidden = container.querySelector(".cb-col--err");
+    expect(forbidden).not.toBeNull();
+    expect(
+      within(forbidden as HTMLElement).getByText("Force-push to main"),
+    ).toBeInTheDocument();
+    // and NOT anywhere else
+    const allowed = container.querySelector(".cb-col--ok") as HTMLElement;
+    expect(
+      within(allowed).queryByText("Force-push to main"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the gate's own reason for each action", () => {
+    render(<ControlBoundary boundary={boundary} />);
+    expect(
+      screen.getByText(/forbidden by workspace policy/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/undoable, flows un-gated/)).toBeInTheDocument();
+  });
+
+  it("says the boundary was computed before anything was attempted", () => {
+    // The prospective claim IS the differentiator — a retrospective log of what
+    // happened is something every tool has.
+    render(<ControlBoundary boundary={boundary} />);
+    expect(
+      screen.getByText(/evaluated before anything was attempted/),
+    ).toBeInTheDocument();
+  });
+
+  it("names the worker when given one", () => {
+    render(<ControlBoundary boundary={boundary} workerName="Release Guardian" />);
+    expect(
+      screen.getByText(/What Release Guardian may do/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty columns with an explanation rather than a blank box", () => {
+    render(<ControlBoundary boundary={empty} />);
+    expect(
+      screen.getByText("Nothing is forbidden for this worker."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("0 actions considered", { exact: false })).toBeInTheDocument();
+  });
+
+  it("singularises the count for one action", () => {
+    render(
+      <ControlBoundary
+        boundary={{ ...empty, mayDoNow: boundary.mayDoNow }}
+      />,
+    );
+    expect(screen.getByText(/1 action considered/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**GAP-2's final third.** This is the screen the product is sold on: everything before it, a chatbot could fake. A list of proposed actions is just text. A statement about *authority* — including one column no approval can unlock — is not.

### Presentational only, deliberately
It renders what the bridge computed and decides nothing itself: no filtering, no re-bucketing, no inference from tool names. `previewActions` (#1236) evaluates candidates through `decideWorkerAction` — the exact function enforcement uses — so a column here **cannot disagree** with what would actually happen. If this component grew its own rules, that guarantee would quietly die.

### Unstacked from #1236
The dashboard imports no bridge source (it talks over HTTP), so `BoundaryAction` mirrors the JSON shape rather than importing the type. That keeps this independent of the bridge PR rather than stacked on it.

### Two things the tests pin, both about not lying to a reader
- **The third column differs from the second in *words***, not only colour: *"No approval can unlock these"* vs *"A named person must say yes"*. Colour alone doesn't survive greyscale, a projector, or a colour-blind reader — and the difference between "wait for someone" and "never" is the entire point of having three columns.
- **The header states the boundary was evaluated *before* anything was attempted.** A retrospective log of what happened is something every tool has; the prospective claim is the differentiator.

Empty columns render an explanation rather than a blank box — an empty "Not permitted" is a meaningful statement (nothing is forbidden for this worker), not missing data.

8 component tests · 180 dashboard component tests green · production build clean.

### Still to come
Wiring it to a live endpoint, once #1236 lands. This PR is the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)