### PR TITLE
fix(recipes): stop discarding compensation identifiers; register 3 unreachable inverses

### DIFF
--- a/src/recipes/tools/__tests__/compensationIdentifiers.test.ts
+++ b/src/recipes/tools/__tests__/compensationIdentifiers.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Compensation identifiers (#1264).
+ *
+ * A write tool that discards the id its own connector returned makes the action
+ * irreversible for reasons that have nothing to do with the vendor API — the
+ * handle a later delete/cancel needs was in hand and thrown away. These are
+ * regression tests for two such cases, asserted at the tool boundary because
+ * that is where the loss happened.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const appendBlock = vi.fn();
+const sendMessage = vi.fn();
+
+vi.mock("../../../connectors/notion.js", () => ({
+  getNotionConnector: () => ({ appendBlock }),
+}));
+vi.mock("../../../connectors/telegram.js", () => ({
+  getTelegramConnector: () => ({ sendMessage }),
+}));
+
+import "../notion.js";
+import "../telegram.js";
+import { getTool } from "../../toolRegistry.js";
+import type { RunContext, StepDeps } from "../../yamlRunner.js";
+
+function ctx(params: Record<string, unknown>) {
+  return {
+    params,
+    step: {} as Record<string, unknown>,
+    ctx: {} as RunContext,
+    deps: {} as StepDeps,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("notion.appendBlock", () => {
+  it("surfaces the created block ids rather than only a count", async () => {
+    appendBlock.mockResolvedValue({
+      results: [
+        { object: "block", id: "blk_1" },
+        { object: "block", id: "blk_2" },
+      ],
+    });
+
+    const out = await getTool("notion.appendBlock")?.execute(
+      ctx({ pageId: "p1", content: "hello" }),
+    );
+    const parsed = JSON.parse(out as string);
+
+    expect(parsed.blockCount).toBe(2);
+    // Without these the append cannot be undone: Notion deletes a block by id,
+    // and a count identifies nothing.
+    expect(parsed.blockIds).toEqual(["blk_1", "blk_2"]);
+  });
+});
+
+describe("telegram.send_message", () => {
+  it("surfaces the numeric chat id, not just the message id", async () => {
+    sendMessage.mockResolvedValue({
+      message_id: 55,
+      date: 0,
+      chat: { id: -100123, type: "group" },
+      text: "hi",
+    });
+
+    const out = await getTool("telegram.send_message")?.execute(
+      // Caller passes an @username; deleteMessage needs the NUMERIC id the API
+      // resolved it to, so echoing the input back would not be enough.
+      ctx({ chat_id: "@somechannel", text: "hi" }),
+    );
+    const parsed = JSON.parse(out as string);
+
+    expect(parsed.message_id).toBe(55);
+    expect(parsed.chat_id).toBe(-100123);
+  });
+
+  it("does not invent a chat id when the API omits one", async () => {
+    sendMessage.mockResolvedValue({ message_id: 7, date: 0, text: "x" });
+
+    const out = await getTool("telegram.send_message")?.execute(
+      ctx({ chat_id: "123", text: "x" }),
+    );
+    const parsed = JSON.parse(out as string);
+
+    expect(parsed.message_id).toBe(7);
+    // Absent, not guessed from params — a wrong id is worse than a missing one.
+    expect(parsed.chat_id).toBeUndefined();
+  });
+});

--- a/src/recipes/tools/__tests__/resend.test.ts
+++ b/src/recipes/tools/__tests__/resend.test.ts
@@ -14,9 +14,10 @@ import type { RunContext } from "../../yamlRunner.js";
 const sendEmail = vi.fn();
 const listEmails = vi.fn();
 const getEmail = vi.fn();
+const cancelEmail = vi.fn();
 
 vi.mock("../../../connectors/resend.js", () => ({
-  getResendConnector: () => ({ sendEmail, listEmails, getEmail }),
+  getResendConnector: () => ({ sendEmail, listEmails, getEmail, cancelEmail }),
 }));
 
 // Trigger self-registration of the resend.* tools into the global registry.
@@ -166,5 +167,39 @@ describe("resend.get_email — execute", () => {
 
     expect(getEmail).toHaveBeenCalledWith("email_789");
     expect(result).toBe(JSON.stringify(email));
+  });
+});
+
+// ── Compensating action (#1264) ──────────────────────────────────────────────
+// Resend can cancel an email only while it is still queued/scheduled — this is
+// a pre-delivery hold, NOT a recall. Once handed to the MTA nothing can undo
+// it. The connector has implemented cancelEmail all along; no recipe could
+// reach it, so a scheduled send had no inverse.
+describe("resend.cancel_email", () => {
+  it("is registered as a write tool", () => {
+    const tool = getTool("resend.cancel_email");
+    expect(tool).toBeDefined();
+    expect(tool?.isWrite).toBe(true);
+    expect(tool?.isConnector).toBe(true);
+  });
+
+  it("calls cancelEmail(id) and returns its result", async () => {
+    cancelEmail.mockResolvedValue({ object: "email", id: "e_1" });
+    const out = await getTool("resend.cancel_email")?.execute(
+      makeCtx({ id: "e_1" }, "resend.cancel_email"),
+    );
+    expect(cancelEmail).toHaveBeenCalledWith("e_1");
+    expect(JSON.parse(out as string)).toEqual({ object: "email", id: "e_1" });
+  });
+
+  it("send_email surfaces the id a later cancel must target", async () => {
+    sendEmail.mockResolvedValue({ id: "e_2" });
+    const out = await getTool("resend.send_email")?.execute(
+      makeCtx(
+        { from: "a@b.c", to: "d@e.f", subject: "s", text: "t" },
+        "resend.send_email",
+      ),
+    );
+    expect(JSON.parse(out as string).id).toBe("e_2");
   });
 });

--- a/src/recipes/tools/__tests__/todoist.test.ts
+++ b/src/recipes/tools/__tests__/todoist.test.ts
@@ -22,6 +22,8 @@ const getTasks = vi.fn();
 const createTask = vi.fn();
 const closeTask = vi.fn();
 const getProjects = vi.fn();
+const reopenTask = vi.fn();
+const deleteTask = vi.fn();
 
 vi.mock("../../../connectors/todoist.js", () => ({
   getTodoistConnector: () => ({
@@ -29,6 +31,8 @@ vi.mock("../../../connectors/todoist.js", () => ({
     createTask,
     closeTask,
     getProjects,
+    reopenTask,
+    deleteTask,
   }),
 }));
 
@@ -222,5 +226,42 @@ describe("todoist recipe-step tools", () => {
       expect(getProjects).toHaveBeenCalledWith();
       expect(out).toBe(JSON.stringify(projects));
     });
+  });
+});
+
+// ── Compensating actions (#1264) ─────────────────────────────────────────────
+// `close_task` and `create_task` shipped without their inverses, even though
+// the connector has implemented both since day one. An action with no
+// reachable inverse is irreversible for reasons unrelated to the vendor API.
+describe("todoist compensating actions", () => {
+  it("exposes todoist.reopen_task as the inverse of close_task", async () => {
+    const tool = getTool("todoist.reopen_task");
+    expect(tool).toBeDefined();
+    expect(tool?.isWrite).toBe(true);
+    expect(tool?.isConnector).toBe(true);
+
+    reopenTask.mockResolvedValue(undefined);
+    const out = await tool?.execute(ctx({ id: "42" }));
+    expect(reopenTask).toHaveBeenCalledWith("42");
+    expect(JSON.parse(out as string)).toEqual({ ok: true, id: "42" });
+  });
+
+  it("exposes todoist.delete_task as the inverse of create_task", async () => {
+    const tool = getTool("todoist.delete_task");
+    expect(tool).toBeDefined();
+    expect(tool?.isWrite).toBe(true);
+
+    deleteTask.mockResolvedValue(undefined);
+    const out = await tool?.execute(ctx({ id: "7" }));
+    expect(deleteTask).toHaveBeenCalledWith("7");
+    expect(JSON.parse(out as string)).toEqual({ ok: true, id: "7" });
+  });
+
+  it("returns the created task id so a later delete can target it", async () => {
+    createTask.mockResolvedValue({ id: "99", content: "x" });
+    const out = await getTool("todoist.create_task")?.execute(
+      ctx({ content: "x" }),
+    );
+    expect(JSON.parse(out as string).id).toBe("99");
   });
 });

--- a/src/recipes/tools/notion.ts
+++ b/src/recipes/tools/notion.ts
@@ -290,6 +290,12 @@ registerTool({
     properties: {
       ok: { type: "boolean" },
       blockCount: { type: "number" },
+      blockIds: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Ids of the created blocks — the handle a compensating delete needs",
+      },
     },
   },
   riskDefault: "medium",
@@ -309,6 +315,13 @@ registerTool({
         typeof connector.appendBlock
       >[0]["blockType"],
     });
-    return JSON.stringify({ ok: true, blockCount: result.results.length });
+    // Surface the created block ids. Without them the append has no inverse:
+    // Notion can delete a block, but only if you know which one — and the ids
+    // are right here in the response (#1264).
+    return JSON.stringify({
+      ok: true,
+      blockCount: result.results.length,
+      blockIds: result.results.map((b) => b.id),
+    });
   }),
 });

--- a/src/recipes/tools/resend.ts
+++ b/src/recipes/tools/resend.ts
@@ -159,3 +159,41 @@ registerTool({
     return JSON.stringify(result);
   }),
 });
+
+// ============================================================================
+// resend.cancel_email — the inverse of send_email, PRE-DELIVERY ONLY
+// ============================================================================
+
+registerTool({
+  id: "resend.cancel_email",
+  namespace: "resend",
+  description:
+    "Cancel a scheduled Resend email by id. This is a pre-delivery hold, NOT a recall: it only succeeds while the email is still queued or scheduled. Once Resend has handed the message to the mail transport nothing can retract it.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Resend email id to cancel (required)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["id"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      object: { type: "string" },
+      id: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: wrapConnectorExecute(async ({ params }) => {
+    const { getResendConnector } = await import("../../connectors/resend.js");
+    const connector = getResendConnector();
+    const result = await connector.cancelEmail(params.id as string);
+    return JSON.stringify(result);
+  }),
+});

--- a/src/recipes/tools/telegram.ts
+++ b/src/recipes/tools/telegram.ts
@@ -43,6 +43,11 @@ registerTool({
     properties: {
       ok: { type: "boolean" },
       message_id: { type: "number" },
+      chat_id: {
+        type: "number",
+        description:
+          "Numeric chat id from the API — deleteMessage needs this plus message_id",
+      },
       error: { type: "string" },
     },
   },
@@ -65,7 +70,14 @@ registerTool({
             ? (params.parse_mode as "Markdown" | "MarkdownV2" | "HTML")
             : undefined,
       });
-      return JSON.stringify({ ok: true, message_id: message.message_id });
+      // `chat` as well as `message_id`: deleteMessage needs BOTH, and the
+      // caller's chat_id may be an @username while the API returns the numeric
+      // id that a later delete must use (#1264).
+      return JSON.stringify({
+        ok: true,
+        message_id: message.message_id,
+        chat_id: message.chat?.id,
+      });
     } catch (err) {
       return JSON.stringify({
         ok: false,

--- a/src/recipes/tools/todoist.ts
+++ b/src/recipes/tools/todoist.ts
@@ -208,6 +208,84 @@ registerTool({
 });
 
 // ============================================================================
+// todoist.reopen_task — the inverse of close_task
+// ============================================================================
+
+registerTool({
+  id: "todoist.reopen_task",
+  namespace: "todoist",
+  description:
+    "Reopen (un-complete) a Todoist task by id. The compensating action for todoist.close_task.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Todoist task id to reopen (required)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["id"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: wrapConnectorExecute(async ({ params }) => {
+    const { getTodoistConnector } = await import("../../connectors/todoist.js");
+    const connector = getTodoistConnector();
+    const id = params.id as string;
+    await connector.reopenTask(id);
+    return JSON.stringify({ ok: true, id });
+  }),
+});
+
+// ============================================================================
+// todoist.delete_task — the inverse of create_task
+// ============================================================================
+
+registerTool({
+  id: "todoist.delete_task",
+  namespace: "todoist",
+  description:
+    "Delete a Todoist task by id. The compensating action for todoist.create_task. Unlike close_task this is permanent — the task is not recoverable from the Todoist UI.",
+  paramsSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Todoist task id to delete (required)",
+      },
+      into: CommonSchemas.into,
+    },
+    required: ["id"],
+  },
+  outputSchema: {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      id: { type: "string" },
+    },
+  },
+  riskDefault: "medium",
+  isWrite: true,
+  isConnector: true,
+  execute: wrapConnectorExecute(async ({ params }) => {
+    const { getTodoistConnector } = await import("../../connectors/todoist.js");
+    const connector = getTodoistConnector();
+    const id = params.id as string;
+    await connector.deleteTask(id);
+    return JSON.stringify({ ok: true, id });
+  }),
+});
+
+// ============================================================================
 // todoist.list_projects
 // ============================================================================
 


### PR DESCRIPTION
Refs #1264. Each claim in that issue was **verified by reading the actual code before writing any**, and one of them turned out to be wrong (see below).

## Identifiers that were thrown away

| Tool | Returned | Problem |
|---|---|---|
| `notion.appendBlock` | `{ok, blockCount}` | `NotionBlock.id` was in the connector response and discarded. Notion deletes a block *by id*; a count identifies nothing. |
| `telegram.send_message` | `{ok, message_id}` | `deleteMessage` needs **chat and message_id**. |

Both now surface the identifier. For Telegram the chat id is taken from the **API response**, not echoed back from params — the caller may pass `@somechannel` while the API resolves it to `-100123`, and only the numeric id works for a delete. When the API omits it the field stays absent rather than being guessed; a wrong id is worse than a missing one, and there's a test for that.

## Inverses that existed but were unreachable

Implemented in the connector, never registered as a recipe tool, so no recipe could call them:

- `resend.cancel_email` — `src/connectors/resend.ts:356`
- `todoist.reopen_task` — `src/connectors/todoist.ts:384`
- `todoist.delete_task` — `src/connectors/todoist.ts:400`

`resend.cancel_email` is described in its own tool description as a **pre-delivery hold, not a recall** — it only succeeds while the mail is queued or scheduled; once Resend hands it to the transport nothing retracts it. Worth stating in the tool itself, because that's the honest shape of every reliable undo here: the clean cases (scheduled-message cancel, uncaptured-payment void, Gmail's own Undo Send) are all *holds*. Recalls either don't exist or leave residue.

`todoist.delete_task` notes in its description that it is permanent, unlike `close_task`.

## One claim in the issue was wrong

It listed `asana.updateTask({completed:false})` as unreachable. It isn't — `asana.update_task` is registered and its schema already exposes `completed` (`src/recipes/tools/asana.ts:362`). Un-completing an Asana task works today. No change made.

## Not in scope

These new tools aren't in `DOMAIN_BY_TOOL`, so they classify as `other:irreversible` for trust purposes. That's the pre-existing taxonomy gap already documented as a known limitation in `docs/worker-autonomy-policy-gate.md` — extending the domain map to connector tool ids is its own change.

## Verification

- Test-first per the Bug Fix Protocol — the new assertions fail before the change
- New `compensationIdentifiers.test.ts` covers the two discard bugs at the tool boundary, which is where the loss happened
- 360 recipe-tool tests pass; the 4 failing *suites* are the pre-existing local reds from the missing `src/ta/backtest` module (CI-excluded), unrelated
- `audit-lsp-tools` clean; typecheck 34 errors before and after, all pre-existing in unrelated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
