### PR TITLE
fix(recipes): stop the digest inventing links between entity tokens

### DIFF
--- a/examples/recipes/advanced-patterns/private-document-digest.yaml
+++ b/examples/recipes/advanced-patterns/private-document-digest.yaml
@@ -19,6 +19,23 @@
 #     LOCAL_ENDPOINT_ALLOW_REMOTE=1 — do not set that casually, it is what
 #     keeps "local" local.
 #   - Iterations run serially. 300 documents is 300 sequential local calls.
+#   - Entity tokens are PER-DOCUMENT, not global. Each document is scrubbed in
+#     its own agent call with no shared mapping, so the first person in every
+#     document becomes E1 and those E1s are different people. The digest step
+#     is told this explicitly; without that instruction it reads a column of
+#     E1s as one entity and invents a link that is not in the source. A
+#     labelling collision becomes a fabricated fact, which is worse than
+#     saying nothing.
+#   - Making tokens consistent across documents is a known technique
+#     ("consistent surrogation") and is deliberately NOT done here. It is a
+#     privacy COST, not a free improvement: a stable token across a batch is
+#     what lets someone re-identify by cross-referencing, which is why the
+#     field's guidance is to limit batch size when using it. A string-keyed
+#     registry would also only give "same string, same token" — it would not
+#     recognise an initial-plus-surname, the same person's full name, and a
+#     later pronoun as one entity. That is cross-document coreference, which
+#     is still an open problem; calling a registry "entity linking" would be
+#     the same class of overclaim as the bug above.
 apiVersion: patchwork.sh/v1
 version: 1.0.0
 name: private-document-digest
@@ -77,8 +94,13 @@ steps:
         worth reporting.
 
         Write a digest: the themes that recur, what changed over the period,
-        and anything that looks like an outlier. Refer to entities by their
-        tokens (E1, E2, …) exactly as they appear.
+        and anything that looks like an outlier.
+
+        Entity tokens are per-document. E1 in one extract and E1 in another are
+        NOT the same person or organisation — every document was scrubbed in
+        its own pass with no shared mapping. Do not link, merge or count
+        entities across extracts, and do not state how many distinct people or
+        organisations appear. Describe each extract on its own terms.
 
         {{extracts}}
       into: digest_text


### PR DESCRIPTION
## The bug

The scrub step is a `fan_out`: each document gets its own agent call with only that document in scope and no shared mapping ([:44-66](examples/recipes/advanced-patterns/private-document-digest.yaml#L44-L66)). So "replace each person with a stable token: E1, E2" makes the first person in **every** document E1. The tokens are stable *within* a document and meaningless *across* documents.

The digest step then said:

> Refer to entities by their tokens (E1, E2, …) exactly as they appear.

That instructs the model to treat a per-document label as a global identifier. Twenty documents about twenty different people produce a digest about one person called E1.

This is not a formatting slip. A labelling collision becomes a **stated fact that appears nowhere in the source**, and it reads as a finding rather than as an error — the failure direction that matters.

## The fix

Replaced with the opposite instruction. **Deleting the sentence alone was not enough** — the model still sees a column of E1s across a JSON array, and linking them is the natural reading. It now gets an explicit negative: tokens are per-document; do not link, merge or count entities across extracts; do not state how many distinct people appear.

Two things recorded in the honest-limits header so the next person doesn't "fix" this by making tokens global:

- **Consistent tokens across a batch is a privacy cost, not a free improvement.** A stable token across many records is what enables re-identification by cross-referencing, which is why the guidance in the field is to limit batch size when using it. Today's collision is accidentally protective.
- **A string-keyed registry would only give "same string, same token."** It would not resolve an initial-plus-surname, a full name and a later pronoun to one entity — that is cross-document coreference, still an open problem. Describing a registry as entity linking would be the same class of overclaim as the bug being fixed.

## Scope

Prompt text and comments only. **No** registry, **no** NER pass, **no** change to the scrub prompt or the token scheme. Whether to add a deterministic detector in front of the model is a separate decision.

## Verification

The discriminating check — harmful instruction absent **and** cross-document guard present:

| | harmful instruction | cross-doc guard | |
|---|---|---|---|
| pre-edit `HEAD` | true | false | **FAIL** |
| post-edit | false | true | **PASS** |

Recipe lint clean, YAML parses, fixture and LSP audits exit 0.

Worth stating plainly: **lint and parse are not evidence here** — they pass on the broken version too. Only the check above discriminates, which is why it was run against both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)