### PR TITLE
chore: union-merge docs/in-flight.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,8 @@
 *.cmd text eol=crlf
 *.bat text eol=crlf
 *.ps1 text eol=crlf
+
+# docs/in-flight.md is an append-only coordination ledger: concurrent sessions
+# add adjacent entries, which git reports as a conflict on every merge (all five
+# of #1256-#1260 last session). Union merge keeps both sides' appends.
+docs/in-flight.md merge=union


### PR DESCRIPTION
One line in `.gitattributes`.

`docs/in-flight.md` is an append-only coordination ledger shared by concurrent sessions. Adjacent entries collide as a merge conflict every time — **all five of #1256–#1260 last session**, each a pure adjacent append with no semantic disagreement.

`merge=union` keeps both sides. That is safe here precisely because the file is a ledger and not code: a duplicated or out-of-order line is readable and gets pruned on the next sweep, whereas a conflict costs a manual resolution plus an ~11 min CI re-run on every merge.

Not applied to any other file — union merge on real source would silently concatenate both sides of a genuine disagreement, which is exactly the failure this repo cannot afford.

🤖 Generated with [Claude Code](https://claude.com/claude-code)