### PR TITLE
docs: retire the demo bridge instance section

### DIFF
--- a/docs/ip-allowlist.md
+++ b/docs/ip-allowlist.md
@@ -76,28 +76,6 @@ iptables -A INPUT -p tcp --dport 9000 -j DROP
 
 ---
 
-## Anthropic QA / test account access
-
-For the claude.ai plugin submission, Anthropic's QA team needs a stable demo instance. The demo bridge at `brushed-burt-swatheable.ngrok-free.app` is configured as follows:
-
-| Setting | Value |
-|---|---|
-| Endpoint | `https://brushed-burt-swatheable.ngrok-free.app` |
-| Auth | Fixed bearer token (share privately with Anthropic) |
-| OAuth issuer | `https://brushed-burt-swatheable.ngrok-free.app` |
-| Workspace | Read-only demo workspace (no write tools enabled on demo) |
-| Uptime | Managed via tmux session `bridge` on the VPS |
-
-To start/restart the demo instance:
-```bash
-# On the VPS
-tmux attach -t bridge
-# Ctrl-C to stop, then:
-npm run remote
-```
-
----
-
 ## Environment variables
 
 | Variable | Description |


### PR DESCRIPTION
## What

The plugin-submission demo instance is being wound down. This removes the section documenting it — its tunnel hostname (which doubled as the OAuth issuer), its auth model, and the restart procedure.

## Severity, stated accurately

The endpoint was named in a public repository, and the section documented the auth design as a fixed bearer token with no rotation.

**The token value was not published.** The row read "share privately with Anthropic", and a scan for token-shaped strings (`[a-f0-9]{32}`, `Bearer <…>`, `token=<…>`) matched nothing. So this was disclosure of an endpoint's *location and auth design*, not of a credential.

Recording that explicitly because an earlier assessment in this cleanup overstated it as a published credential requiring immediate rotation. It was not, and anyone reading this history later should not inherit the error.

## Why remove it even though the host is probably already gone

Of the two candidate hosts, one (`185.220.204.65`) is confirmed cancelled and answers on no port; the other presents a changed SSH host key and was deliberately not connected to. The published address most likely resolves to nothing already.

Removed regardless: documentation describing live infrastructure becomes wrong the moment that stops being true, and this section had no way of saying so. It read as current for as long as it existed.

## Kept

All the generic self-hosting guidance — ngrok setup, IP allowlisting, TLS termination, the security checklist. That content is genuinely useful and is what the document is for. It uses `YOUR-SUBDOMAIN.ngrok-free.app` placeholders, matching the convention the repo follows for real hosts.

## Verification

- No occurrence of the real hostname remains anywhere in the working tree (the two `ngrok-free.app` references left are placeholders)
- `audit-doc-links.mjs` passes — the section's removal broke no links
- `audit-business-content.mjs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)