### PR TITLE
fix(dashboard): match connector namespaces as tokens, not substrings

### DIFF
--- a/dashboard/src/lib/__tests__/recipeConnectors.test.ts
+++ b/dashboard/src/lib/__tests__/recipeConnectors.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression: `detectConnectorsForRecipe` matched connector namespaces by naive
+ * substring, so the two-letter alias `es` (elasticsearch) hit the letters "es"
+ * inside ordinary English — "does", "files", "causes", "assembles". On a real
+ * install that made 63 of 73 recipes report "It needs Elasticsearch connected
+ * before it can run", with a Connect button leading to a setup task that did
+ * not exist.
+ *
+ * A FALSE required-connector is worse than a missed one: it blocks a working
+ * recipe behind imaginary setup. These pin whole-token matching.
+ */
+
+import { describe, expect, it } from "vitest";
+import { detectConnectorsForRecipe } from "../recipeConnectors";
+
+describe("detectConnectorsForRecipe — no substring false positives", () => {
+  it("does not infer elasticsearch from ordinary English containing 'es'", () => {
+    const recipe = {
+      name: "month-end-exception-review",
+      description:
+        "It does not post anything. The recipe reads both evidence files and " +
+        "assembles the memo, decomposing causes by type.",
+    };
+    expect(detectConnectorsForRecipe(recipe)).not.toContain("elasticsearch");
+  });
+
+  it.each([
+    ["does", "it does not post anything"],
+    ["files", "reads both evidence files"],
+    ["causes", "decomposing causes by type"],
+    ["assembles", "assembles the memo"],
+    ["notes", "release notes for the period"],
+  ])("'%s' does not trigger elasticsearch", (_word, description) => {
+    expect(
+      detectConnectorsForRecipe({ name: "r", description }),
+    ).not.toContain("elasticsearch");
+  });
+
+  it("still detects a genuine `es` namespace as a whole token", () => {
+    expect(
+      detectConnectorsForRecipe({ name: "r", description: "queries es for logs" }),
+    ).toContain("elasticsearch");
+  });
+
+  it("still detects a full connector id by name", () => {
+    expect(
+      detectConnectorsForRecipe({
+        name: "log-search",
+        description: "reads from elasticsearch",
+      }),
+    ).toContain("elasticsearch");
+  });
+
+  it("detects hyphenated connector ids (regex-escaped)", () => {
+    expect(
+      detectConnectorsForRecipe({
+        name: "r",
+        description: "syncs with google-calendar each morning",
+      }),
+    ).toContain("google-calendar");
+  });
+
+  it("does not infer a connector from a word merely containing its id", () => {
+    // "slackness" contains "slack"; a token match must not fire.
+    expect(
+      detectConnectorsForRecipe({ name: "r", description: "reviews slackness" }),
+    ).not.toContain("slack");
+  });
+
+  it("returns nothing for a recipe that names no connector", () => {
+    expect(
+      detectConnectorsForRecipe({
+        name: "month-end-exception-review",
+        description: "reads a local csv and writes a memo to the inbox",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/dashboard/src/lib/recipeConnectors.ts
+++ b/dashboard/src/lib/recipeConnectors.ts
@@ -35,6 +35,11 @@ export interface RecipeSummaryForConnectors {
   description?: string;
 }
 
+/** Escape a token for safe use inside a RegExp (connector ids contain `-`). */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function detectConnectorsForRecipe(recipe: RecipeSummaryForConnectors): string[] {
   const haystack = `${recipe.name} ${recipe.description ?? ""}`.toLowerCase();
   const found = new Set<string>();
@@ -42,7 +47,14 @@ export function detectConnectorsForRecipe(recipe: RecipeSummaryForConnectors): s
     ...Object.keys(TOOL_NAMESPACE_TO_CONNECTOR),
     ...KNOWN_CONNECTOR_IDS,
   ]) {
-    if (haystack.includes(ns.toLowerCase())) {
+    // Whole-token match, NOT substring. A naive `includes()` made the
+    // two-letter alias `es` (elasticsearch) match the letters "es" inside
+    // ordinary English — "does", "files", "causes" — so 63 of 73 installed
+    // recipes falsely reported "needs Elasticsearch connected before it can
+    // run". A false required-connector is worse than a missed one: it blocks
+    // a working recipe behind a setup task that does not exist.
+    const re = new RegExp(`(?:^|[^a-z0-9])${escapeRe(ns.toLowerCase())}(?:[^a-z0-9]|$)`);
+    if (re.test(haystack)) {
       const c = namespaceToConnector(ns);
       if (c) found.add(c);
     }


### PR DESCRIPTION
## The bug
`detectConnectorsForRecipe` matched connector namespaces by naive substring:

```ts
if (haystack.includes(ns.toLowerCase()))
```

The alias map contains `es: "elasticsearch"`. Two letters. So **any** recipe whose name or description contains "es" — *does*, *files*, *causes*, *assembles*, *notes* — was reported as requiring Elasticsearch.

On my live install that was **63 of 73 recipes**, each showing:

> **Needs you** — It needs Elasticsearch connected before it can run. `[Connect Elasticsearch]`

A false required-connector is worse than a missed one: it blocks a working recipe behind setup that doesn't exist, and on the recipe detail page it reads as the recipe being broken.

Found while rehearsing a demo — the recipe under demo showed a blocker banner for a connector it has no relationship to.

## The fix
Token-boundary matching, with the id regex-escaped since connector ids contain hyphens (`google-calendar`).

## Verification
Run against the live 73-recipe corpus: **63 → 0** false positives.

Genuine detection still works — 11 tests cover:
- a real `es` namespace as a whole token → still detects elasticsearch
- a full connector id in prose → still detects
- hyphenated ids (`google-calendar`) → still detects, escape is correct
- `slackness` → does **not** infer slack
- a recipe naming no connector → `[]`