### PR TITLE
fix(butler): the approvals section could not render, and reject lied

### DIFF
--- a/dashboard/src/app/butler/__tests__/butler-page.test.tsx
+++ b/dashboard/src/app/butler/__tests__/butler-page.test.tsx
@@ -69,7 +69,11 @@ function mockBridge(over: Record<string, unknown> = {}) {
     "/butler/quarantine": { ok: true, facts: [GUESS] },
     "/butler/permissions/exercises": { ok: true, exercises: [EXERCISE] },
     "/butler/permissions": { ok: true, permissions: [PERMISSION] },
-    "/approvals": { pending: [ASK] },
+    // GET /approvals returns a BARE ARRAY (src/approvalHttp.ts). This
+    // fixture used to wrap it in `{pending: […]}`, which no server ever sent,
+    // so the test passed while the page read `.pending` off an array and
+    // rendered "Nothing right now." forever.
+    "/approvals": [ASK],
     ...over,
   };
   vi.stubGlobal(
@@ -258,7 +262,12 @@ describe("A5 — keyboard operable, and nothing is hover-only", () => {
     expect(yes.getAttribute("type")).toBe("button");
     fireEvent.click(yes);
     await waitFor(() =>
-      expect(calls.some((c) => c.url.includes("/approvals/approve/"))).toBe(
+      expect(
+        // The bridge routes /approve/<id>; there is no /approvals/ prefix on
+        // the decision route. This asserted the URL the page used to send,
+        // which 404'd.
+        calls.some((c) => c.url.includes("/approve/")),
+      ).toBe(
         true,
       ),
     );
@@ -277,6 +286,50 @@ describe("honesty when the bridge is unreachable", () => {
     expect(
       screen.getByText(/not the same as knowing nothing about you/i),
     ).toBeTruthy();
+  });
+
+  it("says so for a 502 too — the failure the old code could not see", async () => {
+    // The dashboard proxy answers a dead bridge with a 502 whose BODY is
+    // valid JSON: {"error":"Bridge unreachable"}. `.then(r => r.json())`
+    // resolved, the shape guards fell through to [], and the page rendered
+    // "Nothing yet." about a bridge it never reached. Only a network-level
+    // rejection (the test above) ever reached the catch — so the existing
+    // test passed while this, the failure that actually happens in
+    // production, went unnoticed.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 502,
+          json: () => Promise.resolve({ error: "Bridge unreachable" }),
+        }),
+      ),
+    );
+    render(<ButlerPage />);
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/could not reach the bridge/i);
+  });
+
+  it("distinguishes 'I cannot check' from 'you have granted nothing'", async () => {
+    // The bridge answers 501 when it has no permission store, with an
+    // explicit comment that it must not read as "you have granted nothing".
+    // The client used to flatten that to an empty list, defeating the
+    // distinction the server went out of its way to make.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 501,
+          json: () => Promise.resolve({ error: "not available" }),
+        }),
+      ),
+    );
+    render(<ButlerPage />);
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/cannot check/i);
   });
 });
 

--- a/dashboard/src/app/butler/page.tsx
+++ b/dashboard/src/app/butler/page.tsx
@@ -143,6 +143,28 @@ function permissionInWords(p: StandingPermission): string {
   }.`;
 }
 
+/**
+ * GET a bridge route and fail loudly on a non-2xx.
+ *
+ * The dashboard proxy returns a JSON body on failure (502
+ * `{"error":"Bridge unreachable"}`), so `.then(r => r.json())` resolves
+ * happily and the caller cannot tell a dead bridge from an empty one.
+ */
+async function getJson(path: string): Promise<Record<string, unknown>> {
+  const res = await fetch(apiPath(path));
+  if (!res.ok) {
+    // The bridge answers 501 for a permission store it cannot read, with an
+    // explicit comment that it must not read as "you have granted nothing".
+    // Preserve that distinction instead of flattening it to an empty list.
+    throw new Error(
+      res.status === 501
+        ? "I cannot check that on this bridge."
+        : `Could not reach the bridge (${res.status}).`,
+    );
+  }
+  return (await res.json()) as Record<string, unknown>;
+}
+
 // ─────────────────────────────────────────────────────────────── page
 
 export default function ButlerPage() {
@@ -168,26 +190,43 @@ export default function ButlerPage() {
 
   const load = useCallback(async () => {
     try {
+      // `r.json()` alone was not enough to keep the promise in the comment
+      // below. The dashboard proxy answers a dead bridge with a 502 whose
+      // BODY is valid JSON (`{"error":"Bridge unreachable"}`), so the parse
+      // succeeded, the shape guards fell through to `[]`, and the page said
+      // "Nothing yet." — confidently, about a bridge it never reached. Only a
+      // network-level rejection ever reached the catch. Check the status.
       const [f, q, p, e, a] = await Promise.all([
-        fetch(apiPath("/api/bridge/butler/facts")).then((r) => r.json()),
-        fetch(apiPath("/api/bridge/butler/quarantine")).then((r) => r.json()),
-        fetch(apiPath("/api/bridge/butler/permissions")).then((r) => r.json()),
-        fetch(apiPath("/api/bridge/butler/permissions/exercises")).then((r) =>
-          r.json(),
-        ),
-        fetch(apiPath("/api/bridge/approvals")).then((r) => r.json()),
+        getJson("/api/bridge/butler/facts"),
+        getJson("/api/bridge/butler/quarantine"),
+        getJson("/api/bridge/butler/permissions"),
+        getJson("/api/bridge/butler/permissions/exercises"),
+        getJson("/api/bridge/approvals"),
       ]);
       setFacts(Array.isArray(f?.facts) ? f.facts : []);
       setQuarantine(Array.isArray(q?.facts) ? q.facts : []);
       setPermissions(Array.isArray(p?.permissions) ? p.permissions : []);
       setExercises(Array.isArray(e?.exercises) ? e.exercises : []);
-      setAsks(Array.isArray(a?.pending) ? a.pending : []);
+      // GET /approvals returns a BARE ARRAY (src/approvalHttp.ts) — there is
+      // no `pending` wrapper. Reading `.pending` off an array is undefined, so
+      // this section rendered "Nothing right now." no matter how many
+      // approvals were queued. The canonical /approvals page casts the body to
+      // an array directly; this now agrees with the server and with it.
+      setAsks(Array.isArray(a) ? a : []);
       setLoadError(null);
     } catch (err) {
       // Say so. A page that silently renders "Butler knows nothing about you"
       // when the truth is "I could not reach the bridge" is worse than an
       // error: the reader believes it.
-      setLoadError(err instanceof Error ? err.message : String(err));
+      // A raw ECONNREFUSED is not a sentence anyone should read. Messages
+      // this page raises itself (getJson) already are; anything else gets the
+      // plain form.
+      const msg = err instanceof Error ? err.message : String(err);
+      setLoadError(
+        /^[A-Z].*[.?]$/.test(msg)
+          ? msg
+          : "I could not reach the bridge, so I cannot show you anything right now.",
+      );
     } finally {
       setReady(true);
     }
@@ -211,21 +250,38 @@ export default function ButlerPage() {
     [load],
   );
 
+  const del = useCallback(
+    async (path: string) => {
+      const res = await fetch(apiPath(path), { method: "DELETE" });
+      if (!res.ok) throw new Error(`${res.status}`);
+      await load();
+      return res;
+    },
+    [load],
+  );
+
   // ── the ask ───────────────────────────────────────────────────────────
   const ask = asks[0];
 
   const answerAsk = useCallback(
     async (p: Pending, decision: "approve" | "reject") => {
       try {
-        await fetch(apiPath(`/api/bridge/approvals/${decision}/${p.callId}`), {
-          method: "POST",
-        });
+        // Two bugs here, and the second is why the first was invisible.
+        //
+        // The bridge routes `/approve/<id>` and `/reject/<id>` — there is no
+        // `/approvals/` prefix on the decision route (the `/approvals/<id>`
+        // pattern is a single-segment detail route). So every answer 404'd.
+        //
+        // And `post()` was not used, so the 404 resolved and Butler said
+        // "Yes. I will go ahead." for an action that never happened. A
+        // governance product telling someone it approved something it did not
+        // is the worst failure on this page.
+        await post(`/api/bridge/${decision}/${p.callId}`);
         announce(
           decision === "approve"
             ? "Yes. I will go ahead."
             : "No. I have left it alone.",
         );
-        await load();
       } catch {
         announce("I could not send your answer. Nothing has changed.");
       }
@@ -237,9 +293,9 @@ export default function ButlerPage() {
   const removeFact = useCallback(
     async (f: ButlerFact) => {
       try {
-        await fetch(apiPath(`/api/bridge/butler/facts/${f.seq}`), {
-          method: "DELETE",
-        });
+        // Was a bare fetch: a failed DELETE still announced "Removed" and
+        // still offered an undo for a deletion that never happened.
+        await del(`/api/bridge/butler/facts/${f.seq}`);
         announce(`Removed: ${factInWords(f)}`);
         // The undo puts the fact back as something YOU said, which is what it
         // was. It stays available until used.
@@ -286,9 +342,7 @@ export default function ButlerPage() {
   const revokePermission = useCallback(
     async (p: StandingPermission) => {
       try {
-        await fetch(apiPath(`/api/bridge/butler/permissions/${p.id}`), {
-          method: "DELETE",
-        });
+        await del(`/api/bridge/butler/permissions/${p.id}`);
         announce("Taken back. I will ask you about those again.");
         offerUndo(`Took back "${permissionInWords(p)}"`, async () => {
           await post("/api/bridge/butler/permissions", {
@@ -322,10 +376,14 @@ export default function ButlerPage() {
 
       <h1>Butler</h1>
 
+      {/* The reason is shown, not just the reassurance. The bridge answers 501
+          when it cannot read the permission store, with an explicit comment
+          that this must not read as "you have granted nothing" — a fixed
+          "could not reach the bridge" sentence throws that distinction away
+          at the last step, after the server took care to make it. */}
       {loadError && (
         <p className="butlerRowText" role="alert">
-          I could not reach the bridge, so I cannot show you anything right now.
-          This is not the same as knowing nothing about you.
+          {loadError} This is not the same as knowing nothing about you.
         </p>
       )}
 
@@ -335,9 +393,14 @@ export default function ButlerPage() {
         {ask ? (
           <div className="butlerRow">
             <p className="butlerRowText">{ask.summary ?? ask.toolName}</p>
+            {/* "and not ask again about this one" was a promise nothing kept:
+                there is no suppression store, so rejecting removes the queue
+                entry and the next run asks again. Saying what actually
+                happens is worth more than a reassurance that turns out to be
+                false the first time the recipe runs on a schedule. */}
             <p className="butlerMeta">
               If you say yes, I will do this now. If you say no, I will leave it
-              alone and not ask again about this one.
+              alone this time.
             </p>
             <div className="butlerActions">
               <button

--- a/src/__tests__/butlerRoutes-error-classification.test.ts
+++ b/src/__tests__/butlerRoutes-error-classification.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The Butler HTTP surface must not hand an unexpected error's text to a
+ * client — CodeQL alert #139, `js/stack-trace-exposure` at butlerRoutes.ts:63.
+ *
+ * Three handlers caught EVERY throw and echoed `err.message` as a 400. The
+ * intent, stated in a comment above one of them, was that `remember` throws
+ * on caller-fixable input and those are 400s. True, and worth keeping — but
+ * the same catch also sees an `appendFileSync` failure whose message carries
+ * the full `~/.patchwork/butler/facts.jsonl` path, and sends it to whoever
+ * asked.
+ *
+ * These tests pin both halves, because fixing only the leak would make the
+ * API worse: a caller who sends a 20 000-character object deserves to be told
+ * that, not "Internal server error".
+ *
+ * The store errors are faked here rather than provoked for real. Filling a
+ * disk or revoking write permission inside a unit test is not portable, and
+ * the thing under test is the ROUTE's classification, not the store's ability
+ * to fail.
+ */
+
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  ButlerNotFoundError,
+  ButlerValidationError,
+} from "../butler/errors.js";
+import type { ButlerRouteDeps } from "../butlerRoutes.js";
+import { tryHandleButlerRoute } from "../butlerRoutes.js";
+
+function makeReq(method: string): IncomingMessage {
+  const req = new EventEmitter() as unknown as IncomingMessage;
+  (req as { method?: string }).method = method;
+  return req;
+}
+
+function makeRes() {
+  let status = 0;
+  let body = "";
+  const res = {
+    writeHead(code: number) {
+      status = code;
+      return this;
+    },
+    end(b?: string) {
+      body = b ?? "";
+      return this;
+    },
+  } as unknown as ServerResponse;
+  return { res, read: () => ({ status, body }) };
+}
+
+/** A fact store whose `remember` throws whatever the test supplies. */
+function storeThrowing(err: unknown) {
+  return {
+    remember: () => {
+      throw err;
+    },
+    list: () => [],
+    quarantined: () => [],
+  } as unknown as ReturnType<ButlerRouteDeps["factStoreFn"]>;
+}
+
+/** POST a valid fact body at a store that will throw `err`. */
+async function postFact(err: unknown) {
+  const req = makeReq("POST");
+  const { res, read } = makeRes();
+  tryHandleButlerRoute(req, res, new URL("http://x/butler/facts"), {
+    factStoreFn: () => storeThrowing(err),
+  });
+  (req as unknown as EventEmitter).emit(
+    "data",
+    Buffer.from(
+      JSON.stringify({ subject: "user", predicate: "likes", object: "tea" }),
+    ),
+  );
+  (req as unknown as EventEmitter).emit("end");
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  return read();
+}
+
+describe("butlerRoutes error classification", () => {
+  it("echoes a validation error as 400 — the caller can fix it", async () => {
+    const { status, body } = await postFact(
+      new ButlerValidationError("object exceeds 4096 characters"),
+    );
+    expect(status).toBe(400);
+    expect(JSON.parse(body).error).toBe("object exceeds 4096 characters");
+  });
+
+  it("echoes a not-found error as 404, not 400", async () => {
+    const { status, body } = await postFact(
+      new ButlerNotFoundError("no fact with seq 999"),
+    );
+    expect(status).toBe(404);
+    expect(JSON.parse(body).error).toBe("no fact with seq 999");
+  });
+
+  it("does NOT echo an unexpected error — this is alert #139", async () => {
+    const leak = new Error(
+      "EACCES: permission denied, open '/Users/someone/.patchwork/butler/facts.jsonl'",
+    );
+    const { status, body } = await postFact(leak);
+    expect(status).toBe(500);
+    // The two things that must never reach a client.
+    expect(body).not.toContain(".patchwork");
+    expect(body).not.toContain("EACCES");
+    expect(JSON.parse(body).error).toBe("Internal server error");
+  });
+
+  it("does not echo a non-Error throw either", async () => {
+    const { status, body } = await postFact({
+      secret: "/Users/someone/.patchwork/tokens",
+    });
+    expect(status).toBe(500);
+    expect(body).not.toContain(".patchwork");
+  });
+});

--- a/src/butler/errors.ts
+++ b/src/butler/errors.ts
@@ -1,0 +1,91 @@
+/**
+ * Typed errors for the Butler stores, so an HTTP route can classify a throw
+ * without reading its prose.
+ *
+ * ## Why this exists
+ *
+ * Three route handlers did this:
+ *
+ *     catch (err) {
+ *       badRequest(res, err instanceof Error ? err.message : String(err));
+ *     }
+ *
+ * The comment above one of them explains the intent — `remember` throws on
+ * caller-fixable input (too long, NUL bytes, confidence out of range), and
+ * those are 400s, not 500s. The intent is right and the API is better for
+ * echoing the reason. The defect is that the catch is wider than the comment:
+ * it also catches an `appendFileSync` failure from the fact store, whose
+ * message carries the full `~/.patchwork/butler/facts.jsonl` path, and hands
+ * that to the client. CodeQL flags the pattern as `js/stack-trace-exposure`
+ * (alert #139).
+ *
+ * The same file already had a narrower fix — string-match the messages you
+ * expect, `respond500` otherwise. That works until somebody adds a validation
+ * message to a store, at which point a caller-fixable 400 silently becomes a
+ * 500, or worse, an unexpected error starts matching a prefix and leaks. The
+ * classification has to travel WITH the error, not be re-derived from its
+ * text at the boundary.
+ *
+ * `src/httpErrorResponse.ts` exists for the same reason at the response end;
+ * this is the request end of the same problem.
+ *
+ * ## The two kinds
+ *
+ *   - `ButlerValidationError` — the caller sent something this store will
+ *     never accept. Safe to echo: the message describes the caller's own
+ *     input, never the machine. Route answers 400.
+ *   - `ButlerNotFoundError` — the caller named a record that does not exist.
+ *     Also safe to echo, and distinct because it is a 404, not a 400. The
+ *     seq/id in the message came from the caller.
+ *
+ * Anything else is unexpected and gets the generic 500 with the detail logged
+ * server-side. That is the default, which is the point: a new failure mode is
+ * private until somebody decides otherwise.
+ */
+
+/** Caller-fixable input. Safe to echo — describes the request, not the host. */
+export class ButlerValidationError extends Error {
+  readonly kind = "validation" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "ButlerValidationError";
+  }
+}
+
+/** A named record does not exist. Safe to echo; answered as 404. */
+export class ButlerNotFoundError extends Error {
+  readonly kind = "not_found" as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "ButlerNotFoundError";
+  }
+}
+
+/**
+ * Narrowing helpers.
+ *
+ * These test the `kind` field rather than using `instanceof`, because
+ * `instanceof` is unreliable across module-instance boundaries — two copies of
+ * this module (a bundled dashboard build, a vendored `src/` in another repo,
+ * a vitest module reset) produce classes that are structurally identical and
+ * fail `instanceof`. The failure mode of getting that wrong is a validation
+ * error silently downgraded to a 500, which is exactly the confusion this
+ * module exists to end.
+ */
+export function isButlerValidationError(
+  err: unknown,
+): err is ButlerValidationError {
+  return (
+    err instanceof Error &&
+    (err as Partial<ButlerValidationError>).kind === "validation"
+  );
+}
+
+export function isButlerNotFoundError(
+  err: unknown,
+): err is ButlerNotFoundError {
+  return (
+    err instanceof Error &&
+    (err as Partial<ButlerNotFoundError>).kind === "not_found"
+  );
+}

--- a/src/butler/factStore.ts
+++ b/src/butler/factStore.ts
@@ -25,6 +25,7 @@ import {
 import path from "node:path";
 import { withFileLockSync } from "../fileLockSync.js";
 import { patchworkPath } from "../patchworkHome.js";
+import { ButlerNotFoundError, ButlerValidationError } from "./errors.js";
 import { type ResolveOpts, resolveFacts, resolveOne } from "./resolve.js";
 import {
   type ButlerFact,
@@ -58,10 +59,12 @@ export interface RememberInput {
 
 function clean(s: string, max: number, field: string): string {
   const t = s.trim();
-  if (!t) throw new Error(`${field} is required`);
+  if (!t) throw new ButlerValidationError(`${field} is required`);
   // NUL would corrupt a JSONL row and break `factKey`'s separator assumption.
-  if (t.includes("\0")) throw new Error(`${field} must not contain null bytes`);
-  if (t.length > max) throw new Error(`${field} exceeds ${max} characters`);
+  if (t.includes("\0"))
+    throw new ButlerValidationError(`${field} must not contain null bytes`);
+  if (t.length > max)
+    throw new ButlerValidationError(`${field} exceeds ${max} characters`);
   return t;
 }
 
@@ -107,17 +110,23 @@ export class ButlerFactStore {
     // checked but not required.
     const object = input.object ?? "";
     if (object.includes("\0"))
-      throw new Error("object must not contain null bytes");
+      throw new ButlerValidationError("object must not contain null bytes");
     if (object.length > MAX_OBJECT_CHARS)
-      throw new Error(`object exceeds ${MAX_OBJECT_CHARS} characters`);
+      throw new ButlerValidationError(
+        `object exceeds ${MAX_OBJECT_CHARS} characters`,
+      );
 
     const tier = PROVENANCE_TIER[input.channel];
     if (tier === undefined)
-      throw new Error(`unknown provenance channel: ${input.channel}`);
+      throw new ButlerValidationError(
+        `unknown provenance channel: ${input.channel}`,
+      );
 
     const cc = input.contentConfidence ?? 1;
     if (!Number.isFinite(cc) || cc < 0 || cc > 1)
-      throw new Error("contentConfidence must be between 0 and 1");
+      throw new ButlerValidationError(
+        "contentConfidence must be between 0 and 1",
+      );
 
     this.tail();
     const recordedAt = this.now();
@@ -159,7 +168,8 @@ export class ButlerFactStore {
   ): ButlerFact {
     this.tail();
     const target = this.facts.find((f) => f.seq === seqToRetract);
-    if (!target) throw new Error(`no fact with seq ${seqToRetract}`);
+    if (!target)
+      throw new ButlerNotFoundError(`no fact with seq ${seqToRetract}`);
     const tier = PROVENANCE_TIER[by];
     const recordedAt = this.now();
     const tomb: ButlerFact = {
@@ -200,7 +210,7 @@ export class ButlerFactStore {
   erase(seqToErase: number): ButlerFact {
     this.tail();
     if (!this.facts.some((f) => f.seq === seqToErase))
-      throw new Error(`no fact with seq ${seqToErase}`);
+      throw new ButlerNotFoundError(`no fact with seq ${seqToErase}`);
 
     let erasedRow: ButlerFact | undefined;
     const tmp = `${this.file}.erase.${process.pid}.tmp`;

--- a/src/butler/permissionStore.ts
+++ b/src/butler/permissionStore.ts
@@ -28,6 +28,7 @@ import { appendFileSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { withFileLockSync } from "../fileLockSync.js";
 import { patchworkPath } from "../patchworkHome.js";
+import { ButlerNotFoundError, ButlerValidationError } from "./errors.js";
 import type { StandingPermission } from "./standingPermission.js";
 
 /** One use of a grant. Written by the enforcement path, never by a preview. */
@@ -97,14 +98,20 @@ export class StandingPermissionStore {
       .map((d) => d.trim())
       .filter((d) => d.length > 0);
     if (domains.length === 0)
-      throw new Error("a standing permission must name at least one domain");
+      throw new ButlerValidationError(
+        "a standing permission must name at least one domain",
+      );
     for (const d of domains) {
       if (d.includes("\0"))
-        throw new Error("scope domains must not contain null bytes");
+        throw new ButlerValidationError(
+          "scope domains must not contain null bytes",
+        );
     }
     const perDay = input.ceiling?.perDay;
     if (perDay !== undefined && (!Number.isInteger(perDay) || perDay < 1))
-      throw new Error("ceiling.perDay must be a positive integer");
+      throw new ButlerValidationError(
+        "ceiling.perDay must be a positive integer",
+      );
 
     const p: StandingPermission = {
       id: randomUUID(),
@@ -127,7 +134,8 @@ export class StandingPermissionStore {
    */
   revoke(id: string): StandingPermission {
     const current = this.list().find((p) => p.id === id);
-    if (!current) throw new Error(`no standing permission with id ${id}`);
+    if (!current)
+      throw new ButlerNotFoundError(`no standing permission with id ${id}`);
     if (current.revokedAt !== undefined) return current; // idempotent
     const revoked: StandingPermission = { ...current, revokedAt: this.now() };
     this.append(this.file, revoked);

--- a/src/butlerRoutes.ts
+++ b/src/butlerRoutes.ts
@@ -38,6 +38,10 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  isButlerNotFoundError,
+  isButlerValidationError,
+} from "./butler/errors.js";
 import type { ButlerFactStore } from "./butler/factStore.js";
 import type { StandingPermissionStore } from "./butler/permissionStore.js";
 import { isActive } from "./butler/standingPermission.js";
@@ -65,6 +69,35 @@ function json(res: ServerResponse, status: number, body: unknown): void {
 
 function badRequest(res: ServerResponse, error: string): void {
   json(res, 400, { ok: false, error });
+}
+
+/**
+ * Answer a throw from a Butler store.
+ *
+ * Only errors the stores raised DELIBERATELY are echoed. Everything else gets
+ * the generic 500 with the detail logged server-side, because the alternative
+ * is what CodeQL alert #139 flagged: an `appendFileSync` failure carrying the
+ * full facts.jsonl path, handed to whoever made the request.
+ *
+ * Classification travels with the error rather than being re-derived from its
+ * text here. String-matching the messages you expect works until somebody adds
+ * a validation message to a store, and then a caller-fixable 400 silently
+ * becomes a 500 — or an unexpected error matches a prefix and leaks.
+ */
+function respondStoreError(
+  res: ServerResponse,
+  err: unknown,
+  context: string,
+): void {
+  if (isButlerValidationError(err)) {
+    badRequest(res, err.message);
+    return;
+  }
+  if (isButlerNotFoundError(err)) {
+    json(res, 404, { ok: false, error: err.message });
+    return;
+  }
+  respond500(res, err, context);
 }
 
 /**
@@ -191,7 +224,7 @@ export function tryHandleButlerRoute(
       } catch (err) {
         // `remember` throws on caller-fixable input (too long, NUL bytes,
         // confidence out of range). Those are 400s, not 500s.
-        badRequest(res, err instanceof Error ? err.message : String(err));
+        respondStoreError(res, err, "butler/facts");
       }
     })();
     return true;
@@ -246,7 +279,7 @@ export function tryHandleButlerRoute(
         });
         json(res, 200, { ok: true, fact, supersedes: seq });
       } catch (err) {
-        badRequest(res, err instanceof Error ? err.message : String(err));
+        respondStoreError(res, err, "butler/facts/supersede");
       }
     })();
     return true;
@@ -270,10 +303,10 @@ export function tryHandleButlerRoute(
         json(res, 200, { ok: true, erased: false, tombstone });
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (/^no fact with seq/.test(msg))
-        json(res, 404, { ok: false, error: msg });
-      else respond500(res, err);
+      // Was a regex over the message. The store now says which kind of error
+      // it raised, so the prefix match — and the chance of it drifting away
+      // from the message it matches — is gone.
+      respondStoreError(res, err, "butler/facts/forget");
     }
     return true;
   }
@@ -415,7 +448,7 @@ export function tryHandleButlerRoute(
           });
           json(res, 201, { ok: true, permission });
         } catch (err) {
-          badRequest(res, err instanceof Error ? err.message : String(err));
+          respondStoreError(res, err, "butler/permissions");
         }
       })();
       return true;
@@ -431,10 +464,7 @@ export function tryHandleButlerRoute(
         // withdrawn" remains answerable.
         json(res, 200, { ok: true, permission });
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (/^no standing permission/.test(msg))
-          json(res, 404, { ok: false, error: msg });
-        else respond500(res, err);
+        respondStoreError(res, err, "butler/permissions/revoke");
       }
       return true;
     }

--- a/templates/recipes/butler-errand.yaml
+++ b/templates/recipes/butler-errand.yaml
@@ -73,4 +73,4 @@ steps:
     tool: file.append
     path: ~/.patchwork/inbox/butler-errands.md
     content: |
-      - {{title}} (todoist id {{created.id}}) — undo: patchwork recipe run … todoist.delete_task id={{created.id}}
+      - {{title}} (todoist id {{created.id}}) — to undo, delete task {{created.id}} in Todoist


### PR DESCRIPTION
Butler Phase 0 — correctness before the page becomes anyone's front door.

## The approvals section never worked

`GET /approvals` returns a **bare array** ([approvalHttp.ts:221](src/approvalHttp.ts#L221)). The page read `a?.pending` off it — undefined — so "Something I need to ask you" showed **"Nothing right now."** no matter how many approvals were queued.

The decision POST went to `/api/bridge/approvals/<decision>/<id>`. The bridge routes `/approve/<id>` and `/reject/<id>`; there is no `/approvals/` prefix on the decision route. **Every answer 404'd.**

And the call didn't check `res.ok`, so the 404 resolved and Butler announced **"Yes. I will go ahead."** for an action that never happened. A governance product telling someone it approved something it did not is the worst failure on this page.

**Both existing tests encoded the bugs** — the fixture wrapped the array in `{pending: […]}`, which no server ever sent, and the URL assertion matched the broken path. That's why 372 green tests didn't catch it. Rewritten to the server's contract; they fail against the pre-fix page.

## Every load failure rendered as a confident empty state

Five loaders did `.then(r => r.json())` with no `r.ok`. The proxy answers a dead bridge with a 502 whose **body is valid JSON** (`{"error":"Bridge unreachable"}`), so the parse succeeded, the shape guards fell through to `[]`, and the page said "Nothing yet." about a bridge it never reached. Only a network-level rejection reached the catch — exactly what the one existing test stubbed, so it passed while the failure that actually happens went unnoticed.

The comment above that catch already said a page rendering "Butler knows nothing about you" when the truth is "I could not reach the bridge" is worse than an error, *because the reader believes it*. The code five lines above did that.

The 501 the bridge deliberately returns for an unreadable permission store now surfaces as "I cannot check that" rather than being flattened to an empty list — the server went out of its way to make that distinction and the client discarded it at the last step.

## Raw error text reached clients (CodeQL #139)

Three handlers echoed `err.message` for **any** throw. The intent — `remember()` throws on caller-fixable input, those are 400s — is right and worth keeping. The defect is the catch being wider than its comment: an `appendFileSync` failure carrying the full `~/.patchwork/butler/facts.jsonl` path went to the client too.

New `src/butler/errors.ts` carries the classification **with** the error instead of re-deriving it from prose at the boundary. The file's own narrower fix — string-match what you expect — works until somebody adds a validation message to a store, at which point a 400 silently becomes a 500, or an unexpected error matches a prefix and leaks. Both surviving regex matches are gone too: one classifier, not three sites and two regexes.

## Also

- Destructive paths go through `post()`/`del()`, so the announcement **and** the undo offer are gated on success. A failed DELETE previously still announced "Removed" and offered to undo a deletion that never happened.
- The errand receipt named a command that doesn't exist (`patchwork recipe run … todoist.delete_task`, literal ellipsis). Replaced with an instruction a person can follow.
- "…and not ask again about this one" — no suppression store exists, so the next run asks again. Now says "this time".

## Deliberately not in this change

**C2, the undo that launders provenance.** Fact undo re-POSTs a plain fact and the route stamps `channel:"user_chat"` unconditionally, so undoing the deletion of a *connector-sourced* fact returns it at trust **1.0**, above `ORIGINATE_THRESHOLD`. Permission undo drops `expiresAt` and `magnitudeBand`. That needs new restore routes — Phase 1, not a client fix. Persisting undo across reload is deferred with it: persisting today's undo would make the laundering durable.

## Verified by making it fail

| Check | Pre-fix | After |
|---|---|---|
| butler page tests (corrected fixtures) | 6 failed, 10 passed | **18 passed** (2 new: the 502 case, the 501 distinction) |
| route classification tests | 3 failed — everything answered 400, including the leak | **4 passed** |

119 bridge butler tests, 42 dashboard butler tests, dashboard typecheck, `tsc` tests.core, fixture/LSP/real-IP audits and recipe lint all green. The single biome warning is pre-existing on `HEAD` in a file this change doesn't touch (verified by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)