### PR TITLE
feat(workers): boundaryForRecipe — resolve a live worker's control boundary

### DIFF
--- a/src/workers/__tests__/boundaryPreview.test.ts
+++ b/src/workers/__tests__/boundaryPreview.test.ts
@@ -1,0 +1,106 @@
+/**
+ * boundaryForRecipe — composition of trust resolution + prospective evaluation.
+ *
+ * The point of the module is that it resolves the worker and store the SAME way
+ * the live gate does, so these tests focus on the composition contract rather
+ * than re-testing previewActions.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { boundaryForRecipe } from "../boundaryPreview.js";
+import { boundarySize } from "../previewActions.js";
+
+let home: string;
+
+function writeWorker(recipe: string, owns: string[]) {
+  const dir = join(home, "workers");
+  mkdirSync(dir, { recursive: true });
+  // The loader reads `*.worker.yaml` only — a .json file is silently ignored.
+  writeFileSync(
+    join(dir, `${recipe}.worker.yaml`),
+    [
+      `id: ${recipe}-worker`,
+      `name: ${recipe} worker`,
+      `recipe: ${recipe}`,
+      "responsibilities:",
+      "  - test",
+      "owns:",
+      ...owns.map((o) => `  - ${o}`),
+      "",
+    ].join("\n"),
+  );
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "boundary-"));
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+const opts = () => ({
+  trustOpts: { patchworkDir: home, workersDir: join(home, "workers") },
+});
+
+describe("boundaryForRecipe", () => {
+  it("returns null when no worker owns the recipe", () => {
+    // Distinguishable from "a worker that may do nothing", which is an EMPTY
+    // boundary rather than a missing one.
+    expect(boundaryForRecipe("nobody-owns-this", opts())).toBeNull();
+  });
+
+  it("computes a boundary from the worker's own ownership by default", () => {
+    writeWorker("release-notes", ["fs-write"]);
+    const r = boundaryForRecipe("release-notes", opts());
+    expect(r).not.toBeNull();
+    expect(r?.workerId).toBe("release-notes-worker");
+    expect(boundarySize(r!.boundary)).toBeGreaterThan(0);
+  });
+
+  it("accepts caller-supplied candidates instead of the default", () => {
+    // The seam: a scenario-specific list is supplied from outside; the generic
+    // derivation is the fallback.
+    writeWorker("release-notes", ["fs-write"]);
+    const r = boundaryForRecipe("release-notes", {
+      ...opts(),
+      candidates: [{ toolName: "getGitStatus", label: "Just this one" }],
+    });
+    expect(boundarySize(r!.boundary)).toBe(1);
+    expect(r!.boundary.mayDoNow[0]?.label).toBe("Just this one");
+  });
+
+  it("applies forbid rules to the preview", () => {
+    writeWorker("release-notes", ["fs-write"]);
+    const r = boundaryForRecipe("release-notes", {
+      ...opts(),
+      candidates: [{ toolName: "editText" }],
+      forbidRules: [{ match: "fs-write", reason: "read-only workspace" }],
+    });
+    expect(r!.boundary.notPermitted).toHaveLength(1);
+    expect(r!.boundary.mayDoNow).toHaveLength(0);
+  });
+
+  it("reports whether the boundary is actually enforced", () => {
+    // With the flag off the boundary is still a correct statement of policy,
+    // but nothing enforces it. Reporting that is the caller's obligation; the
+    // alternative — hiding the boundary — leaves an operator with nothing.
+    writeWorker("release-notes", ["fs-write"]);
+    const r = boundaryForRecipe("release-notes", opts());
+    expect(typeof r!.enforced).toBe("boolean");
+  });
+
+  it("still returns a boundary when the flag is off", () => {
+    writeWorker("release-notes", ["fs-write"]);
+    expect(boundaryForRecipe("release-notes", opts())).not.toBeNull();
+  });
+
+  it("writes nothing — no approval enqueued, no decision recorded", () => {
+    writeWorker("release-notes", ["fs-write", "vcs-push"]);
+    boundaryForRecipe("release-notes", opts());
+    // A decision log would appear here if the preview recorded anything.
+    expect(() => rmSync(join(home, "worker_gate_decisions.jsonl"))).toThrow();
+  });
+});

--- a/src/workers/boundaryPreview.ts
+++ b/src/workers/boundaryPreview.ts
@@ -1,0 +1,81 @@
+/**
+ * The control boundary for a live worker — composition, not policy.
+ *
+ * `previewActions` answers "what would the gate say about these candidates?"
+ * given a worker and its trust store. This resolves those two from a recipe
+ * name, so a caller with nothing but "release-notes" can render the boundary.
+ *
+ * It reuses `loadWorkerTrustForRecipe` — the same resolution the live gate
+ * performs in `buildWorkerAutonomyGate`. That matters for the same reason
+ * `previewActions` reuses `decideWorkerAction`: if the preview resolved trust
+ * its own way, it could show a boundary computed from a different worker
+ * manifest or a staler store than the one enforcement will use, and be
+ * confidently wrong. Every layer of this screen has to be a view of the gate.
+ *
+ * Returns null when no worker owns the recipe — the honest answer, and
+ * distinguishable from "a worker that may do nothing", which is an empty
+ * boundary rather than a missing one.
+ */
+
+import { FLAG_WORKER_AUTONOMY, isEnabled } from "../featureFlags.js";
+import type { ForbidRule } from "./forbidPolicy.js";
+import {
+  type ActionBoundary,
+  type CandidateAction,
+  defaultCandidatesFor,
+  previewActions,
+} from "./previewActions.js";
+import type { RunWorkerShadowOpts } from "./runWorkerShadow.js";
+import { loadWorkerTrustForRecipe } from "./runWorkerShadow.js";
+
+export interface WorkerBoundary {
+  workerId: string;
+  workerName: string;
+  recipeName: string;
+  boundary: ActionBoundary;
+  /**
+   * False when the worker-autonomy flag is off. The boundary is still computed
+   * and still correct as a statement of policy — but nothing is enforcing it,
+   * and a screen that does not say so would imply protection that is not
+   * running. The caller must surface this.
+   */
+  enforced: boolean;
+}
+
+export interface BoundaryPreviewOpts {
+  /** Caller-supplied candidates. Omitted ⇒ derived from the worker's `owns`. */
+  candidates?: readonly CandidateAction[];
+  forbidRules?: readonly ForbidRule[];
+  trustOpts?: RunWorkerShadowOpts;
+}
+
+/**
+ * Compute the control boundary for whichever worker owns `recipeName`.
+ *
+ * Read-only: resolves trust, evaluates hypotheticals, writes nothing. No
+ * approval is enqueued and no decision is recorded — see `previewActions`.
+ */
+export function boundaryForRecipe(
+  recipeName: string,
+  opts: BoundaryPreviewOpts = {},
+): WorkerBoundary | null {
+  const trust = loadWorkerTrustForRecipe(recipeName, opts.trustOpts);
+  if (!trust) return null;
+
+  const { worker, store } = trust;
+  const candidates = opts.candidates ?? defaultCandidatesFor(worker);
+
+  return {
+    workerId: worker.id,
+    workerName: worker.name,
+    recipeName,
+    boundary: previewActions(worker, candidates, store, {
+      ...(opts.forbidRules ? { forbidRules: opts.forbidRules } : {}),
+    }),
+    // Deliberately reported rather than used to suppress the result. An
+    // operator asking "what may this worker do?" while the flag is off should
+    // get the answer AND be told it is not being enforced — hiding the boundary
+    // would leave them with no information at all, which is worse.
+    enforced: isEnabled(FLAG_WORKER_AUTONOMY),
+  };
+}


### PR DESCRIPTION
Composition, not policy. `previewActions` answers *"what would the gate say about these candidates?"* given a worker and its trust store. This resolves those two from a recipe name, so a caller with nothing but `"release-notes"` can render the boundary.

### Why it reuses the gate's own trust resolution
It calls `loadWorkerTrustForRecipe` — the same function `buildWorkerAutonomyGate` uses. Same reason `previewActions` reuses `decideWorkerAction`: a preview that resolved trust its own way could show a boundary computed from a **different manifest or a staler store** than enforcement will use, and be confidently wrong.

Every layer of this screen has to be a *view of* the gate, not a *description of* it. That's now true at both layers.

### Three deliberate choices
- **Returns `null` when no worker owns the recipe** — distinguishable from "a worker that may do nothing", which is an *empty* boundary rather than a missing one.
- **Reports `enforced` rather than using it to suppress the result.** With the worker-autonomy flag off, the boundary is still a correct statement of policy — nothing is enforcing it. An operator asking "what may this worker do?" should get the answer *and* be told it isn't live. Hiding the boundary leaves them with nothing, which is worse.
- **Candidates default to the worker's `owns`, and the caller can replace them** — the generic derivation lives in the repo, anything scenario-specific is supplied from outside.

Read-only: resolves trust, evaluates hypotheticals, writes nothing. A test asserts no decision log is produced.

Also drops a duplicated `FLAG_WORKER_AUTONOMY` literal in favour of the exported constant — a second copy of a flag id is exactly the drift this module argues against.

7 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)