### PR TITLE
fix(workers): surface magnitudeBand on the decision record and in CLI help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4956,7 +4956,9 @@ if (process.argv[2] === "gate") {
         "Explain the worker-autonomy gate's most recent decision(s) for a given\n" +
         "worker × action-class, from the local Decision Record\n" +
         "(~/.patchwork/worker_gate_decisions.jsonl) — no bridge required.\n\n" +
-        '  <classKey>       e.g. "issue:compensable:high" (domain:reversibility:blastTier)\n' +
+        '  <classKey>       e.g. "issue:compensable:high" (domain:reversibility:blastTier),\n' +
+        "                   plus a magnitude band on value-bearing domains, e.g.\n" +
+        '                   "payments:irreversible:high:band<=50"\n' +
         "  --limit N        show the N most recent decisions (default 1, or 2 with --diff)\n" +
         "  --diff           compare the 2 most recent decisions and show what changed\n" +
         "  --json            emit raw JSON (for scripting)\n",

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -229,6 +229,9 @@ export async function buildWorkerAutonomyGate(
           domain: decision.domain,
           owned: decision.owned,
           blastTier: decision.blastTier,
+          ...(decision.magnitudeBand && {
+            magnitudeBand: decision.magnitudeBand,
+          }),
           reversibility: decision.reversibility,
           earnedLevel: decision.earnedLevel,
           autonomyCeiling: decision.autonomyCeiling,

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -77,12 +77,17 @@ export interface GateDecisionRecord {
   workerId: string;
   toolName: string;
   action: GateAction;
-  /** `${domain}:${reversibility}:${blastTier}` — the trust unit. */
+  /** `${domain}:${reversibility}:${blastTier}`, plus `:${magnitudeBand}` for
+   *  value-bearing domains — the trust unit. */
   classKey: string;
   domain: string;
   owned: boolean;
   /** "low" | "medium" | "high" (RiskTier, kept as string to decouple). */
   blastTier: string;
+  /** Value bucket for value-bearing domains (e.g. "band<=50"); absent
+   *  otherwise, and absent on every pre-worker-ramp-v2 record. Optional so an
+   *  older reader is unaffected. */
+  magnitudeBand?: string;
   reversibility: Reversibility;
   /** Trust earned on this class as of the decision. */
   earnedLevel: number;
@@ -231,6 +236,7 @@ export class WorkerGateDecisionLog {
       domain: input.domain,
       owned: input.owned,
       blastTier: input.blastTier,
+      ...(input.magnitudeBand && { magnitudeBand: input.magnitudeBand }),
       reversibility: input.reversibility,
       earnedLevel: input.earnedLevel,
       autonomyCeiling: input.autonomyCeiling,

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -186,3 +186,26 @@ describe("money movement rates high blast", () => {
     expect(outcomeWeight(ac, false)).toBe(12 * 3 * 1.5);
   });
 });
+
+describe("decision record legibility", () => {
+  it("names the band on the decision, not only inside the key string", () => {
+    // `gate explain` answers "why was THIS action gated". Leaving magnitude
+    // implicit in the key would make an operator parse a string to find the
+    // one fact that decided it.
+    const ac = classifyActionClass("paystack.charge_authorization", {
+      amount: 5_000_00,
+    });
+    expect(ac.magnitudeBand).toBe("band>500");
+    expect(ac.key.endsWith(":band>500")).toBe(true);
+  });
+
+  it("leaves the band absent — not undefined-valued — for non-value domains", () => {
+    const ac = classifyActionClass("gitPush");
+    expect(ac.magnitudeBand).toBeUndefined();
+    // Absent in the serialised form: "not applicable", not "we looked and
+    // found none".
+    expect(Object.hasOwn(JSON.parse(JSON.stringify(ac)), "magnitudeBand")).toBe(
+      false,
+    );
+  });
+});

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -91,6 +91,11 @@ export interface WorkerGateDecision {
   domain: string;
   owned: boolean;
   blastTier: ActionClass["blastTier"];
+  /** Coarse value bucket for value-bearing domains; absent elsewhere. Broken
+   *  out explicitly, like every other component of the class key — an operator
+   *  asking "why was THIS gated" needs the magnitude named, not left implicit
+   *  in a key string they have to parse. */
+  magnitudeBand?: ActionClass["magnitudeBand"];
   reversibility: ActionClass["reversibility"];
   /** Trust actually earned on this class (for logging / the dial). */
   earnedLevel: TrustLevel;
@@ -213,6 +218,10 @@ export function decideWorkerAction(
     domain: ac.domain,
     owned,
     blastTier: ac.blastTier,
+    // Spread-conditional: absent, not undefined, for non-value domains — an
+    // explicit `undefined` would serialise into the Decision Record as a null
+    // and read as "we looked and there was none" rather than "not applicable".
+    ...(ac.magnitudeBand && { magnitudeBand: ac.magnitudeBand }),
     reversibility: ac.reversibility,
     earnedLevel,
     autonomyCeiling: worker.autonomyCeiling,


### PR DESCRIPTION
Self-review follow-up to #1267 — two gaps I left in that change.

**1. The band was invisible on the Decision Record.** `domain`, `blastTier` and `reversibility` are all broken out as explicit fields; the magnitude band existed only inside the `classKey` string. Since `patchwork gate explain` exists to answer *"why was THIS action gated"*, leaving the deciding fact implicit means an operator has to parse a key to find it.

**2. The CLI help was stale** — still documented the class key as `domain:reversibility:blastTier` as of worker-ramp-v2.

Both additions are optional and spread-conditional, so for non-value domains the band is **absent rather than explicitly undefined**. An explicit `undefined` serialises into the JSONL record as `null`, which reads as "we looked and there was none" instead of "not applicable" — the same distinction the codebase already keeps for `actor` on pre-attribution records.

**No behaviour change.** Nothing gates differently; this only changes what the record says about a decision already made.

## Compatibility, verified

No class-key parser breaks on a 4th segment:
- `src/workers/worker.ts:178`, `src/workersHttp.ts:75`, `dashboard/src/lib/workerTrust.ts`, `dashboard/src/app/workers/page.tsx` all index `[0]`/`[1]`/`[2]`, which still resolve correctly
- prefix matching (`ac.key.startsWith(pattern + ":")`) means a manifest `owns` entry naming the unbanded class still covers every band — while the store keeps trust separated per band, which is the intended split
- older readers ignore an unknown optional field; pre-v2 records stay valid

268 worker tests + the orchestration gate suite pass; schema audit reports 0 breaking changes; typecheck unchanged at 34 pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)