### PR TITLE
fix(deploy): deploy scripts aimed credentials at a hardcoded address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
       # enough — the local ide-refactor sat on the pre-refactorAnalyze version.
       - name: Audit skill parity (gating)
         run: node scripts/audit-skill-parity.mjs
+      # Two deploy scripts hardcoded `root@<ip>` for a server whose address the
+      # hosting provider later reassigned to an unrelated customer, while one of
+      # them passes the bridge token and dashboard password to whatever host it
+      # names. Five files carried stale real addresses and all were found by
+      # accident, months later. Nothing was going to report it.
+      - name: Audit real IP literals (gating)
+        run: node scripts/audit-real-ips.mjs
       # Supply chain. Scoped to PRODUCTION dependencies at high/critical —
       # that is what ships, and dev-tooling advisories would make this job red
       # on somebody else's release schedule.

--- a/deploy/deploy-dashboard.sh
+++ b/deploy/deploy-dashboard.sh
@@ -3,12 +3,43 @@
 # Run from Mac: bash deploy/deploy-dashboard.sh
 set -euo pipefail
 
-VPS="root@185.167.97.141"
-REMOTE_DIR="/opt/patchwork-dashboard"
-PM2_NAME="patchwork-dashboard"
-PORT=3200
-NGINX_CONF="/etc/nginx/sites-available/patchworkos"
-DASHBOARD_URL="https://patchworkos.com/dashboard"
+# Deployment target. REQUIRED, and deliberately without a default.
+#
+# This used to be a hardcoded `root@<ip>` pointing at one specific server.
+# That address was later reassigned by the hosting provider to an unrelated
+# customer, and the script kept pointing at it — while line ~48 passes
+# PATCHWORK_BRIDGE_TOKEN and DASHBOARD_PASSWORD to whatever host it names.
+# A deploy script that guesses its target is the bug; refusing to guess is
+# the fix. Nothing here is secret, but a wrong default aims real
+# credentials at a real stranger.
+if [ -z "${PATCHWORK_VPS:-}" ]; then
+  cat >&2 <<'ERR'
+error: PATCHWORK_VPS is not set.
+
+  Set it to the ssh destination for YOUR server, e.g.
+
+      PATCHWORK_VPS=root@203.0.113.10  bash deploy/deploy-dashboard.sh
+      PATCHWORK_VPS=deploy@example.com bash deploy/deploy-dashboard.sh
+
+  An ssh config alias works too (see deploy/macos/README.md).
+
+  There is no default on purpose: this script sends deployment
+  credentials to whatever host it is given.
+ERR
+  exit 1
+fi
+VPS="$PATCHWORK_VPS"
+
+# Site-specific settings. These defaults suit a single-site install; override
+# per deployment. They are NOT secrets — they are paths and process names.
+REMOTE_DIR="${PATCHWORK_REMOTE_DIR:-/opt/patchwork-dashboard}"
+PM2_NAME="${PATCHWORK_PM2_NAME:-patchwork-dashboard}"
+PORT="${PATCHWORK_DASHBOARD_PORT:-3200}"
+NGINX_CONF="${PATCHWORK_NGINX_CONF:-/etc/nginx/sites-available/patchwork}"
+DASHBOARD_URL="${PATCHWORK_DASHBOARD_URL:-https://your.tld/dashboard}"
+# Written into the remote .env.local. VAPID_SUBJECT must be a mailto: you own.
+BRIDGE_URL="${PATCHWORK_BRIDGE_URL:-https://your.tld}"
+VAPID_SUBJECT="${PATCHWORK_VAPID_SUBJECT:-mailto:admin@your.tld}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -45,14 +76,23 @@ echo "==> Deploying on VPS..."
 # `${PATCHWORK_BRIDGE_TOKEN:-REPLACE_ME}` inside the heredoc evaluated on
 # the remote, where the var doesn't exist, and always wrote REPLACE_ME.
 # shellcheck disable=SC2087
-ssh "$VPS" bash -s -- "${PATCHWORK_BRIDGE_TOKEN:-REPLACE_ME}" "${DASHBOARD_PASSWORD:-}" <<'REMOTE'
+ssh "$VPS" bash -s -- \
+  "${PATCHWORK_BRIDGE_TOKEN:-REPLACE_ME}" "${DASHBOARD_PASSWORD:-}" \
+  "$REMOTE_DIR" "$PM2_NAME" "$PORT" "$BRIDGE_URL" "$VAPID_SUBJECT" <<'REMOTE'
 set -euo pipefail
 # `${N:-}` so an empty/missing positional arg doesn't trip `set -u`.
+#
+# The site settings are passed in rather than repeated here. They used to be
+# declared twice — once locally and once inside this heredoc — so overriding
+# the local copy silently changed nothing on the remote side. Two sources of
+# truth for the same path is a bug waiting for someone to trust the wrong one.
 PATCHWORK_BRIDGE_TOKEN="${1:-REPLACE_ME}"
 DASHBOARD_PASSWORD="${2:-}"
-REMOTE_DIR="/opt/patchwork-dashboard"
-PM2_NAME="patchwork-dashboard"
-PORT=3200
+REMOTE_DIR="${3:-/opt/patchwork-dashboard}"
+PM2_NAME="${4:-patchwork-dashboard}"
+PORT="${5:-3200}"
+BRIDGE_URL="${6:-https://your.tld}"
+VAPID_SUBJECT="${7:-mailto:admin@your.tld}"
 
 # Stop existing PM2 process if running
 if pm2 list | grep -q "$PM2_NAME"; then
@@ -109,9 +149,9 @@ if [ -f "$REMOTE_DIR/.env.local" ]; then
 else
   cat > "$REMOTE_DIR/.env.local" <<ENV
 NEXT_PUBLIC_BASE_PATH=/dashboard
-PATCHWORK_BRIDGE_URL=https://patchworkos.com
+PATCHWORK_BRIDGE_URL=${BRIDGE_URL}
 PATCHWORK_BRIDGE_TOKEN=${PATCHWORK_BRIDGE_TOKEN:-REPLACE_ME}
-VAPID_SUBJECT=mailto:support@gigsecure.co.ke
+VAPID_SUBJECT=${VAPID_SUBJECT}
 DASHBOARD_PASSWORD=${DASHBOARD_PASSWORD:-}
 ENV
   chmod 600 "$REMOTE_DIR/.env.local"
@@ -123,32 +163,38 @@ which pm2 || npm install -g pm2
 
 # Start with PM2
 cd "$REMOTE_DIR"
-PORT=3200 pm2 start server.js --name "$PM2_NAME"
+PORT="$PORT" pm2 start server.js --name "$PM2_NAME"
 
 pm2 save
 echo "PM2 started: $PM2_NAME on port $PORT"
 REMOTE
 
 echo "==> Configuring nginx..."
-ssh "$VPS" bash <<'NGINX'
+ssh "$VPS" bash -s -- "$NGINX_CONF" "$PORT" <<'NGINX'
 set -euo pipefail
-NGINX_CONF="/etc/nginx/sites-available/patchworkos"
+# Passed in, not repeated — see the note on the REMOTE heredoc above.
+NGINX_CONF="${1:?nginx conf path not passed}"
+# The proxy_pass port MUST track the port pm2 starts the app on. These were
+# two independent literals; making the port configurable without threading it
+# here would have produced a proxy pointing at nothing.
+APP_PORT="${2:?app port not passed}"
 
 # Add SSE location block if missing
 if ! grep -q "location /dashboard/api/bridge/stream" "$NGINX_CONF"; then
   # Insert before the closing brace of the SSL server block
   # We insert just before the last `}` that closes the server block listening on 443
-  python3 - "$NGINX_CONF" <<'PYEOF'
+  python3 - "$NGINX_CONF" "$APP_PORT" <<'PYEOF'
 import sys, re
 
 path = sys.argv[1]
+port = sys.argv[2]
 with open(path) as f:
     content = f.read()
 
-sse_block = """
+sse_block = f"""
     # SSE passthrough — no buffering
-    location /dashboard/api/bridge/stream {
-        proxy_pass http://127.0.0.1:3200;
+    location /dashboard/api/bridge/stream {{
+        proxy_pass http://127.0.0.1:{port};
         proxy_http_version 1.1;
         proxy_buffering off;
         proxy_cache off;
@@ -159,18 +205,18 @@ sse_block = """
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header X-Accel-Buffering no;
-    }
+    }}
 
     # Dashboard app
-    location /dashboard {
-        proxy_pass http://127.0.0.1:3200;
+    location /dashboard {{
+        proxy_pass http://127.0.0.1:{port};
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 60s;
-    }
+    }}
 """
 
 # Find the ssl/443 server block and insert before its closing brace
@@ -195,4 +241,4 @@ NGINX
 
 echo ""
 echo "==> Deploy complete!"
-echo "    Dashboard: https://patchworkos.com/dashboard"
+echo "    Dashboard: $DASHBOARD_URL"

--- a/deploy/deploy-landing.sh
+++ b/deploy/deploy-landing.sh
@@ -3,9 +3,26 @@
 # Run from Mac: bash deploy/deploy-landing.sh
 set -euo pipefail
 
-VPS="root@185.167.97.141"
-LANDING_DIR="/var/www/patchwork-landing"
-NGINX_CONF="/etc/nginx/sites-available/patchworkos"
+# Deployment target. REQUIRED, no default — see deploy/deploy-dashboard.sh
+# for why. The address that used to sit here was reassigned by the hosting
+# provider to an unrelated customer.
+if [ -z "${PATCHWORK_VPS:-}" ]; then
+  cat >&2 <<'ERR'
+error: PATCHWORK_VPS is not set.
+
+  Set it to the ssh destination for YOUR server, e.g.
+
+      PATCHWORK_VPS=root@203.0.113.10 bash deploy/deploy-landing.sh
+
+  There is no default on purpose.
+ERR
+  exit 1
+fi
+VPS="$PATCHWORK_VPS"
+
+LANDING_DIR="${PATCHWORK_LANDING_DIR:-/var/www/patchwork-landing}"
+NGINX_CONF="${PATCHWORK_NGINX_CONF:-/etc/nginx/sites-available/patchwork}"
+LANDING_URL="${PATCHWORK_LANDING_URL:-https://your.tld}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -21,23 +38,27 @@ scp "$REPO_ROOT/landing/favicon.svg"  "$VPS:$LANDING_DIR/favicon.svg"
 scp "$REPO_ROOT/landing/manifest.json" "$VPS:$LANDING_DIR/manifest.json"
 
 echo "==> Updating nginx to serve landing page at root..."
-ssh "$VPS" bash <<'REMOTE'
+ssh "$VPS" bash -s -- "$NGINX_CONF" "$LANDING_DIR" <<'REMOTE'
 set -euo pipefail
-NGINX_CONF="/etc/nginx/sites-available/patchworkos"
+# Passed in rather than repeated: these were declared twice, so overriding
+# the local copy silently changed nothing on the remote side.
+NGINX_CONF="${1:?nginx conf path not passed}"
+LANDING_DIR="${2:?landing dir not passed}"
 
 # Insert landing page root location if not already present
 if ! grep -q "location = /" "$NGINX_CONF"; then
-  python3 - "$NGINX_CONF" <<'PYEOF'
+  python3 - "$NGINX_CONF" "$LANDING_DIR" <<'PYEOF'
 import sys, re
 
 path = sys.argv[1]
+landing = sys.argv[2]
 with open(path) as f:
     content = f.read()
 
 landing_blocks = """
     # Static landing page at root
     location = / {
-        root /var/www/patchwork-landing;
+        root __LANDING_DIR__;
         try_files /index.html =404;
     }
 
@@ -55,6 +76,8 @@ landing_blocks = """
         proxy_send_timeout 3600s;
     }
 """
+
+landing_blocks = landing_blocks.replace("__LANDING_DIR__", landing)
 
 # Insert before the SSE/dashboard blocks (before first "location /dashboard")
 # or before the last closing brace if those don't exist
@@ -80,31 +103,34 @@ fi
 # Independent idempotency block for the apex asset locations — these were
 # added after the original landing block, so existing installs miss them.
 if ! grep -q "location = /favicon.ico" "$NGINX_CONF"; then
-  python3 - "$NGINX_CONF" <<'PYEOF'
+  python3 - "$NGINX_CONF" "$LANDING_DIR" <<'PYEOF'
 import sys
 
 path = sys.argv[1]
+landing = sys.argv[2]
 with open(path) as f:
     content = f.read()
 
 asset_blocks = """
     # Apex assets — favicon + PWA manifest browsers probe at root
     location = /favicon.ico {
-        root /var/www/patchwork-landing;
+        root __LANDING_DIR__;
         try_files /favicon.ico =404;
         access_log off;
     }
     location = /favicon.svg {
-        root /var/www/patchwork-landing;
+        root __LANDING_DIR__;
         try_files /favicon.svg =404;
         access_log off;
     }
     location = /manifest.json {
-        root /var/www/patchwork-landing;
+        root __LANDING_DIR__;
         try_files /manifest.json =404;
         access_log off;
     }
 """
+
+asset_blocks = asset_blocks.replace("__LANDING_DIR__", landing)
 
 # Insert immediately after the existing `location = /` block
 marker = '    location = / {'
@@ -133,4 +159,4 @@ REMOTE
 
 echo ""
 echo "==> Deploy complete!"
-echo "    Landing page: https://patchworkos.com"
+echo "    Landing page: $LANDING_URL"

--- a/deploy/macos/README.md
+++ b/deploy/macos/README.md
@@ -34,7 +34,7 @@ self-hosted dashboard persistent on your Mac:
    ```ssh-config
    # ~/.ssh/config
    Host pw-bridge
-       HostName 185.167.97.141       # your VPS IP — stable across DNS shifts
+       HostName 203.0.113.10       # your VPS IP — stable across DNS shifts
        User wesh                      # or root, whatever your VPS allows
        IdentityFile ~/.ssh/id_ed25519
        ServerAliveInterval 30
@@ -57,11 +57,11 @@ self-hosted dashboard persistent on your Mac:
    Without an alias (interactive, prompts for VPS host):
    ```bash
    bash deploy/macos/install-mac-bridge.sh
-   # → prompts; recommend the IP (185.167.97.141) over the domain
+   # → prompts; recommend the IP (203.0.113.10) over the domain
    ```
    Or fully env-driven:
    ```bash
-   VPS_HOST=185.167.97.141 VPS_USER=root \
+   VPS_HOST=203.0.113.10 VPS_USER=root \
    BRIDGE_PORT=63906 VPS_PORT=3285 \
    bash deploy/macos/install-mac-bridge.sh
    ```

--- a/deploy/macos/install-mac-bridge.sh
+++ b/deploy/macos/install-mac-bridge.sh
@@ -7,7 +7,7 @@
 #   bash deploy/macos/install-mac-bridge.sh
 #
 # Usage (env-driven, idempotent re-install):
-#   VPS_HOST=185.167.97.141 VPS_USER=root BRIDGE_PORT=63906 \
+#   VPS_HOST=203.0.113.10 VPS_USER=root BRIDGE_PORT=63906 \
 #   VPS_PORT=3285 BRIDGE_TOKEN="$(uuidgen | tr '[:upper:]' '[:lower:]')" \
 #   bash deploy/macos/install-mac-bridge.sh
 #
@@ -20,7 +20,7 @@
 # Using a ~/.ssh/config alias (cleanest):
 #   # in ~/.ssh/config:
 #   #   Host pw-bridge
-#   #       HostName 185.167.97.141
+#   #       HostName 203.0.113.10
 #   #       User wesh
 #   #       IdentityFile ~/.ssh/id_ed25519
 #   VPS_HOST=pw-bridge VPS_USER=wesh \
@@ -103,7 +103,7 @@ VPS target — three choices, in increasing order of stability:
   (1) Public domain     e.g. bridge.your.tld
       DNS-resolved each connection. Drifts during redeploys → host-key churn.
 
-  (2) VPS IP            e.g. 185.167.97.141
+  (2) VPS IP            e.g. 203.0.113.10
       Stable per VPS. Doesn't survive a VPS rebuild but doesn't drift between.
 
   (3) ~/.ssh/config alias  e.g. pw-bridge

--- a/docs/ip-allowlist.md
+++ b/docs/ip-allowlist.md
@@ -46,7 +46,7 @@ on_http_request:
         config:
           enforce: true
           allow:
-            - 1.2.3.4/32   # Anthropic QA IP or your own client IP
+            - 203.0.113.10/32   # Anthropic QA IP or your own client IP
 ```
 
 ### Option B — direct VPS binding
@@ -61,14 +61,14 @@ claude-ide-bridge --bind 0.0.0.0 --port 9000 --fixed-token $(uuidgen)
 **UFW (Ubuntu):**
 ```bash
 # Allow only specific source IPs
-ufw allow from 1.2.3.4 to any port 9000
-ufw allow from 5.6.7.8 to any port 9000
+ufw allow from 203.0.113.10 to any port 9000
+ufw allow from 203.0.113.11 to any port 9000
 ufw deny 9000
 ```
 
 **iptables:**
 ```bash
-iptables -A INPUT -p tcp --dport 9000 -s 1.2.3.4 -j ACCEPT
+iptables -A INPUT -p tcp --dport 9000 -s 203.0.113.10 -j ACCEPT
 iptables -A INPUT -p tcp --dport 9000 -j DROP
 ```
 

--- a/docs/mobile-oversight-self-host.md
+++ b/docs/mobile-oversight-self-host.md
@@ -160,7 +160,9 @@ PATCHWORK_PUSH_TOKEN=<random uuid — must match bridge pushServiceToken>
 Deploy the dashboard to the VPS:
 
 ```bash
-PATCHWORK_BRIDGE_TOKEN="<your laptop bridge auth token>" bash deploy/deploy-dashboard.sh
+PATCHWORK_VPS="root@your.vps.ip.here" \
+  PATCHWORK_BRIDGE_TOKEN="<your laptop bridge auth token>" \
+  bash deploy/deploy-dashboard.sh
 ```
 
 The deploy script preserves `.env.local` across runs, but its default

--- a/scripts/audit-real-ips-allowlist.json
+++ b/scripts/audit-real-ips-allowlist.json
@@ -1,0 +1,26 @@
+{
+  "_readme": [
+    "Public IPv4 literals that must stay in tracked files.",
+    "Checked by scripts/audit-real-ips.mjs. Every entry needs a reason.",
+    "Prefer an environment variable, or an RFC 5737 documentation address",
+    "(192.0.2.x / 198.51.100.x / 203.0.113.x), over an entry here.",
+    "Unused entries are reported, not fatal, so they can be deleted."
+  ],
+  "allow": [
+    {
+      "file": "docs/mobile-oversight-self-host.md",
+      "ip": "1.1.1.1",
+      "reason": "Cloudflare's public DNS resolver, in a `dig @1.1.1.1` command. A documentation-range address would make the command fail \u2014 the whole point is querying a resolver that answers."
+    },
+    {
+      "file": "docs/ip-allowlist.html",
+      "ip": "160.79.104.0",
+      "reason": "Anthropic's published egress range, shown as a worked nginx allow example. A fake range would teach the wrong value. The page already says to use the live list rather than this snapshot."
+    },
+    {
+      "file": "docs/ip-allowlist.html",
+      "ip": "54.84.169.0",
+      "reason": "Second half of the same published egress range \u2014 see the entry above."
+    }
+  ]
+}

--- a/scripts/audit-real-ips.mjs
+++ b/scripts/audit-real-ips.mjs
@@ -75,6 +75,24 @@ const IPV4_RE = /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g;
 const SKIP_FILE =
   /(^|\/)(package-lock\.json|\.gitattributes)$|\.(png|jpg|jpeg|gif|svg|ico|woff2?|pdf|vsix|tgz)$|(^|\/)__tests__\/|\.(test|spec)\.[cm]?[jt]sx?$/i;
 
+/**
+ * This gate's own files.
+ *
+ * The allowlist exists to hold IP addresses, so scanning it means every
+ * accepted exception is re-reported as a violation — and this file's header
+ * quotes `8.8.8.8` while explaining why tests are excluded.
+ *
+ * Worth recording how this was found, because the local run said OK: both
+ * files were still UNTRACKED when it ran, so `git ls-files` never showed
+ * them to the scanner. The check could not have failed, which made its
+ * passing meaningless. CI caught it on the first push, once they were
+ * tracked.
+ */
+const SELF = new Set([
+  "scripts/audit-real-ips.mjs",
+  "scripts/audit-real-ips-allowlist.json",
+]);
+
 function isAllowedAddress(o) {
   const [a, b] = o;
   if (o.some((n) => n > 255)) return true; // not a valid address at all
@@ -98,7 +116,7 @@ function trackedFiles() {
   })
     .split("\n")
     .filter(Boolean)
-    .filter((f) => !SKIP_FILE.test(f));
+    .filter((f) => !SKIP_FILE.test(f) && !SELF.has(f));
 }
 
 /** Real addresses that must stay, each with a reason. */

--- a/scripts/audit-real-ips.mjs
+++ b/scripts/audit-real-ips.mjs
@@ -1,0 +1,189 @@
+/**
+ * Public-IP-literal gate for tracked files.
+ *
+ * Fails when a tracked file contains a routable IPv4 address. Reserved,
+ * private and documentation ranges are allowed, because those are what a
+ * reader is supposed to see.
+ *
+ * ## Why this exists now
+ *
+ * `deploy/deploy-dashboard.sh` and `deploy/deploy-landing.sh` each carried a
+ * hardcoded `VPS="root@<ip>"`. The hosting provider later reassigned that
+ * address to an unrelated customer. The scripts did not notice, and could
+ * not: an IP literal has no way of saying it changed hands.
+ *
+ * That mattered more than a stale value normally would, because
+ * `deploy-dashboard.sh` passes `PATCHWORK_BRIDGE_TOKEN` and
+ * `DASHBOARD_PASSWORD` to whatever host it names. The only thing standing
+ * between "run the deploy script" and "send two secrets to a stranger" was
+ * SSH's changed-host-key warning — a prompt a person can type `yes` past.
+ *
+ * Three more files carried the same address in documentation, and a fourth
+ * carried a second, since-cancelled one. All five were found by accident,
+ * four months after the address changed hands. That is the argument for a
+ * gate rather than a convention: nothing was going to report this.
+ *
+ * ## What is allowed
+ *
+ *   - RFC 5737 documentation ranges (192.0.2.x, 198.51.100.x, 203.0.113.x)
+ *     — the correct thing to write in an example
+ *   - loopback (127.x), link-local (169.254.x), and RFC 1918 private ranges
+ *     (10.x, 172.16-31.x, 192.168.x) — these describe a reader's own machine
+ *   - 0.0.0.0 and 255.255.255.255 — bind-all and broadcast, not locations
+ *   - multicast and reserved (224.x-255.x)
+ *
+ * Anything else is a real place on the internet and needs a reason.
+ *
+ * ## What this deliberately does NOT do
+ *
+ * No IPv6, and no hostnames. Both are real gaps. A hostname check would need
+ * to distinguish `example.com` from a live host, which is a judgement call a
+ * regex loses; the existing `audit-business-content.mjs` makes the same
+ * trade-off and says so. Version numbers and semver strings are excluded by
+ * requiring the match to look like an address, not a dotted quad in general.
+ *
+ * Usage:  node scripts/audit-real-ips.mjs
+ * Exit:   0 clean · 1 public IP literal found · 2 script error
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+/** Dotted quad with word boundaries. Octet range is validated separately. */
+const IPV4_RE = /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g;
+
+/**
+ * Files not worth scanning.
+ *
+ * TESTS ARE EXCLUDED, deliberately and with a cost. The SSRF and rate-limit
+ * suites assert things like `isPrivateHost("8.8.8.8") === false`, which is
+ * only meaningful with a genuinely public address — 68 of the first run's
+ * findings were exactly that, and every one was correct code. A gate whose
+ * output is mostly false positives gets switched off, and then it protects
+ * nothing.
+ *
+ * What this gives up: a real production address pasted into a test fixture
+ * would not be caught. That is a narrower risk than the one being closed —
+ * a test does not connect anywhere on deploy — but it is a real gap, not a
+ * clean exclusion.
+ */
+const SKIP_FILE =
+  /(^|\/)(package-lock\.json|\.gitattributes)$|\.(png|jpg|jpeg|gif|svg|ico|woff2?|pdf|vsix|tgz)$|(^|\/)__tests__\/|\.(test|spec)\.[cm]?[jt]sx?$/i;
+
+function isAllowedAddress(o) {
+  const [a, b] = o;
+  if (o.some((n) => n > 255)) return true; // not a valid address at all
+  if (a === 0 || a === 127 || a >= 224) return true; // this-network, loopback, multicast/reserved
+  if (a === 10) return true; // RFC 1918
+  if (a === 172 && b >= 16 && b <= 31) return true; // RFC 1918
+  if (a === 192 && b === 168) return true; // RFC 1918
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 192 && b === 0) return true; // 192.0.2.0/24 docs + 192.0.0.0/24 IETF
+  if (a === 198 && (b === 51 || b === 18 || b === 19)) return true; // docs + benchmarking
+  if (a === 203 && b === 0) return true; // 203.0.113.0/24 docs
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  return false;
+}
+
+function trackedFiles() {
+  return execFileSync("git", ["ls-files"], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  })
+    .split("\n")
+    .filter(Boolean)
+    .filter((f) => !SKIP_FILE.test(f));
+}
+
+/** Real addresses that must stay, each with a reason. */
+function loadAllowlist() {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(
+        path.join(root, "scripts/audit-real-ips-allowlist.json"),
+        "utf8",
+      ),
+    );
+    if (!Array.isArray(parsed.allow))
+      throw new Error("`allow` must be an array");
+    return parsed.allow;
+  } catch (err) {
+    if (err.code === "ENOENT") return [];
+    console.error(`[real-ips] allowlist unreadable: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+function main() {
+  const files = trackedFiles();
+  const allow = loadAllowlist();
+  const used = new Set();
+  const isAllowed = (file, ip) =>
+    allow.some((a, i) => {
+      const hit = a.file === file && a.ip === ip;
+      if (hit) used.add(i);
+      return hit;
+    });
+
+  const found = [];
+  let scanned = 0;
+
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(path.join(root, file), "utf8");
+    } catch {
+      continue; // binary or unreadable; not this gate's business
+    }
+    if (content.includes("\0")) continue;
+    scanned++;
+
+    content.split("\n").forEach((line, i) => {
+      for (const m of line.matchAll(IPV4_RE)) {
+        const octets = m.slice(1, 5).map(Number);
+        if (isAllowedAddress(octets)) continue;
+        const ip = octets.join(".");
+        if (isAllowed(file, ip)) continue;
+        found.push({ file, line: i + 1, ip, text: line.trim().slice(0, 100) });
+      }
+    });
+  }
+
+  console.log(
+    `[real-ips] scanned ${scanned} tracked text files · ${allow.length} allowlist entries`,
+  );
+
+  allow.forEach((a, i) => {
+    if (!used.has(i))
+      console.log(
+        `[real-ips]   stale allowlist entry: ${a.file} / ${a.ip} — no longer present, delete it`,
+      );
+  });
+
+  if (found.length === 0) {
+    console.log("[real-ips] OK — no public IP literals.");
+    process.exit(0);
+  }
+
+  console.error(`\n[real-ips] FAIL — ${found.length} public IP literal(s):\n`);
+  for (const f of found) {
+    console.error(`  ${f.file}:${f.line}  ${f.ip}\n    ${f.text}`);
+  }
+  console.error(
+    "\nA real address in a tracked file goes stale silently, and a hosting\n" +
+      "provider can reassign it to someone else without telling you. Use an\n" +
+      "environment variable for anything a script connects to, and an\n" +
+      "RFC 5737 documentation address (203.0.113.10) in examples.\n\n" +
+      "If an address genuinely must stay, add it to\n" +
+      "scripts/audit-real-ips-allowlist.json with a reason.\n",
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -279,7 +279,7 @@ SESSION_DISPLAY_NAME="bridge:${WS_BASENAME}"
 CLAUDE_CMD="cd $(printf '%q' "$WORKSPACE") && unset CLAUDECODE && CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS=10000 claude --ide --name $(printf '%q' "$SESSION_DISPLAY_NAME")"
 
 # --- SSH reverse tunnel command (pane 4, only when --vps is set) ---
-# Format: --vps user@host:remote_port  (e.g. root@185.220.204.65:9000)
+# Format: --vps user@host:remote_port  (e.g. root@203.0.113.10:9000)
 # The tunnel forwards remote_port on the VPS back to the local bridge port,
 # so a static MCP URL on the VPS proxies directly to the local bridge.
 TUNNEL_CMD=""


### PR DESCRIPTION
## The bug

## Target is now required, with no default

Both scripts read `PATCHWORK_VPS` and exit 1 with instructions when unset. A deploy script that guesses where to send credentials is the bug; refusing to guess is the fix.

## These scripts were never generic

They also hardcoded one operator's domain, nginx site file, pm2 name, remote directory, and a support address belonging to an unrelated project — while `docs/mobile-oversight-self-host.md` **tells self-hosters to run `deploy-dashboard.sh`**. As shipped, that would have deployed their dashboard to somebody else's server. It's now environment-driven with placeholder defaults, making the documented use true for the first time.

## Two latent bugs surfaced on the way

Both from values declared twice:

- `REMOTE_DIR` / `PM2_NAME` / `PORT` existed locally **and** inside the remote heredoc, so overriding the local copy silently changed nothing on the far side. Now passed as positional args — one source of truth.
- Making `PORT` configurable would have **broken nginx**, which hardcoded `proxy_pass http://127.0.0.1:3200` independently. Threaded through so the proxy tracks the port pm2 actually uses. Same for the landing page's four `root /var/www/…` paths.

## The gate

`scripts/audit-real-ips.mjs` fails on any routable IPv4 literal in a tracked file. Documentation (RFC 5737), private, loopback and CGNAT ranges pass — those are what a reader is meant to see.

**Tests are excluded, deliberately and at a cost.** The SSRF and rate-limit suites assert `isPrivateHost("8.8.8.8") === false`, which is only meaningful with a genuinely public address — 68 of the first run's findings were exactly that, and every one was correct code. A gate whose output is mostly false positives gets switched off. What this gives up: a real address pasted into a fixture isn't caught. Narrower risk (a test doesn't connect anywhere on deploy) but a real gap, not a clean exclusion.

Three real addresses stay, allowlisted with reasons — Cloudflare's resolver in a `dig` command that has to actually resolve, and a published egress range shown as a worked nginx example where a fake range would teach the wrong value.

## Verified by making it fail

| Check | Result |
|---|---|
| Reintroduce the exact original line | exit 1, names file, line and IP |
| Stale allowlist entry | reported, non-fatal |
| Documentation-range addresses | silent, as intended |
| Both scripts with no `PATCHWORK_VPS` | exit 1 with instructions |
| nginx f-string + placeholder substitution | renders valid output — a missed brace escape would have thrown |

All six gating audits pass; both shell syntax checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)