### PR TITLE
fix(recipes): fan_out ran in silence and an inert budget looked enforced

### DIFF
--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -1238,6 +1238,26 @@ export function extractRunLogStepResults(result: RunRecipeResult["result"]):
   }));
 }
 
+/**
+ * Surface the budget notices the runner already computed.
+ *
+ * `RunBudget` raises a one-time notice whenever a cap cannot actually be
+ * enforced — a local or subscription driver incurs no metered cost, or a model
+ * is missing from the price table. Those notices reached the run result and
+ * the run log and stopped there: the CLI never printed them.
+ *
+ * So a recipe declaring `usdMax: 2.00` and running against a local model
+ * printed a clean report, and the operator had every reason to believe the cap
+ * was holding. It was inert. A cap you believe in and do not have is worse
+ * than no cap, because it is the one you stop checking.
+ */
+function pushBudgetWarnings(lines: string[], result: unknown): void {
+  const warnings = (result as { budgetWarnings?: unknown }).budgetWarnings;
+  if (!Array.isArray(warnings) || warnings.length === 0) return;
+  lines.push("");
+  for (const w of warnings) lines.push(`  ⚠ ${String(w)}`);
+}
+
 export function formatRunReport(
   result: RunRecipeResult["result"],
   recipeName: string,
@@ -1253,6 +1273,7 @@ export function formatRunReport(
       for (const o of result.outputs) lines.push(`  → ${o}`);
     }
     if (result.errorMessage) lines.push(`  Error: ${result.errorMessage}`);
+    pushBudgetWarnings(lines, result);
     return lines.join("\n");
   }
 
@@ -1275,6 +1296,7 @@ export function formatRunReport(
   if (summary.skipped > 0) parts.push(`${summary.skipped} skipped`);
   if (summary.failed > 0) parts.push(`${summary.failed} failed`);
   lines.push(`${overallOk ? "✓" : "✗"} ${parts.join(" · ")}`);
+  pushBudgetWarnings(lines, result);
   return lines.join("\n");
 }
 

--- a/src/recipes/__tests__/fanOutProgress.test.ts
+++ b/src/recipes/__tests__/fanOutProgress.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `fan_out` must say it is alive, and a declared budget must not look enforced
+ * when it is not.
+ *
+ * Both come from the same real run: a local-model pass over 20 documents.
+ * Measured at ~11s per item, so 300 documents is an hour — during which
+ * `fan_out` printed nothing at all. An hour of silence is indistinguishable
+ * from a hang, and that is not a hypothetical: the run was misdiagnosed as
+ * hung while it was working.
+ *
+ * The budget half is quieter and worse. The recipe declared `usdMax: 2.00`.
+ * `RunBudget` correctly worked out that a local driver incurs no metered cost
+ * and raised a notice saying the cap was not being enforced — and the CLI
+ * never printed it. The report looked clean, so the cap looked real. A cap you
+ * believe in and do not have is worse than no cap, because it is the one you
+ * stop checking.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { formatRunReport } from "../../commands/recipe.js";
+import { executeTool } from "../tools/index.js";
+
+describe("fan_out progress", () => {
+  /** Minimal deps: an agent executor that always succeeds, plus a collector. */
+  function run(items: string[], agentOk = true) {
+    const seen: Array<{ index: number; total: number; ok: boolean }> = [];
+    const deps = {
+      runNestedAgent: vi
+        .fn()
+        .mockResolvedValue(
+          agentOk
+            ? { text: "done", ok: true }
+            : { text: "", ok: false, error: "model unavailable" },
+        ),
+      onIterationProgress: (p: { index: number; total: number; ok: boolean }) =>
+        seen.push(p),
+    };
+    return executeTool("fan_out", {
+      params: {
+        items: JSON.stringify(items),
+        as: "doc",
+        do: { agent: { prompt: "summarise {{doc}}" } },
+        on_iter_error: "continue",
+      },
+      step: {},
+      ctx: {},
+      deps: deps as never,
+    }).then((out) => ({ out, seen, deps }));
+  }
+
+  it("reports after every iteration, not just at the end", async () => {
+    const { seen } = await run(["a", "b", "c"]);
+    expect(seen).toEqual([
+      { index: 0, total: 3, ok: true },
+      { index: 1, total: 3, ok: true },
+      { index: 2, total: 3, ok: true },
+    ]);
+  });
+
+  it("reports FAILED iterations too", async () => {
+    // Reporting only successes would be worse than reporting nothing: the run
+    // would appear to stall at the first failure while still working.
+    const { seen } = await run(["a", "b"], false);
+    expect(seen.map((s) => s.ok)).toEqual([false, false]);
+    expect(seen).toHaveLength(2);
+  });
+
+  it("is a no-op when no reporter is injected", async () => {
+    // Absent means silent — byte-identical to the old behaviour for any
+    // caller that does not opt in.
+    const out = await executeTool("fan_out", {
+      params: {
+        items: JSON.stringify(["a"]),
+        as: "doc",
+        do: { agent: { prompt: "x {{doc}}" } },
+      },
+      step: {},
+      ctx: {},
+      deps: {
+        runNestedAgent: vi.fn().mockResolvedValue({ text: "t", ok: true }),
+      } as never,
+    });
+    expect(out).toBeTruthy();
+  });
+});
+
+describe("budget warnings reach the operator", () => {
+  it("prints a cap that is not being enforced", () => {
+    const report = formatRunReport(
+      {
+        stepsRun: 1,
+        outputs: [],
+        budgetWarnings: [
+          'Driver "local" does not incur metered API cost — usdMax is not enforced for its calls.',
+        ],
+      } as never,
+      "private-document-digest",
+    );
+    // Before the fix the notice existed on the result and was never printed.
+    expect(report).toContain("usdMax is not enforced");
+  });
+
+  it("says nothing extra when there are no warnings", () => {
+    const report = formatRunReport(
+      { stepsRun: 1, outputs: [] } as never,
+      "clean-recipe",
+    );
+    expect(report).not.toContain("⚠");
+  });
+});

--- a/src/recipes/tools/fanOut.ts
+++ b/src/recipes/tools/fanOut.ts
@@ -214,6 +214,23 @@ registerTool({
 
     const aggregate: IterResult[] = [];
 
+    /**
+     * Say an iteration finished.
+     *
+     * Called from EVERY path that appends to `aggregate` — success, agent
+     * failure, circuit-breaker short-circuit, tool error. Reporting only the
+     * happy path would be worse than reporting nothing: the run would appear
+     * to stall at the first failure while it was in fact still working.
+     */
+    const report = (index: number, ok: boolean, error?: string): void => {
+      deps.onIterationProgress?.({
+        index,
+        total: items.length,
+        ok,
+        ...(error ? { error } : {}),
+      });
+    };
+
     // Hoist the lazy import outside the loop — dynamic imports cache the
     // module after the first load so correctness is unaffected, but resolving
     // the same promise on every iteration adds async overhead for each item.
@@ -249,6 +266,7 @@ registerTool({
             ? { index: i, ok: true, output: res.text }
             : { index: i, ok: false, error: res.error ?? "agent failed" },
         );
+        report(i, res.ok, res.ok ? undefined : (res.error ?? "agent failed"));
         // A budget refusal is NOT an ordinary iteration failure:
         // `on_iter_error: continue` must not carry the loop past a cap that
         // just said stop. Halt regardless of the setting, keeping the
@@ -287,6 +305,7 @@ registerTool({
       if (breakerKey && getCircuitBreaker().isOpen(breakerKey)) {
         const msg = `circuit_open: "${toolId}" has failed repeatedly for recipe "${deps.recipeName}" — short-circuiting until the cooldown elapses.`;
         aggregate.push({ index: i, ok: false, error: msg });
+        report(i, false, msg);
         if (onIterError === "halt") {
           throw new Error(
             `fan_out: iter ${i} failed (on_iter_error=halt): ${msg}`,
@@ -314,10 +333,12 @@ registerTool({
           ok: true,
           ...(output != null && { output }),
         });
+        report(i, true);
       } catch (err) {
         if (breakerKey) getCircuitBreaker().recordFailure(breakerKey);
         const msg = err instanceof Error ? err.message : String(err);
         aggregate.push({ index: i, ok: false, error: msg });
+        report(i, false, msg);
         if (onIterError === "halt") {
           throw new Error(
             `fan_out: iter ${i} failed (on_iter_error=halt): ${msg}`,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -898,6 +898,28 @@ export type StepDeps = Required<
     /** Budget refused admission — the loop must stop, not continue. */
     budgetHalt?: boolean;
   }>;
+  /**
+   * Called after every `fan_out` iteration so a long loop can say it is alive.
+   *
+   * `fan_out` ran in total silence. A measured local-model pass is ~11s per
+   * item, so 300 documents is an hour of nothing on stdout — and an hour of
+   * silence is indistinguishable from a hang. That is not hypothetical: it is
+   * what made a real dogfood run get misdiagnosed as hung when it was working.
+   *
+   * A seam rather than a `console.log` inside the tool, for the same reason
+   * `runNestedAgent` is one: a tool that writes to a stream of its own choosing
+   * cannot be tested, cannot be silenced for JSON output, and cannot be routed
+   * anywhere else later. Optional — absent means no progress, which is the
+   * old behaviour exactly.
+   */
+  onIterationProgress?: (p: {
+    /** 0-based index of the iteration that just finished. */
+    index: number;
+    total: number;
+    ok: boolean;
+    /** Failure reason, when this iteration failed. */
+    error?: string;
+  }) => void;
 };
 
 // Strip tool-call narration some models (e.g. Gemini) prepend before the markdown block.
@@ -1701,6 +1723,25 @@ export async function runYamlRecipe(
     return { text: stripped, ok: true };
   };
   stepDeps.runNestedAgent = runNestedAgent;
+
+  /**
+   * Default progress reporter for `fan_out`.
+   *
+   * stderr, not stdout: a recipe's output is stdout, and progress is not
+   * output. Anything piping a run into a file or parsing its result keeps
+   * working, and a human watching the terminal still sees it.
+   *
+   * Only wired when the caller has not supplied one, so a test, the dashboard
+   * or an embedding runner can route it elsewhere without this stomping on it.
+   */
+  if (!stepDeps.onIterationProgress) {
+    stepDeps.onIterationProgress = ({ index, total, ok, error }) => {
+      const n = String(index + 1).padStart(String(total).length, " ");
+      process.stderr.write(
+        `  fan_out ${n}/${total} ${ok ? "ok" : `failed — ${error ?? "unknown"}`}\n`,
+      );
+    };
+  }
 
   const runJudgeRefineLoop = async (params: {
     agentCfg: NonNullable<YamlStep["agent"]>;


### PR DESCRIPTION
Both defects come from one real run: a local-model pass over a batch of documents.

## An hour of silence is indistinguishable from a hang

`fan_out` printed nothing between the first item and the last. Measured at **~11s per item**, so 300 documents is an hour of no output. Not a hypothetical cost — the run was misdiagnosed as hung while it was working fine.

New optional `StepDeps.onIterationProgress`, called after **every** iteration. `runYamlRecipe` wires a default writing to stderr; absent, nothing is emitted and behaviour is byte-identical to before.

Two decisions worth stating:

- **A seam, not a `console.log` inside the tool** — same reason `runNestedAgent` is one: a tool writing to a stream of its own choosing cannot be tested, cannot be silenced for JSON output, and cannot be routed elsewhere later.
- **stderr, not stdout** — a recipe's output is stdout; progress is not output. Piping a run into a file still yields the result alone.

It reports **failed** iterations too. Reporting only successes would be worse than reporting nothing: the loop would appear to stall at the first failure while still working. All four paths that append to the aggregate report — agent success, agent failure, circuit-breaker short-circuit, tool error.

## A cap you believe in and do not have

`RunBudget` already raises a one-time notice when a cap can't be enforced — a local or subscription driver incurs no metered cost, or the model is missing from the price table. The notice reached the run result and the run log and **stopped there**: `formatRunReport` never printed it.

So a recipe declaring `usdMax: 2.00` against a local model printed a clean report, and the operator had every reason to think the cap was holding. It was inert — **worse than no cap, because it's the one you stop checking.**

## Verified by making it fail

Reverted `fanOut.ts` and `recipe.ts` to `HEAD` with the new tests in place:

```
PRE-FIX   3 failed | 2 passed (5)
RESTORED  5 passed (5)
```

The two that stayed green are the no-op cases — they assert the **old** behaviour is preserved when nothing opts in, so passing pre-fix is correct for those.

1424 tests green across the recipe subsystem; `tsc` tests.core clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)