### PR TITLE
fix(butler): make the trust tiers mean what the docstrings claim

### DIFF
--- a/src/butler/__tests__/factStore.test.ts
+++ b/src/butler/__tests__/factStore.test.ts
@@ -86,7 +86,8 @@ describe("provenance and trust", () => {
       channel: "recipe_agent",
       contentConfidence: 0.4,
     });
-    expect(f.provenance.tier).toBe(0.6);
+    // 0.5 — strictly below ORIGINATE_THRESHOLD so an agent cannot originate.
+    expect(f.provenance.tier).toBe(0.5);
     expect(f.trust).toBeCloseTo(0.4);
   });
 

--- a/src/butler/__tests__/thresholds.test.ts
+++ b/src/butler/__tests__/thresholds.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The trust tiers make a specific safety claim: an agent may REINFORCE a
+ * belief the user has stated, but may not ORIGINATE one on its own. That claim
+ * is only true if the agent tier sits strictly below the originate threshold.
+ *
+ * It did not. `recipe_agent` was 0.6, `ORIGINATE_THRESHOLD` was 0.6, and both
+ * gates compare with `>=` — so an agent whose context was a just-read email
+ * could seed a brand-new belief that rendered into every later session's
+ * system prompt. The docstring asserting otherwise shipped in the same commit.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildMemoryCard } from "../memoryCard.js";
+import type { ButlerFact } from "../types.js";
+import { ORIGINATE_THRESHOLD, PROVENANCE_TIER } from "../types.js";
+
+const NOW = 1_000 * 86_400_000;
+
+function factAt(trust: number): ButlerFact {
+  return {
+    seq: 1,
+    ownerId: null,
+    subject: "user",
+    predicate: "diet.avoid",
+    object: "nothing at all",
+    recordedAt: NOW,
+    validFrom: NOW,
+    provenance: { channel: "recipe_agent", tier: trust, validated: false },
+    contentConfidence: 1,
+    trust,
+  };
+}
+
+describe("only the user can originate a belief", () => {
+  it("puts the agent tier strictly below the originate threshold", () => {
+    expect(PROVENANCE_TIER.recipe_agent).toBeLessThan(ORIGINATE_THRESHOLD);
+  });
+
+  it("keeps connector text below it too, by a wider margin", () => {
+    expect(PROVENANCE_TIER.connector).toBeLessThan(
+      PROVENANCE_TIER.recipe_agent,
+    );
+  });
+
+  it("lets the user tiers clear it", () => {
+    expect(PROVENANCE_TIER.user_chat).toBeGreaterThanOrEqual(
+      ORIGINATE_THRESHOLD,
+    );
+    expect(PROVENANCE_TIER.user_confirmed).toBeGreaterThanOrEqual(
+      ORIGINATE_THRESHOLD,
+    );
+  });
+
+  it("keeps an agent-written fact out of the system prompt", () => {
+    // The end-to-end consequence: an agent that has just read a poisoned
+    // email cannot put words in the next session's instructions block.
+    const card = buildMemoryCard([factAt(PROVENANCE_TIER.recipe_agent)], {
+      now: NOW,
+    });
+    expect(card).toEqual([]);
+  });
+});

--- a/src/butler/factStore.ts
+++ b/src/butler/factStore.ts
@@ -70,17 +70,28 @@ export class ButlerFactStore {
   private readonly file: string;
   private readonly dir: string;
   private readonly now: () => number;
+  /**
+   * Never undefined. The torn-row and malformed-row warnings are the store's
+   * ONLY signal that a durable belief failed to load, and a caller that simply
+   * forgot the option turned them into silent no-ops — which is how
+   * `src/tools/index.ts` shipped with them disabled. Defaulting here fixes
+   * every present and future call site instead of one.
+   */
+  private readonly logger: { warn?: (msg: string) => void };
   /** ADR-0007 tail-on-read watermark. */
   private lastReadOffset = 0;
 
-  constructor(private readonly opts: FactStoreOptions = {}) {
+  constructor(opts: FactStoreOptions = {}) {
     this.dir = opts.dir ?? patchworkPath("butler");
     this.file = path.join(this.dir, "facts.jsonl");
     this.now = opts.now ?? Date.now;
+    this.logger = opts.logger ?? {
+      warn: (msg: string) => console.warn(msg),
+    };
     try {
       mkdirSync(this.dir, { recursive: true, mode: 0o700 });
     } catch (err) {
-      opts.logger?.warn?.(
+      this.logger.warn?.(
         `[butler-facts] could not create ${this.dir}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
@@ -239,7 +250,7 @@ export class ButlerFactStore {
       const buf = readFileSync(this.file);
       raw = buf.subarray(this.lastReadOffset).toString("utf8");
     } catch (err) {
-      this.opts.logger?.warn?.(
+      this.logger.warn?.(
         `[butler-facts] could not read ${this.file}: ${err instanceof Error ? err.message : String(err)}`,
       );
       return;
@@ -253,7 +264,7 @@ export class ButlerFactStore {
       } catch {
         // A torn row is skipped, not fatal — but say so. Silence here would
         // make a lost belief indistinguishable from one never recorded.
-        this.opts.logger?.warn?.(
+        this.logger.warn?.(
           "[butler-facts] skipped an unparseable row — a belief may be missing",
         );
         continue;
@@ -265,7 +276,7 @@ export class ButlerFactStore {
         typeof f?.predicate !== "string" ||
         typeof f?.trust !== "number"
       ) {
-        this.opts.logger?.warn?.("[butler-facts] skipped a malformed row");
+        this.logger.warn?.("[butler-facts] skipped a malformed row");
         continue;
       }
       this.facts.push(f);

--- a/src/butler/types.ts
+++ b/src/butler/types.ts
@@ -48,17 +48,29 @@ export type ProvenanceChannel =
 export const PROVENANCE_TIER: Record<ProvenanceChannel, number> = {
   user_chat: 1.0,
   user_confirmed: 1.0,
-  recipe_agent: 0.6, // may reinforce an existing belief, may not originate one
+  // STRICTLY below ORIGINATE_THRESHOLD, and that is the whole claim: an agent
+  // whose context is a just-read email must not be able to seed a new belief.
+  // These were equal (0.6 and 0.6) with both gates comparing `>=`, so the
+  // docstring's "may not originate" was false for the first day it existed.
+  recipe_agent: 0.5,
   connector: 0.3, // may never, on its own, establish anything
   import: 0.3, // never upgraded on the way in
 };
 
-/** Minimum trust to establish a NEW belief that nothing else asserts. */
+/**
+ * Minimum trust to establish a NEW belief that nothing else asserts. Compared
+ * with `>=`, so any channel intended to be unable to originate must sit
+ * STRICTLY below this.
+ */
 export const ORIGINATE_THRESHOLD = 0.6;
 
-/** Minimum trust to write a standing instruction ("always CC my accountant").
- *  Only the user. A connector proposing one is the archetypal ASI06 attack. */
-export const STANDING_THRESHOLD = 1.0;
+// A STANDING_THRESHOLD constant lived here, documented as "only the user may
+// write a standing instruction". Nothing read it: there is no standing-
+// instruction store yet (deferred — see docs/plans/butler-walking-skeleton-
+// 2026-08-05.md). A documented control that no code enforces is worse than an
+// absent one, because a reader budgets for protection that is not there. It is
+// deleted rather than kept aspirationally; reinstate it in the commit that
+// actually enforces it.
 
 export interface FactProvenance {
   channel: ProvenanceChannel;

--- a/src/tools/butlerMemory.ts
+++ b/src/tools/butlerMemory.ts
@@ -28,7 +28,7 @@ export function createButlerRememberTool(store: ButlerFactStore) {
     schema: {
       name: "butlerRemember",
       description:
-        "Record one durable fact about the user (preference, household, standing context) as subject + predicate + value. Written at agent trust, below the belief threshold: it is stored and auditable but does not become something Butler asserts.",
+        "Record one durable fact about the user (preference, household, standing context) as subject + predicate + value. Stored at agent trust: auditable, but not something Butler asserts on its own.",
       annotations: { readOnlyHint: false, destructiveHint: false },
       inputSchema: {
         type: "object" as const,

--- a/src/tools/butlerMemory.ts
+++ b/src/tools/butlerMemory.ts
@@ -6,12 +6,21 @@ import { error, requireString, successStructured } from "./utils.js";
  * Butler's durable memory, exposed to agents.
  *
  * The write tool deliberately does NOT take a provenance channel. An agent
- * asking to remember something is, by definition, `recipe_agent` (tier 0.6) —
- * it may reinforce a belief but never originate a high-stakes one, and it can
- * never write at user tier. Letting the caller name its own trust level would
- * hand the pen to whatever text the agent just read, which is the OWASP ASI06
- * failure mode this store exists to resist. Promotion to user tier happens only
- * through a human act, outside this surface.
+ * asking to remember something is, by definition, `recipe_agent` — tier 0.5,
+ * STRICTLY below ORIGINATE_THRESHOLD. Letting the caller name its own trust
+ * level would hand the pen to whatever text the agent just read, which is the
+ * OWASP ASI06 failure mode this store exists to resist.
+ *
+ * What that tier actually buys, stated precisely because an earlier version of
+ * this comment overstated it: a fact written here is DURABLY RECORDED and
+ * readable via `butlerRecall({minTrust: 0})`, but it does not become a belief
+ * on its own — it is filtered out of `resolveFacts` at the originate floor and
+ * never reaches the memory card, so it cannot address the model in a later
+ * session's system prompt. It is a proposal with a receipt, not a fact.
+ *
+ * Promotion to user tier happens only through a human act, outside this
+ * surface. There is no reinforcement mechanism yet: two agent-tier rows about
+ * the same subject do not combine into something that clears the floor.
  */
 
 export function createButlerRememberTool(store: ButlerFactStore) {
@@ -19,7 +28,7 @@ export function createButlerRememberTool(store: ButlerFactStore) {
     schema: {
       name: "butlerRemember",
       description:
-        "Record one durable fact about the user (preference, household, standing context) as subject + predicate + value. Written at agent trust: it can reinforce what the user said, never override it.",
+        "Record one durable fact about the user (preference, household, standing context) as subject + predicate + value. Written at agent trust, below the belief threshold: it is stored and auditable but does not become something Butler asserts.",
       annotations: { readOnlyHint: false, destructiveHint: false },
       inputSchema: {
         type: "object" as const,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -455,6 +455,9 @@ export function registerAllTools(
   // directory through patchworkPath() so PATCHWORK_HOME is honoured (#1265) —
   // a belief store that lands in a different root than the rest of the install
   // is the exact split-installation failure that issue is about.
+  // No logger passed: ButlerFactStore defaults to console.warn. That default
+  // exists because a missing logger here silently disabled the store's only
+  // signal that a belief went missing.
   const butlerFactStore = new ButlerFactStore();
 
   const workspace = config.workspace;


### PR DESCRIPTION
Three controls were **documented but not implemented**. Found by adversarial review, each confirmed before changing code.

## 1. An agent could originate a belief

`PROVENANCE_TIER.recipe_agent` was **0.6**, `ORIGINATE_THRESHOLD` was **0.6**, and both gates compare with `>=`. The "may reinforce, may not originate" claim was false from the day it was written — an agent whose context was a just-read email could seed a brand-new belief that rendered into every later session's system prompt.

Agent tier is now 0.5. The test pins the **ordering**, not the literal, so a future tweak can't silently re-close the gap.

## 2. `STANDING_THRESHOLD` was enforced by nothing

Documented as "only the user may write a standing instruction", read by no code, and there's no standing-instruction store to enforce it against (deferred by the plan). **Deleted.** A documented control that nothing reads is worse than an absent one — a reader budgets for protection that isn't there. Reinstate it in the commit that enforces it.

## 3. The tools-path store had its warnings disabled

`src/tools/index.ts` constructed `ButlerFactStore` with no logger, so the torn-row and malformed-row warnings — the store's *only* signal that a durable belief failed to load — were silent no-ops. For a store whose headline property is "never loses a belief quietly", that's the exact failure it was built to prevent.

Fixed by **defaulting the logger inside the store** rather than patching the one call site, so every present and future caller is covered. The bridge still injects its own.

## Docstring corrected too

`butlerRemember`'s comment overstated what the agent tier buys. It now says what's true: an agent-written fact is durably recorded and readable at `minTrust: 0`, but is filtered out at the originate floor and never reaches the memory card. **A proposal with a receipt, not a fact.** And there is no reinforcement mechanism yet — two agent-tier rows don't combine into something that clears the floor, which the old wording implied.

54 tests in `src/butler/`, 1842 across the tools suite; typecheck unchanged at 34 pre-existing.

## Still open from the review

- `src/tools/butlerMemory.ts` still has **zero tests** — 251 lines, three MCP tools
- cross-process `seq` collision + the tail watermark clobber (the more serious remaining pair)
- the inert `!=` guard in `butler-errand.yaml`
- `asana.create_task` classified compensable with no inverse

🤖 Generated with [Claude Code](https://claude.com/claude-code)