### PR TITLE
fix(recipes): one resolver for the local model and endpoint

### DIFF
--- a/src/recipes/__tests__/localModelPrecedence.test.ts
+++ b/src/recipes/__tests__/localModelPrecedence.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Precedence tests for the `driver: "local"` model and endpoint.
+ *
+ * ## The bug these pin
+ *
+ * Three settings could name the local model, and they disagreed:
+ *
+ *   1. the step's own `model:` — the most specific thing anyone wrote
+ *   2. `LOCAL_MODEL` in the environment
+ *   3. `localModel` in ~/.patchwork/config.json
+ *
+ * `src/config.ts` seeds (2) from (3) only when (2) is unset, and calls that
+ * "non-destructive" — i.e. the environment is documented to win over config.
+ * `defaultLocalFn` then read config DIRECTLY and never looked at the
+ * environment at all, so for recipe steps the documented precedence was
+ * inverted. Worse, it applied `cfg.localModel ?? model`, so a global config
+ * default beat the model a recipe author had written explicitly.
+ *
+ * The failure is silent in the direction that matters: the run completes, the
+ * digest looks fine, and the run log names the model the step ASKED for while
+ * a different one actually answered. A run that is invalid is indistinguishable
+ * from one that is not.
+ *
+ * Same class as #1256: two paths that must agree, and don't. The fix is one
+ * resolver used by everyone, which is what `resolveLocalModel` /
+ * `resolveLocalEndpoint` are.
+ *
+ * ## Why the fallback is not `DEFAULT_MODEL`
+ *
+ * `agentExecutor.DEFAULT_MODEL` is `claude-haiku-4-5-20251001` — an Anthropic
+ * id. It was the fallback on the LOCAL path too, so a `driver: local` step
+ * with no `model:` sent an Anthropic model name to Ollama. `cfg.localModel ??`
+ * masked that whenever config happened to set a local model, which is why the
+ * config override was simultaneously a bug and the only thing making the local
+ * path work. Both are fixed here: the local chain ends at the local adapter's
+ * own default, never at an Anthropic id.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAgent } from "../agentExecutor.js";
+import {
+  LOCAL_FALLBACK_MODEL,
+  resolveLocalEndpoint,
+  resolveLocalModel,
+} from "../localSettings.js";
+
+const SAVED = {
+  model: process.env.LOCAL_MODEL,
+  endpoint: process.env.LOCAL_ENDPOINT,
+};
+
+beforeEach(() => {
+  process.env.LOCAL_MODEL = undefined;
+  process.env.LOCAL_ENDPOINT = undefined;
+  delete process.env.LOCAL_MODEL;
+  delete process.env.LOCAL_ENDPOINT;
+});
+
+afterEach(() => {
+  if (SAVED.model === undefined) delete process.env.LOCAL_MODEL;
+  else process.env.LOCAL_MODEL = SAVED.model;
+  if (SAVED.endpoint === undefined) delete process.env.LOCAL_ENDPOINT;
+  else process.env.LOCAL_ENDPOINT = SAVED.endpoint;
+});
+
+describe("resolveLocalModel", () => {
+  it("the step's explicit model beats config — the reported bug", () => {
+    // Before the fix this returned "cfg-model": `cfg.localModel ?? model`
+    // put a global default ahead of what the recipe author wrote.
+    expect(resolveLocalModel("step-model", { localModel: "cfg-model" })).toBe(
+      "step-model",
+    );
+  });
+
+  it("the step's explicit model beats the environment too", () => {
+    process.env.LOCAL_MODEL = "env-model";
+    expect(resolveLocalModel("step-model", {})).toBe("step-model");
+  });
+
+  it("environment beats config when the step says nothing", () => {
+    // src/config.ts:697-700 seeds env from config only when env is unset and
+    // calls it non-destructive. Env-wins is the documented contract; this is
+    // the assertion that defaultLocalFn used to violate by ignoring env.
+    process.env.LOCAL_MODEL = "env-model";
+    expect(resolveLocalModel(undefined, { localModel: "cfg-model" })).toBe(
+      "env-model",
+    );
+  });
+
+  it("config is used when neither the step nor the environment names one", () => {
+    expect(resolveLocalModel(undefined, { localModel: "cfg-model" })).toBe(
+      "cfg-model",
+    );
+  });
+
+  it("falls back to a LOCAL model id, never an Anthropic one", () => {
+    const resolved = resolveLocalModel(undefined, {});
+    expect(resolved).toBe(LOCAL_FALLBACK_MODEL);
+    // The regression that matters: sending "claude-…" to Ollama.
+    expect(resolved).not.toMatch(/^claude-/);
+  });
+
+  it("treats an empty string as unset rather than as a choice", () => {
+    process.env.LOCAL_MODEL = "";
+    expect(resolveLocalModel("", { localModel: "cfg-model" })).toBe(
+      "cfg-model",
+    );
+  });
+});
+
+describe("resolveLocalEndpoint", () => {
+  it("environment beats config", () => {
+    process.env.LOCAL_ENDPOINT = "http://127.0.0.1:1234";
+    expect(
+      resolveLocalEndpoint({ localEndpoint: "http://127.0.0.1:9999" }),
+    ).toBe("http://127.0.0.1:1234");
+  });
+
+  it("config is used when the environment is unset", () => {
+    expect(
+      resolveLocalEndpoint({ localEndpoint: "http://127.0.0.1:9999" }),
+    ).toBe("http://127.0.0.1:9999");
+  });
+
+  it("returns undefined when neither is set, letting the adapter default", () => {
+    expect(resolveLocalEndpoint({})).toBeUndefined();
+  });
+
+  it("treats an empty string as unset", () => {
+    process.env.LOCAL_ENDPOINT = "";
+    expect(
+      resolveLocalEndpoint({ localEndpoint: "http://127.0.0.1:9999" }),
+    ).toBe("http://127.0.0.1:9999");
+  });
+});
+
+/**
+ * The resolver being correct in isolation proves nothing about the paths that
+ * were broken. These go through `executeAgent`, which is where the wrong
+ * model was chosen and where the run log was stamped with a model that never
+ * ran. Both assertions below fail against the pre-fix implementation.
+ */
+describe("executeAgent local paths use the resolver", () => {
+  const makeDeps = (cfg: Record<string, string> = {}) => ({
+    anthropicFn: vi.fn().mockResolvedValue({ text: "a" }),
+    providerDriverFn: vi.fn().mockResolvedValue({ text: "p" }),
+    claudeCliFn: vi.fn().mockResolvedValue({ text: "c" }),
+    localFn: vi.fn().mockResolvedValue({ text: "local-result" }),
+    probeClaudeCli: vi.fn().mockReturnValue(false),
+    loadPatchworkConfig: vi.fn().mockReturnValue(cfg),
+  });
+
+  it('driver:"local" — the step model beats config, and is what gets stamped', async () => {
+    const deps = makeDeps({ localModel: "cfg-model" });
+    const result = await executeAgent(
+      { driver: "local", prompt: "hi", model: "step-model" },
+      deps as never,
+    );
+    // Pre-fix: localFn received "step-model" but the adapter then applied
+    // cfg.localModel, so the wrong model ran while the log said otherwise.
+    expect(deps.localFn).toHaveBeenCalledWith("hi", "step-model");
+    expect(result.servedBy).toEqual({ driver: "local", model: "step-model" });
+  });
+
+  it('driver:"local" with no model: never sends an Anthropic id', async () => {
+    const deps = makeDeps({});
+    const result = await executeAgent(
+      { driver: "local", prompt: "hi" },
+      deps as never,
+    );
+    // Pre-fix this was DEFAULT_MODEL — "claude-haiku-4-5-20251001" — sent to
+    // a local server.
+    expect(deps.localFn).toHaveBeenCalledWith("hi", LOCAL_FALLBACK_MODEL);
+    expect(result.servedBy?.model).not.toMatch(/^claude-/);
+  });
+
+  it("config model:local branch resolves the same way", async () => {
+    const deps = makeDeps({ model: "local", localModel: "cfg-model" });
+    const result = await executeAgent({ prompt: "hi" }, deps as never);
+    expect(deps.localFn).toHaveBeenCalledWith("hi", "cfg-model");
+    expect(result.servedBy).toEqual({ driver: "local", model: "cfg-model" });
+  });
+});
+
+/**
+ * `defaultLocalFn` itself — where `cfg.localModel ?? model` lived.
+ *
+ * The executeAgent tests above mock localFn, so they cannot see this: the
+ * caller passed the step's model correctly and the corruption happened one
+ * layer down, inside the function the mock replaced. Noting it because the
+ * first executeAgent test PASSES against the pre-fix code and is therefore
+ * not evidence on its own — these are.
+ */
+describe("defaultLocalFn honours precedence at the adapter boundary", () => {
+  it("passes the step model, not cfg.localModel, to the adapter", async () => {
+    vi.resetModules();
+    const createLocalAdapter = vi.fn().mockReturnValue({
+      complete: vi.fn().mockResolvedValue({ text: "ok" }),
+    });
+    vi.doMock("../../adapters/local.js", () => ({ createLocalAdapter }));
+    vi.doMock("../../patchworkConfig.js", () => ({
+      loadConfig: () => ({ localModel: "cfg-model" }),
+    }));
+    const { defaultLocalFn } = await import("../yamlRunner.js");
+    await defaultLocalFn("hi", "step-model");
+    expect(createLocalAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultModel: "step-model" }),
+    );
+    vi.doUnmock("../../adapters/local.js");
+    vi.doUnmock("../../patchworkConfig.js");
+  });
+
+  it("honours LOCAL_ENDPOINT over config", async () => {
+    vi.resetModules();
+    process.env.LOCAL_ENDPOINT = "http://127.0.0.1:1234";
+    const createLocalAdapter = vi.fn().mockReturnValue({
+      complete: vi.fn().mockResolvedValue({ text: "ok" }),
+    });
+    vi.doMock("../../adapters/local.js", () => ({ createLocalAdapter }));
+    vi.doMock("../../patchworkConfig.js", () => ({
+      loadConfig: () => ({ localEndpoint: "http://127.0.0.1:9999" }),
+    }));
+    const { defaultLocalFn } = await import("../yamlRunner.js");
+    await defaultLocalFn("hi", "m");
+    expect(createLocalAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: "http://127.0.0.1:1234" }),
+    );
+    vi.doUnmock("../../adapters/local.js");
+    vi.doUnmock("../../patchworkConfig.js");
+  });
+});

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -8,6 +8,8 @@
  * localFn (Ollama/LM Studio) instead of Anthropic API — opt-in behaviour change.
  */
 
+import { resolveLocalModel } from "./localSettings.js";
+
 /**
  * Token usage reported by an adapter. Both fields are integers; absent
  * `usage` on the parent `AgentResult` means the driver didn't surface
@@ -65,7 +67,12 @@ export interface AgentExecutorDeps {
   /** Returns true when the `claude` CLI is available on PATH. */
   probeClaudeCli: () => boolean;
   /** Reads ~/.patchwork/config; returns {} when absent. */
-  loadPatchworkConfig: () => { model?: string; driver?: string };
+  loadPatchworkConfig: () => {
+    model?: string;
+    driver?: string;
+    localModel?: string;
+    localEndpoint?: string;
+  };
 }
 
 export interface AgentExecutorInput {
@@ -263,11 +270,14 @@ export async function executeAgent(
     return stamp("subprocess", model, deps.claudeCliFn(prompt, cliOpts));
   }
   if (driver === "local") {
-    return stamp(
-      "local",
-      model ?? DEFAULT_MODEL,
-      deps.localFn(prompt, model ?? DEFAULT_MODEL),
-    );
+    // Resolve through the shared resolver, NOT `model ?? DEFAULT_MODEL`.
+    // DEFAULT_MODEL is an Anthropic id; using it here sent "claude-…" to a
+    // local server whenever a step omitted `model:`. Stamping the RESOLVED
+    // value is the other half: the log previously recorded what the step
+    // asked for while a config default answered, so an invalid run and a
+    // valid one looked identical.
+    const localModel = resolveLocalModel(model, deps.loadPatchworkConfig());
+    return stamp("local", localModel, deps.localFn(prompt, localModel));
   }
   if (driver !== undefined) {
     throw new Error(`Unknown driver: "${driver}"`);
@@ -276,11 +286,8 @@ export async function executeAgent(
   // No driver — check pwCfg for local model preference (THE MISSING BRANCH).
   const pwCfg = deps.loadPatchworkConfig();
   if (pwCfg.model === "local") {
-    return stamp(
-      "local",
-      model ?? DEFAULT_MODEL,
-      deps.localFn(prompt, model ?? DEFAULT_MODEL),
-    );
+    const localModel = resolveLocalModel(model, pwCfg);
+    return stamp("local", localModel, deps.localFn(prompt, localModel));
   }
 
   // Explicit subprocess driver config → skip API key check entirely.

--- a/src/recipes/localSettings.ts
+++ b/src/recipes/localSettings.ts
@@ -1,0 +1,106 @@
+/**
+ * One place that decides which local model and endpoint a `driver: "local"`
+ * agent step actually uses.
+ *
+ * ## Why this module exists
+ *
+ * Three things could name the local model — the step's own `model:`, the
+ * `LOCAL_MODEL` environment variable, and `localModel` in the patchwork config
+ * — and two different code paths disagreed about which won.
+ *
+ * `src/config.ts` seeds the environment from config only when the environment
+ * is unset, and its comment calls that "non-destructive": the environment is
+ * documented to win. `LocalApiDriver` honours that, because it reads the
+ * environment. But `defaultLocalFn` read the config directly and never looked
+ * at the environment at all, then applied `cfg.localModel ?? model` — putting
+ * a global default ahead of the model a recipe author had written explicitly.
+ *
+ * The failure is silent in the direction that matters. The run completes, the
+ * output looks reasonable, and the run log names the model the step ASKED for
+ * while a different one answered. A run that is invalid is indistinguishable
+ * from one that is not, which is worse than an error.
+ *
+ * This is the same class as #1256: two paths that must agree, and don't. The
+ * durable fix is not to correct one path — it is to leave only one. Both the
+ * caller (`agentExecutor`) and `defaultLocalFn` resolve through here, so the
+ * stamped `servedBy.model` and the model the adapter receives cannot drift
+ * apart.
+ *
+ * ## Precedence
+ *
+ *   model:     step `model:`  >  LOCAL_MODEL  >  config.localModel  >  fallback
+ *   endpoint:  LOCAL_ENDPOINT >  config.localEndpoint               >  adapter
+ *
+ * Most specific first. The step is the only one of the three that was written
+ * with this particular call in mind.
+ *
+ * ## Why the fallback is not `agentExecutor.DEFAULT_MODEL`
+ *
+ * That constant is `claude-haiku-4-5-20251001`, an Anthropic id, and it was the
+ * fallback on the local path too — so a `driver: local` step with no `model:`
+ * sent an Anthropic model name to a local server. `cfg.localModel ??` hid that
+ * whenever config happened to set a local model, which is why the config
+ * override was at once a bug and the only thing keeping the local path
+ * working. The local chain therefore ends at a local id.
+ */
+
+/**
+ * Last resort when nothing names a model. Matches `DEFAULT_MODEL` in
+ * `src/adapters/local.ts` — the adapter would apply the same value itself, so
+ * resolving it here changes nothing except that the run log can now record
+ * what will actually be used instead of leaving it blank.
+ */
+export const LOCAL_FALLBACK_MODEL = "llama3";
+
+/** The subset of the patchwork config this resolver reads. */
+export interface LocalSettingsConfig {
+  localEndpoint?: string;
+  localModel?: string;
+}
+
+/**
+ * An empty string is a value the shell hands you when a variable is exported
+ * but blank (`LOCAL_MODEL=`), and it is never a model anyone meant to pick.
+ * Treating it as unset keeps a stray blank from silently shadowing config.
+ */
+function present(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Resolve the model for a local agent call.
+ *
+ * @param stepModel The step's explicit `model:`, or undefined when it omitted
+ *                  one. Callers must NOT substitute a default before calling —
+ *                  doing so destroys the distinction between "the author chose
+ *                  this" and "nobody said", which is the whole basis of the
+ *                  precedence below.
+ */
+export function resolveLocalModel(
+  stepModel: string | undefined,
+  cfg: LocalSettingsConfig,
+): string {
+  return (
+    present(stepModel) ??
+    present(process.env.LOCAL_MODEL) ??
+    present(cfg.localModel) ??
+    LOCAL_FALLBACK_MODEL
+  );
+}
+
+/**
+ * Resolve the endpoint for a local agent call.
+ *
+ * Returns undefined when nothing is configured, so the adapter applies its own
+ * default rather than this module inventing a second one.
+ *
+ * Note this deliberately does NOT do the SSRF check. That guard lives in
+ * `isLoopbackOrPrivateEndpoint` and is already shared by every caller; a
+ * second copy here is the exact duplication this module exists to remove.
+ */
+export function resolveLocalEndpoint(
+  cfg: LocalSettingsConfig,
+): string | undefined {
+  return present(process.env.LOCAL_ENDPOINT) ?? present(cfg.localEndpoint);
+}

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -86,6 +86,7 @@ import {
   JUDGE_PROMPT_SUFFIX,
   parseJudgeVerdict,
 } from "./judgeVerdict.js";
+import { resolveLocalEndpoint, resolveLocalModel } from "./localSettings.js";
 import {
   defaultDeprecationWarn,
   normalizeRecipeForRuntime,
@@ -3867,23 +3868,37 @@ export async function defaultLocalFn(
       "../patchworkConfig.js"
     );
     const cfg = loadPatchworkConfig();
-    // Anti-SSRF: the local adapter streams the prompt to `cfg.localEndpoint`
-    // (dashboard/config-controlled). A `driver: local` recipe must not be
-    // able to POST the prompt to an arbitrary public host. Mirror the
-    // LocalApiDriver gate (src/drivers/local/index.ts): reject any non
-    // loopback/private endpoint unless LOCAL_ENDPOINT_ALLOW_REMOTE=1.
+    // Endpoint and model come from the shared resolver, not from `cfg`
+    // directly. This function used to read config ONLY — never
+    // LOCAL_ENDPOINT / LOCAL_MODEL — while src/config.ts seeds env from
+    // config only when env is unset and calls that "non-destructive", i.e.
+    // env wins. So recipe steps ran the opposite precedence to every other
+    // caller. It also applied `cfg.localModel ?? model`, putting a global
+    // default ahead of a model the recipe author wrote explicitly.
+    //
+    // Resolving is idempotent: agentExecutor already resolves before calling
+    // here, and re-resolving a concrete value returns it unchanged. Direct
+    // callers of this exported function still get the right precedence.
+    const endpoint = resolveLocalEndpoint(cfg);
+    // Anti-SSRF: the local adapter streams the prompt to the resolved
+    // endpoint. A `driver: local` recipe must not be able to POST the prompt
+    // to an arbitrary public host. Mirror the LocalApiDriver gate
+    // (src/drivers/local/index.ts): reject any non loopback/private endpoint
+    // unless LOCAL_ENDPOINT_ALLOW_REMOTE=1. Checking the RESOLVED value
+    // matters — guarding `cfg.localEndpoint` while the adapter used the env
+    // var would have left the env path unguarded.
     if (
-      cfg.localEndpoint &&
+      endpoint &&
       process.env.LOCAL_ENDPOINT_ALLOW_REMOTE !== "1" &&
-      !isLoopbackOrPrivateEndpoint(cfg.localEndpoint)
+      !isLoopbackOrPrivateEndpoint(endpoint)
     ) {
       return {
         text: "[agent step failed: localEndpoint is a public host; set LOCAL_ENDPOINT_ALLOW_REMOTE=1 to override]",
       };
     }
     const adapter = createLocalAdapter({
-      endpoint: cfg.localEndpoint,
-      defaultModel: cfg.localModel ?? model,
+      endpoint,
+      defaultModel: resolveLocalModel(model, cfg),
     });
     const result = await adapter.complete({
       systemPrompt: "",


### PR DESCRIPTION
## The reported bug

`defaultLocalFn` read `~/.patchwork/config.json` and nothing else. It never looked at `LOCAL_ENDPOINT` or `LOCAL_MODEL`, while [config.ts:697-700](src/config.ts#L697-L700) seeds env from config *only when env is unset* and calls that "non-destructive" — env is the documented winner. So recipe steps ran the opposite precedence to every other caller, including `LocalApiDriver`.

It also applied `cfg.localModel ?? model`, putting a global config default ahead of the model a recipe author wrote explicitly.

## Two more defects, which change the shape of the fix

**1. The local path's fallback was an Anthropic model id.** [agentExecutor.ts:112](src/recipes/agentExecutor.ts#L112) `DEFAULT_MODEL = "claude-haiku-4-5-20251001"` was the fallback at [:268](src/recipes/agentExecutor.ts#L268) and [:281](src/recipes/agentExecutor.ts#L281) — the **local** branches. A `driver: local` step with no `model:` sent `claude-…` to a local server. `cfg.localModel ??` masked it whenever config happened to set one, so **the config override being reported as a bug was also the only thing keeping the local path working**. Removing it naively would have broken working setups.

**2. The run log named a model that never ran.** `stamp("local", model ?? DEFAULT_MODEL, …)` recorded what the step *asked for* while a config default answered — and it feeds `RunBudget.quoteUsd` pricing. That's the failure that matters: the run completes, the output looks fine, and an invalid run is indistinguishable from a valid one.

## The fix

New `src/recipes/localSettings.ts` is the single resolver. Both `agentExecutor` and `defaultLocalFn` go through it, so the stamped model and the model the adapter receives cannot drift apart. Same principle as #1256 — not *correct one path*, **leave only one**.

```
model:     step `model:`  >  LOCAL_MODEL  >  config.localModel  >  llama3
endpoint:  LOCAL_ENDPOINT >  config.localEndpoint               >  adapter
```

Most specific first — the step is the only one of the three written with this particular call in mind. Empty strings count as unset (an exported-but-blank var is not a choice). Resolution is idempotent, so the executor resolving before calling `defaultLocalFn` is harmless and direct callers of that exported function still get correct precedence.

**The SSRF guard now checks the resolved endpoint** rather than `cfg.localEndpoint`. Guarding config while the adapter used env would have left the newly-honoured env path unguarded — the fix creating the hole. The guard itself is untouched and still shared; no second copy.

## Verified by making it fail

Reverted `agentExecutor.ts` and `yamlRunner.ts` to `HEAD` with the new tests in place:

```
PRE-FIX   4 failed | 11 passed (15)
RESTORED  15 passed (15)
```

Recorded in the test file: **one of the `executeAgent` assertions passes pre-fix and is therefore not evidence on its own** — it mocks `localFn`, and the corruption lived one layer below in `defaultLocalFn`. The two `defaultLocalFn` tests are what actually pin the reported bug. Worth stating rather than counting all 15 as proof.

253 tests green across `agentExecutor`, `yamlRunner`, the local-endpoint guard, the live-model guard and `fanOutAgent`. `tsc` tests.core clean; fixture and LSP audits exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)