### PR TITLE
feat(workers): derive a default candidate set for the boundary view

### DIFF
--- a/src/workers/__tests__/previewActions.test.ts
+++ b/src/workers/__tests__/previewActions.test.ts
@@ -7,13 +7,15 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { classifyActionClass, knownActionTools } from "../actionClass.js";
 import type { GraduationConfig } from "../graduation.js";
 import {
   boundarySize,
   type CandidateAction,
+  defaultCandidatesFor,
   previewActions,
 } from "../previewActions.js";
-import { parseWorker } from "../worker.js";
+import { ownsAction, parseWorker } from "../worker.js";
 import { decideWorkerAction, gateOutcomeFor } from "../workerGate.js";
 import { WorkerLevelStore } from "../workerLevelStore.js";
 
@@ -145,5 +147,63 @@ describe("previewActions", () => {
         expect(expectedColumn.map((a) => a.toolName)).toContain(c.toolName);
       }
     }
+  });
+});
+
+describe("defaultCandidatesFor", () => {
+  it("returns the tools the worker owns, and nothing else", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const cands = defaultCandidatesFor(w);
+    expect(cands.length).toBeGreaterThan(0);
+    for (const c of cands) {
+      expect(ownsAction(w, classifyActionClass(c.toolName))).toBe(true);
+    }
+  });
+
+  it("does not return the whole tool registry", () => {
+    // A screen listing every tool in the product buries the handful that matter
+    // and puts all of them in "needs approval" — technically true, useless.
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    expect(defaultCandidatesFor(w).length).toBeLessThan(
+      knownActionTools().length,
+    );
+  });
+
+  it("widens as the worker's ownership widens", () => {
+    const narrow = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    const wide = parseWorker({
+      id: "w",
+      name: "W",
+      owns: ["fs-write", "vcs-push"],
+    });
+    expect(defaultCandidatesFor(wide).length).toBeGreaterThan(
+      defaultCandidatesFor(narrow).length,
+    );
+  });
+
+  it("returns nothing for a worker that owns nothing", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: [] });
+    expect(defaultCandidatesFor(w)).toEqual([]);
+  });
+
+  it("is stable in order, so the screen does not reshuffle between loads", () => {
+    const w = parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+    expect(defaultCandidatesFor(w)).toEqual(defaultCandidatesFor(w));
+  });
+
+  it("feeds previewActions without any external input", () => {
+    // The point of the default: a boundary is viewable for any worker with no
+    // caller-supplied list at all.
+    const w = parseWorker({
+      id: "w",
+      name: "W",
+      owns: ["fs-write", "vcs-push"],
+    });
+    const b = previewActions(
+      w,
+      defaultCandidatesFor(w),
+      new WorkerLevelStore(),
+    );
+    expect(boundarySize(b)).toBeGreaterThan(0);
   });
 });

--- a/src/workers/previewActions.ts
+++ b/src/workers/previewActions.ts
@@ -37,8 +37,9 @@
  * that never happened.
  */
 
+import { classifyActionClass, knownActionTools } from "./actionClass.js";
 import type { ForbidRule } from "./forbidPolicy.js";
-import type { WorkerManifest } from "./worker.js";
+import { ownsAction, type WorkerManifest } from "./worker.js";
 import { decideWorkerAction, gateOutcomeFor } from "./workerGate.js";
 import type { WorkerLevelStore } from "./workerLevelStore.js";
 
@@ -130,4 +131,36 @@ export function previewActions(
 /** Total candidates evaluated — for a "N actions considered" caption. */
 export function boundarySize(b: ActionBoundary): number {
   return b.mayDoNow.length + b.needsApproval.length + b.notPermitted.length;
+}
+
+/**
+ * The default candidate set for a worker: every action-class tool it owns.
+ *
+ * A boundary screen needs something to evaluate. Making the caller always
+ * supply that list would mean the generic product has no default view, and the
+ * only way to see a worker's boundary would be to hand-write its actions —
+ * which is fine for a scripted walkthrough and useless for an operator asking
+ * "what can this thing actually do?".
+ *
+ * So the default is derived from the worker's own manifest: the tools the
+ * classifier knows (`knownActionTools`), filtered to the classes this worker
+ * `owns`. That is the honest answer to the question, because a worker's `owns`
+ * IS the declaration of what it is for.
+ *
+ * Deliberately NOT the whole tool registry. Showing every tool in the product
+ * would bury the handful that matter under a hundred rows the worker will never
+ * touch, and every one of them would land in "needs approval" — a screen that
+ * is technically true and tells an operator nothing.
+ *
+ * Callers with a specific set in mind (a case, a scripted scenario) pass their
+ * own candidates to `previewActions` instead. This is the default, not the
+ * only, list.
+ */
+export function defaultCandidatesFor(
+  worker: WorkerManifest,
+): CandidateAction[] {
+  return knownActionTools()
+    .filter((toolName) => ownsAction(worker, classifyActionClass(toolName)))
+    .sort()
+    .map((toolName) => ({ toolName }));
 }


### PR DESCRIPTION
A boundary screen needs something to evaluate. Requiring the caller to *always* supply that list would leave the generic product with **no default view** — the only way to see a worker's boundary would be to hand-write its actions. Fine for a scripted walkthrough; useless for an operator asking "what can this thing actually do?"

`defaultCandidatesFor(worker)` derives the list from the manifest: the tools the classifier knows, filtered to the classes the worker `owns`. That's the honest answer, because **a worker's `owns` is its declaration of purpose.**

### Deliberately not the whole tool registry
Listing every tool in the product buries the handful that matter under rows the worker will never touch — and every one of them lands in "needs approval", producing a screen that's technically true and tells an operator nothing. A test pins that the default is strictly smaller than `knownActionTools()`.

Sorted, so the screen doesn't reshuffle between loads.

### Default, not only
A caller with a specific set in mind passes its own candidates to `previewActions`. The **generic derivation** lives in the repo; anything scenario-specific is supplied from outside it.

6 tests, including one asserting a boundary is viewable for any worker with no caller-supplied input at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)