### PR TITLE
feat(butler): ambient memory card in the MCP instructions block

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -16,6 +16,8 @@ import { getApprovalQueue } from "./approvalQueue.js";
 import { AutomationHooks, loadPolicy } from "./automation.js";
 import { loadOrCreateBridgeToken } from "./bridgeToken.js";
 import { repairBridgeToolsRulesIfStale } from "./bridgeToolsRules.js";
+import { ButlerFactStore } from "./butler/factStore.js";
+import { buildMemoryCard } from "./butler/memoryCard.js";
 import { ClaudeOrchestrator } from "./claudeOrchestrator.js";
 import { CommitIssueLinkLog } from "./commitIssueLinkLog.js";
 import type { Config } from "./config.js";
@@ -216,6 +218,10 @@ export class Bridge {
   private workerGateDecisionLog: WorkerGateDecisionLog | null = null;
   /** Pre-computed digest of recent decisions, refreshed on each session connect. */
   private recentTracesDigest: string[] = [];
+  /** Butler's durable memory. Read lazily so a bridge that never uses it pays
+   *  nothing, and so a corrupt store degrades to "no card" rather than
+   *  refusing to start. */
+  private butlerFactStore: ButlerFactStore | null = null;
   private httpMcpHandler: StreamableHttpHandler | null = null;
   private oauthServer: OAuthServerImpl | null = null;
   /** Incremented each time the VS Code extension (re)connects — guards stale async callbacks. */
@@ -994,6 +1000,11 @@ export class Bridge {
       lines.push(...this.recentTracesDigest);
       lines.push("");
     }
+    const memory = this.buildButlerMemoryCard();
+    if (memory.length > 0) {
+      lines.push(...memory);
+      lines.push("");
+    }
     lines.push("CONTEXT PLATFORM:");
     lines.push(
       "  Use ctx tools for issue/PR/error context — not gh or githubViewPR.",
@@ -1008,6 +1019,27 @@ export class Bridge {
     lines.push("");
     lines.push(...buildEnforcementReminder());
     return lines.join("\n");
+  }
+
+  /**
+   * Butler's memory as instruction lines. Fail-soft in both directions: an
+   * unreadable store yields no card rather than a broken handshake, and only
+   * facts at or above the originate threshold are rendered — anything Butler
+   * merely READ (email, chat, calendar) must never reach the system prompt,
+   * which is the whole OWASP ASI06 attack in one step.
+   */
+  private buildButlerMemoryCard(): string[] {
+    try {
+      this.butlerFactStore ??= new ButlerFactStore({ logger: this.logger });
+      return buildMemoryCard(this.butlerFactStore.recall(), {
+        now: Date.now(),
+      });
+    } catch (err) {
+      this.logger.warn?.(
+        `[butler-memory] card unavailable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return [];
+    }
   }
 
   private async refreshRecentTracesDigest(): Promise<void> {

--- a/src/butler/__tests__/memoryCard.test.ts
+++ b/src/butler/__tests__/memoryCard.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMemoryCard,
+  MAX_CARD_BYTES,
+  MAX_FACT_CHARS,
+} from "../memoryCard.js";
+import type { ButlerFact, ProvenanceChannel } from "../types.js";
+import { PROVENANCE_TIER } from "../types.js";
+
+const NOW = 1_000 * 86_400_000; // day 1000
+
+function fact(
+  subject: string,
+  predicate: string,
+  object: string,
+  o: { channel?: ProvenanceChannel; daysAgo?: number; seq?: number } = {},
+): ButlerFact {
+  const channel = o.channel ?? "user_chat";
+  const tier = PROVENANCE_TIER[channel];
+  const recordedAt = NOW - (o.daysAgo ?? 0) * 86_400_000;
+  return {
+    seq: o.seq ?? 1,
+    ownerId: "u1",
+    subject,
+    predicate,
+    object,
+    recordedAt,
+    validFrom: recordedAt,
+    provenance: { channel, tier, validated: false },
+    contentConfidence: 1,
+    trust: tier,
+  };
+}
+
+const opts = { now: NOW };
+
+describe("content", () => {
+  it("renders each belief with its age", () => {
+    const card = buildMemoryCard(
+      [fact("user", "diet.avoid", "shellfish", { daysAgo: 3 })],
+      opts,
+    );
+    expect(card[0]).toMatch(/WHAT YOU KNOW/);
+    expect(card[1]).toBe("  • user diet.avoid: shellfish (3d ago)");
+  });
+
+  it("says nothing at all when there is nothing to say", () => {
+    // An empty heading with no content is worse than omitting the section.
+    expect(buildMemoryCard([], opts)).toEqual([]);
+  });
+
+  it("shows age coarsely across scales", () => {
+    const f = (d: number) =>
+      buildMemoryCard([fact("u", "p", "v", { daysAgo: d })], opts)[1];
+    expect(f(0)).toMatch(/today/);
+    expect(f(1)).toMatch(/1d ago/);
+    expect(f(10)).toMatch(/10d ago/);
+    expect(f(90)).toMatch(/3mo ago/);
+    expect(f(800)).toMatch(/2y ago/);
+  });
+
+  it("renders age so a stale belief is visibly stale", () => {
+    // Agents do not self-detect staleness; the model can only weigh what it
+    // can see.
+    const card = buildMemoryCard(
+      [fact("user", "employer", "Acme", { daysAgo: 500 })],
+      opts,
+    );
+    expect(card[1]).toMatch(/16mo ago/);
+  });
+});
+
+describe("trust floor", () => {
+  it("excludes connector-derived claims by default", () => {
+    // Anything Butler READ is attacker-controlled. Putting it in the system
+    // prompt is the ASI06 attack in one step.
+    const card = buildMemoryCard(
+      [
+        fact("user", "diet.avoid", "nothing", { channel: "connector" }),
+        fact("user", "city", "Lisbon", { channel: "user_chat" }),
+      ],
+      opts,
+    );
+    expect(card.join("\n")).toContain("Lisbon");
+    expect(card.join("\n")).not.toContain("nothing");
+  });
+
+  it("excludes an agent-written claim below the originate threshold", () => {
+    const hedged = fact("user", "city", "Madrid", { channel: "recipe_agent" });
+    hedged.trust = 0.4;
+    expect(buildMemoryCard([hedged], opts)).toEqual([]);
+  });
+
+  it("emits nothing when every fact is below the floor", () => {
+    const card = buildMemoryCard(
+      [fact("user", "x", "y", { channel: "connector" })],
+      opts,
+    );
+    expect(card).toEqual([]);
+  });
+});
+
+describe("budget", () => {
+  it("stays inside the byte cap", () => {
+    const many = Array.from({ length: 200 }, (_, i) =>
+      fact(`subject.${i}`, "predicate.long.name", "a".repeat(60), { seq: i }),
+    );
+    const card = buildMemoryCard(many, opts);
+    expect(Buffer.byteLength(card.join("\n"), "utf8")).toBeLessThanOrEqual(
+      MAX_CARD_BYTES,
+    );
+  });
+
+  it("states how many it dropped rather than hiding the loss", () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      fact(`s${i}`, "p", "v", { seq: i }),
+    );
+    const card = buildMemoryCard(many, opts);
+    expect(card.join("\n")).toMatch(/\d+ more not shown/);
+  });
+
+  it("truncates a long fact instead of blowing the line budget", () => {
+    const card = buildMemoryCard([fact("user", "note", "x".repeat(500))], opts);
+    // The FACT body is capped; the "  • " prefix and " (age)" suffix are
+    // bounded additions on top of it.
+    const body = card[1]?.replace(/^ {2}• /, "").replace(/ \([^)]*\)$/, "");
+    expect(body?.length).toBeLessThanOrEqual(MAX_FACT_CHARS);
+    expect(card[1]).toMatch(/…/);
+  });
+
+  it("keeps the newest facts when the budget bites", () => {
+    const card = buildMemoryCard(
+      [
+        fact("old", "p", "v", { daysAgo: 100, seq: 1 }),
+        fact("new", "p", "v", { daysAgo: 0, seq: 2 }),
+      ],
+      { ...opts, maxFacts: 1 },
+    );
+    expect(card.join("\n")).toContain("new");
+    expect(card.join("\n")).not.toContain("old p");
+  });
+
+  it("emits nothing rather than a bare heading when the cap is tiny", () => {
+    const card = buildMemoryCard([fact("user", "city", "Lisbon")], {
+      ...opts,
+      maxBytes: 10,
+    });
+    expect(card).toEqual([]);
+  });
+});
+
+describe("instructions", () => {
+  it("tells the model not to parrot the facts back", () => {
+    const card = buildMemoryCard([fact("user", "city", "Lisbon")], opts);
+    expect(card.at(-1)).toMatch(/Do not restate/);
+  });
+});

--- a/src/butler/memoryCard.ts
+++ b/src/butler/memoryCard.ts
@@ -1,0 +1,122 @@
+/**
+ * The ambient memory card spliced into the MCP `instructions` block.
+ *
+ * Deliberately modelled on `tools/recentTracesDigest.ts` — same shape, same
+ * discipline: a hard byte cap, per-line truncation, and a bounded item count.
+ * There is no reason for a second style of budgeted context block, and one
+ * consistent one is easier to reason about when both land in the same prompt.
+ *
+ * Three things this must not do:
+ *
+ *  - Include low-trust claims. Anything Butler READ (email, chat, calendar)
+ *    sits below `ORIGINATE_THRESHOLD`; putting it here would let a stranger's
+ *    email address the model directly in its system prompt, which is the whole
+ *    OWASP ASI06 attack in one step.
+ *  - Hide its own truncation. A card that silently drops the fact that mattered
+ *    is worse than no card, so a dropped remainder is stated.
+ *  - Present a stale belief as fresh. Age is rendered, because agents do not
+ *    notice staleness on their own (arXiv 2605.06527) — the model can only
+ *    weigh what it can see.
+ */
+
+import type { ButlerFact } from "./types.js";
+import { ORIGINATE_THRESHOLD } from "./types.js";
+
+/** Matches recentTracesDigest's budget — the two share one prompt. */
+export const MAX_CARD_BYTES = 2_048;
+export const MAX_FACT_CHARS = 80;
+export const DEFAULT_MAX_FACTS = 12;
+
+const DAY = 86_400_000;
+
+/** "today" | "3d ago" | "5mo ago" — coarse on purpose; precision is noise. */
+function age(recordedAt: number, now: number): string {
+  const d = Math.floor((now - recordedAt) / DAY);
+  if (d <= 0) return "today";
+  if (d === 1) return "1d ago";
+  if (d < 30) return `${d}d ago`;
+  const mo = Math.floor(d / 30);
+  if (mo < 24) return `${mo}mo ago`;
+  return `${Math.floor(d / 365)}y ago`;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}
+
+export interface MemoryCardOpts {
+  now: number;
+  maxFacts?: number;
+  maxBytes?: number;
+  /** Floor on trust. Defaults to ORIGINATE_THRESHOLD — established beliefs
+   *  only. Lowering it puts attacker-influenceable text in the system prompt;
+   *  callers should have a specific reason. */
+  minTrust?: number;
+}
+
+/**
+ * Render resolved facts as instruction lines. Returns [] when there is nothing
+ * to say, so the caller can omit the section entirely rather than emit an empty
+ * heading.
+ */
+export function buildMemoryCard(
+  facts: readonly ButlerFact[],
+  opts: MemoryCardOpts,
+): string[] {
+  const minTrust = opts.minTrust ?? ORIGINATE_THRESHOLD;
+  const maxFacts = opts.maxFacts ?? DEFAULT_MAX_FACTS;
+  const maxBytes = opts.maxBytes ?? MAX_CARD_BYTES;
+
+  const eligible = facts
+    .filter((f) => f.trust >= minTrust)
+    // Most recently recorded first: if the budget bites, lose the oldest.
+    .slice()
+    .sort((a, b) => b.recordedAt - a.recordedAt);
+
+  if (eligible.length === 0) return [];
+
+  const shown = eligible.slice(0, maxFacts);
+  const lines = [
+    "WHAT YOU KNOW ABOUT THE USER (Butler memory):",
+    ...shown.map((f) => {
+      const body = truncate(
+        `${f.subject} ${f.predicate}: ${f.object}`,
+        MAX_FACT_CHARS,
+      );
+      return `  • ${body} (${age(f.recordedAt, opts.now)})`;
+    }),
+  ];
+
+  let dropped = eligible.length - shown.length;
+
+  // Byte budget. Pop facts from the tail — never the heading, and never the
+  // trailing notice, which is what makes the loss visible.
+  while (lines.length > 1 && byteLen(lines, dropped) > maxBytes) {
+    lines.pop();
+    dropped++;
+  }
+
+  // Everything got squeezed out: say nothing rather than emit a bare heading
+  // followed by an apology.
+  if (lines.length === 1) return [];
+
+  if (dropped > 0) {
+    lines.push(
+      `  (${dropped} more not shown — call butlerRecall for the full set)`,
+    );
+  }
+  lines.push(
+    "  Use these unless the user says otherwise. Do not restate them back unprompted.",
+  );
+  return lines;
+}
+
+/** Byte length including the notice line the caller may still append. */
+function byteLen(lines: string[], dropped: number): number {
+  const extra =
+    dropped > 0
+      ? `  (${dropped} more not shown — call butlerRecall for the full set)\n`
+          .length
+      : 0;
+  return Buffer.byteLength(lines.join("\n"), "utf8") + extra;
+}


### PR DESCRIPTION
Phase 2a of [the walking skeleton](docs/plans/butler-walking-skeleton-2026-08-05.md). #1271 stored facts; nothing read them. This makes them **ambient** — every connecting session sees what Butler knows, alongside the existing recent-traces digest.

Modelled on `tools/recentTracesDigest.ts` deliberately: same 2 KB cap, same per-line truncation, same bounded item count. Two budgeted context blocks landing in the same prompt should not have two different styles.

## Three properties the tests pin

**Only established beliefs reach the prompt.** The card filters at `ORIGINATE_THRESHOLD`, so anything Butler merely *read* — email, chat, calendar, trust 0.3 — can never appear. Rendering it there would let a stranger's email address the model directly in its system prompt, which is the entire OWASP ASI06 attack in one step. This is the single most important line in the file.

**Truncation is visible.** Dropped facts are counted in the card itself (`(3 more not shown — call butlerRecall…)`). A card that silently loses the fact that mattered is worse than no card. If the budget squeezes everything out it emits nothing rather than a bare heading followed by an apology.

**Age is rendered.** Agents don't self-detect staleness (arXiv 2605.06527). A 16-month-old employer is only weighable if the model can see how old it is.

## Fail-soft, both directions

An unreadable store yields no card rather than a broken handshake. The store is constructed lazily, so a bridge that never uses Butler pays nothing.

## Notes for review

- The trailing instruction (`Do not restate them back unprompted`) is there because the failure mode of ambient memory is a model that opens every reply by reciting what it knows about you.
- Ordering is most-recently-recorded first, so when the budget bites it's the oldest that goes.
- Two of my own test expectations were wrong on first run (500 days renders as `16mo`, not `1y`; the line-length cap applies to the fact body, not the rendered line). Corrected the tests, not the code — the behaviour was right.

13 new tests, 50 in `src/butler/` total; bridge suite green; audit gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)