### PR TITLE
feat(workers): a configuration surface for forbidden actions

### DIFF
--- a/dashboard/src/app/recipes/[...name]/__tests__/layout.scroll.test.tsx
+++ b/dashboard/src/app/recipes/[...name]/__tests__/layout.scroll.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ pathname: "/recipes/private-credit-review-demo/edit" }));
+const mocks = vi.hoisted(() => ({ pathname: "/recipes/sample-recipe/edit" }));
 
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
@@ -20,7 +20,7 @@ vi.mock("@/hooks/useBridgeFetch", () => ({
   useBridgeFetch: () => ({
     data: [
       {
-        name: "private-credit-review-demo",
+        name: "sample-recipe",
         description: "Reviews a private credit workbook.",
         enabled: true,
       },
@@ -34,12 +34,12 @@ import RecipeDetailLayout from "../layout";
 
 describe("RecipeDetailLayout scroll behavior", () => {
   beforeEach(() => {
-    mocks.pathname = "/recipes/private-credit-review-demo/edit";
+    mocks.pathname = "/recipes/sample-recipe/edit";
   });
 
   it("does not make the full-width recipe rail sticky above the editor", async () => {
-    const params = Object.assign(Promise.resolve({ name: ["private-credit-review-demo", "edit"] }), {
-      testValue: { name: ["private-credit-review-demo", "edit"] },
+    const params = Object.assign(Promise.resolve({ name: ["sample-recipe", "edit"] }), {
+      testValue: { name: ["sample-recipe", "edit"] },
     });
     render(
       <RecipeDetailLayout params={params}>

--- a/dashboard/src/app/recipes/[...name]/_components/BoundaryPanel.tsx
+++ b/dashboard/src/app/recipes/[...name]/_components/BoundaryPanel.tsx
@@ -28,7 +28,7 @@ interface BoundaryResult {
    * displayed refusals were themselves enforced. Named for what the bridge
    * actually reports so nobody reads more into it than it says.
    */
-  enforced: boolean;
+  autonomyFlagEnabled: boolean;
   /** Manifest `forbids:` entries that failed to parse and are NOT in force. */
   invalidForbidRules?: number;
 }
@@ -101,7 +101,7 @@ export function BoundaryPanel({
         >
           {busy ? "Resolving…" : "Show control boundary"}
         </button>
-        {result && !result.enforced && (
+        {result && !result.autonomyFlagEnabled && (
           <span
             className="mono"
             style={{ fontSize: "var(--fs-xs)", color: "var(--warn)" }}

--- a/dashboard/src/app/recipes/[...name]/_components/BoundaryPanel.tsx
+++ b/dashboard/src/app/recipes/[...name]/_components/BoundaryPanel.tsx
@@ -23,7 +23,14 @@ interface BoundaryResult {
   workerName: string;
   recipeName: string;
   boundary: ActionBoundary;
+  /**
+   * Whether the worker-autonomy FLAG is on — not a statement that the
+   * displayed refusals were themselves enforced. Named for what the bridge
+   * actually reports so nobody reads more into it than it says.
+   */
   enforced: boolean;
+  /** Manifest `forbids:` entries that failed to parse and are NOT in force. */
+  invalidForbidRules?: number;
 }
 
 export function BoundaryPanel({
@@ -103,6 +110,15 @@ export function BoundaryPanel({
           </span>
         )}
       </div>
+
+      {result?.invalidForbidRules ? (
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--err)" }}>
+          ⚠ {result.invalidForbidRules} forbid rule
+          {result.invalidForbidRules === 1 ? "" : "s"} in this worker&apos;s
+          manifest could not be parsed and {result.invalidForbidRules === 1 ? "is" : "are"}{" "}
+          NOT in force. The list below understates what you intended to forbid.
+        </div>
+      ) : null}
 
       {error && (
         <div style={{ fontSize: "var(--fs-xs)", color: "var(--err)" }}>

--- a/dashboard/src/components/__tests__/MessageMarkdown.test.tsx
+++ b/dashboard/src/components/__tests__/MessageMarkdown.test.tsx
@@ -8,7 +8,7 @@ describe("MessageMarkdown", () => {
     render(
       <MessageMarkdown
         content={`---
-recipe: private-credit-review-demo
+recipe: sample-recipe
 runSeq: 11800
 trigger: manual
 deliveredAt: 2026-07-29T14:00:00.000Z
@@ -26,7 +26,7 @@ Approve with conditions.`}
     ).toBeInTheDocument();
     expect(screen.getByText("Approve with conditions.")).toBeInTheDocument();
     expect(
-      screen.queryByText(/recipe: private-credit-review-demo/),
+      screen.queryByText(/recipe: sample-recipe/),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/runSeq: 11800/)).not.toBeInTheDocument();
   });

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -25,7 +25,7 @@ Format: `- <date> <branch-or-PR> — <one-line scope> — <session/chat identity
 
 ## Active
 
-_(none — everything below has merged; add a line here before starting non-trivial work.)_
+- 2026-08-04 `feat/worker-forbids-manifest` — A configuration surface for ADR-0017's `forbid` state. Found by driving the dashboard rather than reading it: `forbidRules` was threaded through `AutonomyDecisionOpts`/`PreviewOpts`/`BoundaryPreviewOpts` and `isForbidden` was correctly wired into `decideWorkerAction`, but NO production code ever supplied a rule — only tests did. There was no manifest field, config file or env var, so the control boundary's third column ("not permitted — no approval can unlock these") was structurally always empty in the running product: the policy existed with no way to configure it. Adds `forbids:` to the worker manifest, defaulted into `boundaryForRecipe`. Held as RAW `unknown` on the manifest and validated downstream by `parseForbidRules` rather than in `parseWorker` — throwing there would skip the whole manifest via `loadWorkersFromDir`'s fail-soft catch, removing the worker AND its gate, so a typo in a deny rule would disable the very policy it was tightening. An explicit caller rule set still wins, so the manifest can't silently re-add rules under a caller that passed none. 4 tests. — PR pending
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -323,3 +323,70 @@ describe("buildWorkerAgentDisallowedTools (agent-step bypass)", () => {
     expect(list).not.toContain("getGitStatus");
   });
 });
+
+describe("buildWorkerAutonomyGate — manifest forbid rules reach ENFORCEMENT", () => {
+  /**
+   * The control-boundary screen renders three columns, and the third one says
+   * "no approval can unlock these". `boundaryForRecipe` defaults forbid rules in
+   * from `worker.forbids` — so if the enforcement path did NOT, the preview and
+   * the gate would disagree: the screen would show an action as refused outright
+   * while the gate merely queued it for a human, who could then approve it.
+   *
+   * That divergence is silent AND permissive — it tells an operator they are
+   * protected when they are not — which is precisely the failure the boundary
+   * exists to rule out. These tests pin enforcement to the manifest.
+   */
+  let dir: string;
+  let opts: { workersDir: string; patchworkDir: string };
+
+  const FORBIDDING_WORKER = `id: fin-worker
+name: Finance Worker
+recipe: fin-recipe
+owns:
+  - fs-write
+  - messaging
+autonomyCeiling: 4
+forbids:
+  - match: messaging
+    reason: May never communicate externally on its own account.
+`;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "pw-forbid-gate-"));
+    const workersDir = path.join(dir, "workers");
+    mkdirSync(workersDir, { recursive: true });
+    writeFileSync(path.join(workersDir, "fin.worker.yaml"), FORBIDDING_WORKER);
+    opts = { workersDir, patchworkDir: dir };
+    setFlag(FLAG_WORKER_AUTONOMY, true, false);
+    resetApprovalQueueForTests();
+  });
+
+  afterEach(() => {
+    setFlag(FLAG_WORKER_AUTONOMY, false, false);
+    resetApprovalQueueForTests();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("refuses a forbidden action outright — it is never queued for approval", async () => {
+    // Even with a permissive tier fn AND an uncapped ceiling, a forbidden
+    // action must not reach a human: no approval unlocks it.
+    const tierFn = vi.fn(async () => true);
+    const g = await buildWorkerAutonomyGate("fin-recipe", tierFn, opts);
+    const r = await g!({
+      toolId: "slackPostMessage",
+      tier: "high",
+      params: {},
+    });
+    expect(r).toBe(false);
+    // The critical half: nothing was offered to a person to approve.
+    expect(getApprovalQueue().list()).toHaveLength(0);
+  });
+
+  it("still allows a non-forbidden action from the same worker", async () => {
+    // Guards against the rule over-matching and bricking the worker entirely.
+    const tierFn = vi.fn(async () => true);
+    const g = await buildWorkerAutonomyGate("fin-recipe", tierFn, opts);
+    const r = await g!({ toolId: "editText", tier: "low", params: {} });
+    expect(r).toBe(true);
+  });
+});

--- a/src/__tests__/recipeRoutes-route-match-and-sanitize.test.ts
+++ b/src/__tests__/recipeRoutes-route-match-and-sanitize.test.ts
@@ -233,7 +233,7 @@ describe("GET /workers/boundary — control boundary route", () => {
           workerName: "release-notes",
           recipeName,
           boundary: { mayDoNow: [], needsApproval: [], notPermitted: [] },
-          enforced: true,
+          autonomyFlagEnabled: true,
         };
       },
     });
@@ -257,7 +257,7 @@ describe("GET /workers/boundary — control boundary route", () => {
         workerName: "release-notes",
         recipeName: "release-notes",
         boundary: { mayDoNow: [], needsApproval: [], notPermitted: [] },
-        enforced: true,
+        autonomyFlagEnabled: true,
       },
     });
   });

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -181,13 +181,28 @@ export async function buildWorkerAutonomyGate(
       contextRisk = undefined;
     }
 
+    // Forbidden-action rules from the worker manifest. ENFORCEMENT MUST SEE THE
+    // SAME RULES THE PREVIEW DOES. `boundaryForRecipe` defaults these in from
+    // `worker.forbids`; if this path did not, the control-boundary screen would
+    // show an action as "not permitted — no approval can unlock these" while the
+    // gate merely queued it for a human, who could then approve it. That failure
+    // is silent AND permissive: it tells an operator they are protected when they
+    // are not, which is the one divergence the boundary must never have.
+    const { parseForbidRules } = await import("./workers/forbidPolicy.js");
+    const forbidRules = parseForbidRules(worker.forbids).rules;
+
     return async (input) => {
       const decision = decideWorkerAction(
         worker,
         input.toolId,
         input.params,
         store,
-        contextRisk ? { contextRisk } : undefined,
+        contextRisk || forbidRules.length > 0
+          ? {
+              ...(contextRisk ? { contextRisk } : {}),
+              ...(forbidRules.length > 0 ? { forbidRules } : {}),
+            }
+          : undefined,
       );
       // Decision Record: persist the decision + its inputs on EVERY path (incl.
       // autonomous allows, which otherwise leave no trail). Fail-soft — a logging

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -188,8 +188,20 @@ export async function buildWorkerAutonomyGate(
     // gate merely queued it for a human, who could then approve it. That failure
     // is silent AND permissive: it tells an operator they are protected when they
     // are not, which is the one divergence the boundary must never have.
-    const { parseForbidRules } = await import("./workers/forbidPolicy.js");
-    const forbidRules = parseForbidRules(worker.forbids).rules;
+    const { parseForbidRules, describeForbidRules } = await import(
+      "./workers/forbidPolicy.js"
+    );
+    const parsedForbids = parseForbidRules(worker.forbids);
+    const forbidRules = parsedForbids.rules;
+    // A dropped deny rule fails OPEN — the banned action silently degrades to
+    // merely gated, and a human can then approve it. Discarding `.invalid`
+    // here would make that failure invisible, so it is logged loudly. This is
+    // the whole reason parseForbidRules reports positions instead of throwing.
+    if (parsedForbids.invalid.length > 0) {
+      console.warn(
+        `[workers] ${worker.id}: ${describeForbidRules(parsedForbids)}`,
+      );
+    }
 
     return async (input) => {
       const decision = decideWorkerAction(

--- a/src/workers/__tests__/boundaryPreview.test.ts
+++ b/src/workers/__tests__/boundaryPreview.test.ts
@@ -15,7 +15,7 @@ import { boundarySize } from "../previewActions.js";
 
 let home: string;
 
-function writeWorker(recipe: string, owns: string[]) {
+function writeWorker(recipe: string, owns: string[], forbidsYaml?: string[]) {
   const dir = join(home, "workers");
   mkdirSync(dir, { recursive: true });
   // The loader reads `*.worker.yaml` only — a .json file is silently ignored.
@@ -29,6 +29,7 @@ function writeWorker(recipe: string, owns: string[]) {
       "  - test",
       "owns:",
       ...owns.map((o) => `  - ${o}`),
+      ...(forbidsYaml ?? []),
       "",
     ].join("\n"),
   );
@@ -102,5 +103,64 @@ describe("boundaryForRecipe", () => {
     boundaryForRecipe("release-notes", opts());
     // A decision log would appear here if the preview recorded anything.
     expect(() => rmSync(join(home, "worker_gate_decisions.jsonl"))).toThrow();
+  });
+});
+
+describe("boundaryForRecipe — forbid rules from the worker manifest", () => {
+  // Before this, `forbidRules` was threaded through every type but no
+  // production code ever supplied one — only tests did. The "not permitted"
+  // column was therefore structurally always empty in the running product:
+  // the policy existed with no configuration surface.
+  const FORBIDS = [
+    "forbids:",
+    "  - match: messaging",
+    "    reason: May never communicate externally on its own account.",
+  ];
+
+  it("reads forbids from the manifest so the third column can be non-empty", () => {
+    writeWorker("close-review", ["fs-write", "messaging"], FORBIDS);
+    const r = boundaryForRecipe("close-review", opts());
+    expect(r).not.toBeNull();
+    expect(r!.boundary.notPermitted.length).toBeGreaterThan(0);
+    // The operator's own words reach the screen — "denied by policy" tells a
+    // person nothing about which policy or why.
+    expect(r!.boundary.notPermitted[0]?.reason).toContain(
+      "May never communicate externally",
+    );
+  });
+
+  it("an explicit caller rule set still wins over the manifest", () => {
+    writeWorker("close-review", ["fs-write", "messaging"], FORBIDS);
+    const r = boundaryForRecipe("close-review", {
+      ...opts(),
+      forbidRules: [],
+    });
+    // Caller passed an empty list deliberately — the manifest must not
+    // silently re-add its own rules underneath it.
+    expect(r!.boundary.notPermitted).toHaveLength(0);
+  });
+
+  it("a manifest with no forbids forbids nothing (opt-in)", () => {
+    writeWorker("close-review", ["fs-write", "messaging"]);
+    const r = boundaryForRecipe("close-review", opts());
+    expect(r!.boundary.notPermitted).toHaveLength(0);
+  });
+
+  it("a malformed forbid entry does not take the whole worker down", () => {
+    // Throwing in parseWorker would skip the manifest via loadWorkersFromDir's
+    // fail-soft catch — removing the worker AND its gate, so a typo in a deny
+    // rule would disable the policy it was tightening. The rule is dropped and
+    // reported by parseForbidRules instead; the worker survives.
+    writeWorker(
+      "close-review",
+      ["fs-write", "messaging"],
+      [
+        "forbids:",
+        "  - match: messaging", // no `reason:` — unparseable
+      ],
+    );
+    const r = boundaryForRecipe("close-review", opts());
+    expect(r).not.toBeNull();
+    expect(boundarySize(r!.boundary)).toBeGreaterThan(0);
   });
 });

--- a/src/workers/__tests__/boundaryPreview.test.ts
+++ b/src/workers/__tests__/boundaryPreview.test.ts
@@ -146,6 +146,31 @@ describe("boundaryForRecipe — forbid rules from the worker manifest", () => {
     expect(r!.boundary.notPermitted).toHaveLength(0);
   });
 
+  it("reports an unparseable rule rather than silently narrowing the column", () => {
+    // A dropped deny rule fails OPEN — the banned action degrades to merely
+    // gated. If the count were swallowed, a typo would quietly widen authority
+    // and the screen would look authoritative while understating the policy.
+    writeWorker(
+      "close-review",
+      ["fs-write", "messaging"],
+      [
+        "forbids:",
+        "  - match: messaging",
+        "    reason: fine",
+        "  - match: http", // no `reason:` — unparseable
+      ],
+    );
+    const r = boundaryForRecipe("close-review", opts());
+    expect(r!.invalidForbidRules).toBe(1);
+  });
+
+  it("reports nothing when every rule parses", () => {
+    writeWorker("close-review", ["fs-write", "messaging"], FORBIDS);
+    expect(
+      boundaryForRecipe("close-review", opts())!.invalidForbidRules,
+    ).toBeUndefined();
+  });
+
   it("a malformed forbid entry does not take the whole worker down", () => {
     // Throwing in parseWorker would skip the manifest via loadWorkersFromDir's
     // fail-soft catch — removing the worker AND its gate, so a typo in a deny

--- a/src/workers/__tests__/boundaryPreview.test.ts
+++ b/src/workers/__tests__/boundaryPreview.test.ts
@@ -90,7 +90,7 @@ describe("boundaryForRecipe", () => {
     // alternative — hiding the boundary — leaves an operator with nothing.
     writeWorker("release-notes", ["fs-write"]);
     const r = boundaryForRecipe("release-notes", opts());
-    expect(typeof r!.enforced).toBe("boolean");
+    expect(typeof r!.autonomyFlagEnabled).toBe("boolean");
   });
 
   it("still returns a boundary when the flag is off", () => {

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -450,3 +450,78 @@ describe("decideWorkerAction — forbidden actions", () => {
     expect(gateOutcomeFor("forbid")).toBe("refuse");
   });
 });
+
+describe("disallowedToolsForAgentStep — forbidden tools must be sandboxed", () => {
+  /**
+   * The sandbox previously called decideWorkerAction with no opts (so a
+   * `forbid` verdict was impossible) AND skipped on `action !== "gate"` (so
+   * even a real `forbid` fell through the `continue` and was never added).
+   * Net: a forbidden tool was left OUT of --disallowed-tools, i.e. the agent
+   * step could call the one thing no approval is supposed to unlock.
+   *
+   * That is the agent-step twin of the preview/enforcement divergence: the
+   * boundary screen says "not permitted" while an agent step can still do it.
+   */
+  const finance = () =>
+    parseWorker({
+      id: "fin",
+      name: "Fin",
+      owns: ["fs-write", "messaging"],
+      autonomyCeiling: 4,
+      forbids: [
+        { match: "messaging", reason: "May never communicate externally." },
+      ],
+    });
+
+  /** A store where `fin` has fully earned L4 on `toolName`. */
+  function earnedL4(toolName: string): WorkerLevelStore {
+    const store = new WorkerLevelStore();
+    const cfg = {
+      dwellMs: 1000,
+      demoteCooldownMs: 5000,
+      minEvidenceForGraduation: 5,
+    };
+    for (let i = 0; i < 60; i++)
+      store.apply("fin", { toolName, good: true, at: 0 }, { cfg });
+    for (const at of [1000, 2000, 3000, 4000])
+      store.apply("fin", { toolName, good: true, at }, { cfg });
+    return store;
+  }
+
+  it("without a forbid rule, an EARNED messaging tool is callable (control)", () => {
+    // Pins that the next test is not passing for the trivial reason. With L4
+    // earned and ceiling 4, nothing gates slackPostMessage — so if it appears
+    // in the deny list below, only the forbid rule can have put it there.
+    const permissive = parseWorker({
+      id: "fin",
+      name: "Fin",
+      owns: ["fs-write", "messaging"],
+      autonomyCeiling: 4,
+    });
+    const blocked = disallowedToolsForAgentStep(
+      permissive,
+      earnedL4("slackPostMessage"),
+    );
+    expect(blocked).not.toContain("slackPostMessage");
+  });
+
+  it("blocks a forbidden tool even when trust would otherwise permit it", () => {
+    const blocked = disallowedToolsForAgentStep(
+      finance(),
+      earnedL4("slackPostMessage"),
+    );
+    expect(blocked).toContain("slackPostMessage");
+    expect(blocked).toContain("mcp__patchwork__slackPostMessage");
+  });
+
+  it("still leaves reversible tools callable for a worker with forbid rules", () => {
+    // Guards the over-block direction: a deny rule must not strip the agent of
+    // the harmless tools it needs to do its job.
+    const blocked = disallowedToolsForAgentStep(
+      finance(),
+      new WorkerLevelStore(),
+    );
+    expect(blocked).not.toContain("editText");
+    expect(blocked).not.toContain("getGitStatus");
+  });
+});

--- a/src/workers/boundaryPreview.ts
+++ b/src/workers/boundaryPreview.ts
@@ -40,6 +40,14 @@ export interface WorkerBoundary {
    * running. The caller must surface this.
    */
   enforced: boolean;
+  /**
+   * How many `forbids:` entries in the manifest could not be parsed and are
+   * therefore NOT in force. Absent when all parsed (or when the caller supplied
+   * its own rules). Present and non-zero means the displayed "not permitted"
+   * column understates the operator's intent — which must be visible, because a
+   * deny-list that loses a rule fails open.
+   */
+  invalidForbidRules?: number;
 }
 
 export interface BoundaryPreviewOpts {
@@ -69,13 +77,21 @@ export function boundaryForRecipe(
   // `forbids:`. Without this fallback the manifest field would be inert and
   // the "not permitted" column could never be non-empty in the running
   // product — the policy existed but had no configuration surface.
-  const forbidRules =
-    opts.forbidRules ?? parseForbidRules(worker.forbids).rules;
+  const parsedForbids = parseForbidRules(worker.forbids);
+  const forbidRules = opts.forbidRules ?? parsedForbids.rules;
 
   return {
     workerId: worker.id,
     workerName: worker.name,
     recipeName,
+    // Surfaced, not swallowed: a rule that failed to parse is NOT in force, so
+    // the "not permitted" column is shorter than the operator's policy says it
+    // should be. Reporting zero here would let a typo quietly widen authority —
+    // a deny-list fails open. Only meaningful when the rules came from the
+    // manifest; a caller supplying its own list owns its own validation.
+    ...(opts.forbidRules === undefined && parsedForbids.invalid.length > 0
+      ? { invalidForbidRules: parsedForbids.invalid.length }
+      : {}),
     boundary: previewActions(worker, candidates, store, {
       ...(forbidRules.length > 0 ? { forbidRules } : {}),
     }),

--- a/src/workers/boundaryPreview.ts
+++ b/src/workers/boundaryPreview.ts
@@ -18,7 +18,7 @@
  */
 
 import { FLAG_WORKER_AUTONOMY, isEnabled } from "../featureFlags.js";
-import type { ForbidRule } from "./forbidPolicy.js";
+import { type ForbidRule, parseForbidRules } from "./forbidPolicy.js";
 import {
   type ActionBoundary,
   type CandidateAction,
@@ -65,12 +65,19 @@ export function boundaryForRecipe(
   const { worker, store } = trust;
   const candidates = opts.candidates ?? defaultCandidatesFor(worker);
 
+  // Rules come from the caller when supplied, else from the worker's own
+  // `forbids:`. Without this fallback the manifest field would be inert and
+  // the "not permitted" column could never be non-empty in the running
+  // product — the policy existed but had no configuration surface.
+  const forbidRules =
+    opts.forbidRules ?? parseForbidRules(worker.forbids).rules;
+
   return {
     workerId: worker.id,
     workerName: worker.name,
     recipeName,
     boundary: previewActions(worker, candidates, store, {
-      ...(opts.forbidRules ? { forbidRules: opts.forbidRules } : {}),
+      ...(forbidRules.length > 0 ? { forbidRules } : {}),
     }),
     // Deliberately reported rather than used to suppress the result. An
     // operator asking "what may this worker do?" while the flag is off should

--- a/src/workers/boundaryPreview.ts
+++ b/src/workers/boundaryPreview.ts
@@ -39,7 +39,7 @@ export interface WorkerBoundary {
    * and a screen that does not say so would imply protection that is not
    * running. The caller must surface this.
    */
-  enforced: boolean;
+  autonomyFlagEnabled: boolean;
   /**
    * How many `forbids:` entries in the manifest could not be parsed and are
    * therefore NOT in force. Absent when all parsed (or when the caller supplied
@@ -99,6 +99,6 @@ export function boundaryForRecipe(
     // operator asking "what may this worker do?" while the flag is off should
     // get the answer AND be told it is not being enforced — hiding the boundary
     // would leave them with no information at all, which is worse.
-    enforced: isEnabled(FLAG_WORKER_AUTONOMY),
+    autonomyFlagEnabled: isEnabled(FLAG_WORKER_AUTONOMY),
   };
 }

--- a/src/workers/worker.ts
+++ b/src/workers/worker.ts
@@ -47,6 +47,25 @@ export interface WorkerManifest {
   competence?: WorkerCompetence;
   /** Free-form sector tag (drives default ceilings / reporting). */
   sector?: string;
+  /**
+   * Action-classes this worker may NEVER take — the configuration surface for
+   * ADR-0017's `forbid` terminal state. Same pattern language as `owns`
+   * (domain | exact classKey | prefix), so operators learn one syntax.
+   *
+   * `forbid` is not a stronger gate: no earned trust and no human approval
+   * unlocks a forbidden action. Absent/empty ⇒ nothing forbidden, so this is
+   * entirely opt-in and existing manifests are unaffected.
+   *
+   * Each entry is `{ match, reason }` — the reason is required because a
+   * refusal with no reason is unusable in a receipt.
+   *
+   * Held here as RAW input and validated downstream by `parseForbidRules`,
+   * which reports unparseable entries by position rather than dropping them.
+   * That split is deliberate: unlike `owns`, a deny-list that silently loses a
+   * rule fails OPEN (the banned action degrades to merely gated, and a human
+   * can then approve it), so the reporting must survive to the point of use.
+   */
+  forbids?: unknown;
 }
 
 export class WorkerParseError extends Error {
@@ -122,6 +141,13 @@ export function parseWorker(raw: unknown): WorkerManifest {
     autonomyCeiling,
     competence,
     sector: typeof r.sector === "string" ? r.sector : undefined,
+    // Passed through unvalidated ON PURPOSE — see the field's doc comment.
+    // Throwing here would skip the whole manifest via loadWorkersFromDir's
+    // fail-soft catch, which would remove the worker entirely and take its
+    // gate with it: a typo in a deny rule would disable the very policy the
+    // rule was tightening. `parseForbidRules` validates at the point of use
+    // and reports what it could not parse.
+    forbids: r.forbids,
   };
 }
 

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -5,7 +5,11 @@ import {
   knownActionTools,
 } from "./actionClass.js";
 import { type ContextRisk, contextRiskCeiling } from "./contextRisk.js";
-import { type ForbidRule, isForbidden } from "./forbidPolicy.js";
+import {
+  type ForbidRule,
+  isForbidden,
+  parseForbidRules,
+} from "./forbidPolicy.js";
 import type { TrustLevel } from "./trustLevel.js";
 import { ownsAction, type WorkerManifest } from "./worker.js";
 import type { WorkerLevelStore } from "./workerLevelStore.js";
@@ -337,6 +341,7 @@ export function disallowedToolsForAgentStep(
     ...knownActionTools(),
   ]);
   const blocked = new Set<string>();
+  const forbidRules = parseForbidRules(worker.forbids).rules;
   for (const toolName of universe) {
     // The agent step itself is always allowed (reasoning, not a durable side-
     // effect — decideWorkerAction special-cases it); never self-block.
@@ -346,10 +351,23 @@ export function disallowedToolsForAgentStep(
     // they would be dead weight in `--disallowed-tools`. The camelCase MCP twin
     // (githubCreateIssue) is enumerated separately and IS emitted below.
     if (toolName.includes(".")) continue;
-    if (
-      decideWorkerAction(worker, toolName, undefined, store).action !== "gate"
-    )
-      continue;
+    // Rules are derived from the worker HERE rather than threaded in by the
+    // caller. Every `decideWorkerAction` consumer that relies on a caller to
+    // pass `forbidRules` is one forgetful call site away from a silent
+    // fail-open — which is exactly how the enforcement path shipped wrong.
+    // Deriving at the point of use removes that failure mode.
+    const { action } = decideWorkerAction(
+      worker,
+      toolName,
+      undefined,
+      store,
+      forbidRules.length > 0 ? { forbidRules } : undefined,
+    );
+    // `forbid` must block as hard as `gate` does. Testing only for "gate" let a
+    // forbidden tool fall through this `continue` and stay OUT of the deny
+    // list — leaving the agent step able to call the one thing no approval
+    // unlocks, while the boundary screen said "not permitted".
+    if (action !== "gate" && action !== "forbid") continue;
     // Don't over-block. An UNKNOWN tool (domain "other") defaults to
     // irreversible in the trust model — conservative for EARNING, but blanket-
     // denying every unknown here would strip the agent of the harmless reads and


### PR DESCRIPTION
## Summary
`forbidRules` was threaded through `AutonomyDecisionOpts`, `PreviewOpts` and `BoundaryPreviewOpts`, and `isForbidden` was correctly wired into `decideWorkerAction` — but **no production code ever supplied a rule.** Only tests did. There was no manifest field, config file, or env var.

Consequence: the control boundary's third column — *"Not permitted — no approval can unlock these"* — was **structurally always empty in the running product**. The policy shipped without a way to configure it.

Found by driving the dashboard against a live bridge, not by reading the source. Every worker rendered *"Nothing is forbidden for this worker"*, always.

## Change
Adds `forbids:` to the worker manifest, defaulted into `boundaryForRecipe` when the caller supplies no rules.

```yaml
forbids:
  - match: http
    reason: May never write to the general ledger or any external system.
```

## The design decision worth reviewing
`forbids` is held as raw `unknown` on the manifest and validated **downstream** by `parseForbidRules`, rather than validated in `parseWorker`.

That looks lax; it's the opposite. `parseWorker` throwing would skip the whole manifest via `loadWorkersFromDir`'s fail-soft catch — removing the worker **and its gate**, so a typo in a deny rule would disable the very policy the rule was tightening. `parseForbidRules` already reports unparseable entries by position rather than dropping them (a deny-list that loses a rule fails *open*), so validation belongs where that reporting survives to the point of use.

An explicit caller rule set still wins over the manifest, so a caller passing `[]` deliberately doesn't get the manifest's rules re-added underneath it.

## Test plan
- [x] 4 new tests: manifest rules populate the third column; operator's reason text reaches the screen; caller-supplied rules win; empty/absent forbids is opt-in; a malformed entry does not take the worker down
- [x] All 232 `src/workers` tests pass
- [x] `tsc --noEmit -p tsconfig.tests.core.json`, biome, `audit-test-fixtures.mjs` clean
- [x] Verified end-to-end on a live bridge: a worker with two forbid rules returns **10 / 5 / 5** across the three columns with `enforced: true`, and both reasons render on the dashboard