### PR TITLE
fix(ci): the CVE gate audited one of four lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,21 @@ jobs:
       # enough — the local ide-refactor sat on the pre-refactorAnalyze version.
       - name: Audit skill parity (gating)
         run: node scripts/audit-skill-parity.mjs
-      # Supply chain. Scoped to PRODUCTION dependencies — that is what ships to
-      # a consumer of the npm package, and it is green today. Dev-tooling
-      # advisories (vitest → vite → postcss → nanoid at time of writing) are
-      # real but not in the shipped artifact, and gating on them would make
-      # this red on somebody else's release schedule.
+      # Supply chain. Scoped to PRODUCTION dependencies at high/critical —
+      # that is what ships, and dev-tooling advisories would make this job red
+      # on somebody else's release schedule.
+      #
+      # This step used to be a bare root-only `npm audit`. The root is one of
+      # four tracked lockfiles, and the other three all ship too: the dashboard
+      # and the relay are deployed, the extension is packaged into a .vsix. A
+      # high-severity advisory sat open in the dashboard's PRODUCTION tree
+      # while this job reported green. The script discovers lockfiles from
+      # `git ls-files` rather than naming them, so a new workspace is covered
+      # the day it lands instead of when somebody remembers to add it.
+      #
+      # Audits from the lockfile — no per-workspace `npm ci` required.
       - name: Audit production dependencies for known CVEs (gating)
-        run: npm audit --omit=dev --audit-level=high
+        run: node scripts/audit-production-cves.mjs
 
   plugin-validate:
     name: Validate plugin manifest

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -6839,9 +6839,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/scripts/audit-production-cves-allowlist.json
+++ b/scripts/audit-production-cves-allowlist.json
@@ -1,0 +1,10 @@
+{
+  "_readme": [
+    "High/critical production advisories accepted for now.",
+    "Checked by scripts/audit-production-cves.mjs. Every entry needs a reason,",
+    "and the reason should say what would have to change for it to be removed.",
+    "`workspace` is the lockfile's directory ('.' for the repository root).",
+    "Unused entries are reported, not fatal, so they can be deleted."
+  ],
+  "allow": []
+}

--- a/scripts/audit-production-cves.mjs
+++ b/scripts/audit-production-cves.mjs
@@ -1,0 +1,232 @@
+/**
+ * Production-dependency CVE gate, across every workspace in the repository.
+ *
+ * Runs `npm audit --omit=dev` against each tracked `package-lock.json` and
+ * fails on any advisory of `high` severity or above.
+ *
+ * ## Why this exists now
+ *
+ * The gate this replaces was a single `npm audit --omit=dev --audit-level=high`
+ * step in `ci.yml`, run from the repository root. The root is one of FOUR
+ * tracked lockfiles. `dashboard/`, `services/push-relay/` and
+ * `vscode-extension/` were never audited by CI at all, and each one ships:
+ * the dashboard is deployed, the relay is deployed, the extension is packaged
+ * into a `.vsix` a user installs.
+ *
+ * That gap was not theoretical. GHSA-2v37-7h3g-55p8 (`nanoid`, high, reached
+ * through `next` → `postcss`) sat open in the dashboard's PRODUCTION tree
+ * while the root-only gate reported green. Worse, the step's own comment cited
+ * "vitest → vite → postcss → nanoid" as its example of a dev-only advisory
+ * that was deliberately excluded — so the comment actively argued that a
+ * nanoid finding was out of scope, while a different nanoid, on a production
+ * path, in a workspace nobody was looking at, was in scope and unreported.
+ *
+ * ## Why discovery rather than a list of four paths
+ *
+ * A hardcoded list is a rule that depends on somebody remembering to extend it
+ * when a workspace is added — which is the failure mode that produced the gap
+ * in the first place. Lockfiles are discovered from `git ls-files`, so a new
+ * workspace is covered the day its lockfile lands.
+ *
+ * ## Scope of the check — deliberately unchanged from the gate it replaces
+ *
+ *   - PRODUCTION dependencies only (`--omit=dev`). Dev-tooling advisories are
+ *     real but are not in any shipped artifact, and gating on them makes this
+ *     job red on somebody else's release schedule.
+ *   - `high` and `critical` only. Moderate and low are reported for visibility
+ *     and do not fail the build.
+ *
+ * This script widens the gate's COVERAGE. It does not lower its threshold.
+ *
+ * Usage:  node scripts/audit-production-cves.mjs
+ * Exit:   0 clean · 1 unallowlisted high/critical advisory · 2 script error
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+/** Severities that fail the build. Everything else is reported only. */
+const FAILING = new Set(["high", "critical"]);
+
+function trackedLockfiles() {
+  return execFileSync("git", ["ls-files", "*package-lock.json"], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  })
+    .split("\n")
+    .filter(Boolean)
+    .map((f) => path.dirname(f)) // "dashboard/package-lock.json" → "dashboard"
+    .sort();
+}
+
+/** Advisories accepted for now. Every entry needs a reason. */
+function loadAllowlist() {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(
+        path.join(root, "scripts/audit-production-cves-allowlist.json"),
+        "utf8",
+      ),
+    );
+    if (!Array.isArray(parsed.allow))
+      throw new Error("`allow` must be an array");
+    return parsed.allow;
+  } catch (err) {
+    if (err.code === "ENOENT") return [];
+    console.error(`[prod-cves] allowlist unreadable: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+/**
+ * Run `npm audit --omit=dev --json` in one workspace.
+ *
+ * npm exits non-zero whenever it finds anything at or above `--audit-level`,
+ * so the exit code cannot distinguish "vulnerabilities found" from "npm could
+ * not run". The report is parsed from stdout instead, and an unparseable
+ * stdout is what counts as a script error — otherwise a network failure would
+ * read as a clean audit, which is the one way a supply-chain gate must never
+ * fail.
+ */
+function auditWorkspace(dir) {
+  let stdout;
+  try {
+    stdout = execFileSync("npm", ["audit", "--omit=dev", "--json"], {
+      cwd: path.join(root, dir),
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // Non-zero exit is expected when advisories exist; the report is still on
+    // stdout. Only a missing/empty stdout is a real failure.
+    stdout = err.stdout;
+    if (!stdout) {
+      console.error(
+        `[prod-cves] ${dir}: npm audit produced no report — ${err.message}`,
+      );
+      process.exit(2);
+    }
+  }
+
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch {
+    console.error(`[prod-cves] ${dir}: npm audit output was not JSON`);
+    process.exit(2);
+  }
+
+  const found = [];
+  for (const [name, v] of Object.entries(report.vulnerabilities ?? {})) {
+    // `via` mixes advisory objects with plain strings (transitive parents);
+    // only the objects carry an identifier.
+    const advisories = (v.via ?? []).filter(
+      (entry) => typeof entry === "object" && entry !== null,
+    );
+    const ids = advisories
+      .map((a) => ghsaFrom(a.url) ?? String(a.source ?? ""))
+      .filter(Boolean);
+    found.push({
+      workspace: dir,
+      name,
+      severity: v.severity,
+      ids: [...new Set(ids)],
+      title: advisories[0]?.title ?? "",
+    });
+  }
+  return found;
+}
+
+/** "https://github.com/advisories/GHSA-xxxx-…" → "GHSA-xxxx-…" */
+function ghsaFrom(url) {
+  const m = /\/advisories\/(GHSA-[\w-]+)/.exec(url ?? "");
+  return m ? m[1] : null;
+}
+
+function main() {
+  const workspaces = trackedLockfiles();
+  if (workspaces.length === 0) {
+    console.error("[prod-cves] no tracked package-lock.json found");
+    process.exit(2);
+  }
+
+  const allow = loadAllowlist();
+  const used = new Set();
+  const isAllowed = (finding) =>
+    allow.some((a, i) => {
+      const hit =
+        a.workspace === finding.workspace && finding.ids.includes(a.advisory);
+      if (hit) used.add(i);
+      return hit;
+    });
+
+  const failing = [];
+  const reported = [];
+
+  for (const dir of workspaces) {
+    for (const finding of auditWorkspace(dir)) {
+      if (!FAILING.has(finding.severity)) {
+        reported.push(finding);
+        continue;
+      }
+      if (isAllowed(finding)) {
+        reported.push({ ...finding, allowlisted: true });
+        continue;
+      }
+      failing.push(finding);
+    }
+  }
+
+  console.log(
+    `[prod-cves] ${workspaces.length} workspace(s) audited (production deps only): ` +
+      workspaces.map((w) => (w === "." ? "<root>" : w)).join(", "),
+  );
+
+  for (const r of reported) {
+    const tag = r.allowlisted ? "allowlisted" : "below threshold";
+    console.log(
+      `[prod-cves]   ${r.workspace}: ${r.name} (${r.severity}, ${tag})`,
+    );
+  }
+
+  // Unused entries are reported, not fatal, so they can be deleted — an
+  // allowlist that outlives its advisory is how a gate quietly stops gating.
+  allow.forEach((a, i) => {
+    if (!used.has(i))
+      console.log(
+        `[prod-cves]   stale allowlist entry: ${a.workspace} / ${a.advisory} — no longer reported, delete it`,
+      );
+  });
+
+  if (failing.length === 0) {
+    console.log("[prod-cves] OK — no high or critical production advisories.");
+    process.exit(0);
+  }
+
+  console.error(
+    `\n[prod-cves] FAIL — ${failing.length} high/critical production advisory(ies):\n`,
+  );
+  for (const f of failing) {
+    console.error(
+      `  ${f.workspace === "." ? "<root>" : f.workspace}: ${f.name} — ${f.severity}` +
+        `${f.ids.length ? ` (${f.ids.join(", ")})` : ""}` +
+        `${f.title ? `\n    ${f.title}` : ""}`,
+    );
+  }
+  console.error(
+    "\nFix with `npm audit fix` in the named workspace. If the advisory cannot\n" +
+      "be fixed yet, add it to scripts/audit-production-cves-allowlist.json\n" +
+      "with a reason — an unexplained exception is indistinguishable from an\n" +
+      "oversight the next time somebody reads this.\n",
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## What

The production-dependency CVE gate ran a bare `npm audit --omit=dev --audit-level=high` from the repository root. The root is **one of four** tracked lockfiles, and the other three all ship — the dashboard and the push relay are deployed, the extension is packaged into a `.vsix`. None of them were ever audited by CI.

The gap was not theoretical. `GHSA-2v37-7h3g-55p8` (nanoid, high, reached through `next` → `postcss`) was open in the dashboard's **production** tree while the job reported green.

The step's own comment made it worse: it cited "vitest → vite → postcss → nanoid" as its example of a dev-only advisory deliberately excluded — so the comment argued a nanoid finding was out of scope, while a *different* nanoid, on a production path, in a workspace nobody was looking at, was in scope and unreported.

## How

`scripts/audit-production-cves.mjs` **discovers** lockfiles from `git ls-files` instead of naming them. A hardcoded list of four paths is a rule that depends on somebody remembering to extend it — which is the failure mode that produced this gap. Audits from the lockfile, so the job needs no per-workspace `npm ci`.

**Scope is unchanged on purpose:** production dependencies only, high/critical only. This widens the gate's *coverage*, not its threshold. Lower severities print for visibility without failing. Exceptions go in the sibling allowlist with a reason, and stale entries are reported so an allowlist cannot quietly outlive its advisory.

Also bumps the advisory this now catches: `dashboard` nanoid 3.3.16 → 3.3.18. Lockfile-only, `package.json` untouched.

## Verified by making it fail

| Condition | Expected | Result |
|---|---|---|
| Vulnerable lockfile restored | fail, naming the workspace | exit 1, `dashboard: nanoid — high (GHSA-2v37-7h3g-55p8)` |
| Same lockfile, advisory allowlisted | pass, report the stale entry | exit 0, both behaviours correct |
| A **new** tracked workspace with a vulnerable lockfile, script unchanged | discovered and failed | exit 1, 5 workspaces audited — proves the discovery claim |
| Probe removed, dashboard fixed | pass | exit 0 |

Also confirmed `npm audit` detects the advisory with **no `node_modules` present**, since the `lsp-audit` job installs only the root — all three sibling workspaces have `node_modules` locally, so a passing local run would not have caught that.

## Out of scope

- Enabling Dependabot security updates / adding `.github/dependabot.yml`. `GET /automated-security-fixes` returns 404, which normally means disabled and would explain why no PR was auto-opened for this alert — but that endpoint also 404s on an under-scoped token, so this needs an owner to check Settings rather than a guess here.
- Lowering `--audit-level` or including dev dependencies — the existing scoping decision stands.
- Code scanning alert #139 (`js/stack-trace-exposure` in `src/butlerRoutes.ts`). Real, and a regression of the class `src/httpErrorResponse.ts` was built to close, but the fix needs a store-side tagged validation error rather than a CI change. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)