### PR TITLE
fix(butler): undo was a trust escalator

### DIFF
--- a/dashboard/src/app/butler/__tests__/butler-page.test.tsx
+++ b/dashboard/src/app/butler/__tests__/butler-page.test.tsx
@@ -85,10 +85,23 @@ function mockBridge(over: Record<string, unknown> = {}) {
       const key = Object.keys(bodies)
         .sort((a, b) => b.length - a.length)
         .find((k) => url.includes(k));
+      // DELETE /butler/facts/:seq answers with the tombstone, and its seq is
+      // what the undo needs to call the restore route. The mock returned `{}`,
+      // so a client reading the tombstone would silently offer no undo — the
+      // fixture has to answer like the server or the test proves nothing.
+      const isFactDelete =
+        init?.method === "DELETE" && url.includes("/butler/facts/");
       return Promise.resolve({
         ok: true,
         status: 200,
-        json: () => Promise.resolve(key ? bodies[key] : {}),
+        json: () =>
+          Promise.resolve(
+            isFactDelete
+              ? { ok: true, erased: false, tombstone: { seq: 99 } }
+              : key
+                ? bodies[key]
+                : {},
+          ),
       });
     }),
   );
@@ -218,8 +231,11 @@ describe("A11 — destructive actions are undoable, and the undo does not time o
 
     await waitFor(() =>
       expect(
+        // Specifically the restore route. Asserting any POST to
+        // /butler/facts passed against the old client, which re-created the
+        // fact as `user_chat` and lost its provenance.
         calls.some(
-          (c) => c.method === "POST" && c.url.includes("/butler/facts"),
+          (c) => c.method === "POST" && c.url.includes("/butler/facts/99/restore"),
         ),
       ).toBe(true),
     );

--- a/dashboard/src/app/butler/page.tsx
+++ b/dashboard/src/app/butler/page.tsx
@@ -295,18 +295,24 @@ export default function ButlerPage() {
       try {
         // Was a bare fetch: a failed DELETE still announced "Removed" and
         // still offered an undo for a deletion that never happened.
-        await del(`/api/bridge/butler/facts/${f.seq}`);
+        // DELETE returns the tombstone; its seq is what identifies the
+        // retraction to undo.
+        const res = await del(`/api/bridge/butler/facts/${f.seq}`);
+        const body = (await res.json()) as { tombstone?: { seq?: number } };
+        const tombSeq = body?.tombstone?.seq;
         announce(`Removed: ${factInWords(f)}`);
-        // The undo puts the fact back as something YOU said, which is what it
-        // was. It stays available until used.
-        offerUndo(`Removed "${factInWords(f)}"`, async () => {
-          await post("/api/bridge/butler/facts", {
-            subject: f.subject,
-            predicate: f.predicate,
-            object: f.object,
+        // Put it back AS IT WAS. This used to re-POST a plain fact, and the
+        // create route stamps channel "user_chat" unconditionally — so undoing
+        // the removal of something Butler had merely READ somewhere returned it
+        // as something you had said, above the threshold at which it starts
+        // being used. The undo was a trust escalator. The restore route copies
+        // the original row's provenance instead.
+        if (tombSeq !== undefined) {
+          offerUndo(`Removed "${factInWords(f)}"`, async () => {
+            await post(`/api/bridge/butler/facts/${tombSeq}/restore`);
+            announce(`Put back: ${factInWords(f)}`);
           });
-          announce(`Put back: ${factInWords(f)}`);
-        });
+        }
         await load();
       } catch {
         announce("I could not remove that. Nothing has changed.");
@@ -344,12 +350,13 @@ export default function ButlerPage() {
       try {
         await del(`/api/bridge/butler/permissions/${p.id}`);
         announce("Taken back. I will ask you about those again.");
+        // Restore the SAME grant. This used to call the grant route with three
+        // fields, which minted a new id and grantedAt and silently dropped
+        // `expiresAt` and the magnitude band — turning a capped, expiring
+        // permission into an uncapped permanent one, and orphaning every
+        // "done without asking" record attached to the old id.
         offerUndo(`Took back "${permissionInWords(p)}"`, async () => {
-          await post("/api/bridge/butler/permissions", {
-            domains: p.scope.domains,
-            ...(p.note && { note: p.note }),
-            ...(p.ceiling?.perDay && { perDay: p.ceiling.perDay }),
-          });
+          await post(`/api/bridge/butler/permissions/${p.id}/restore`);
           announce("Allowed again.");
         });
         await load();

--- a/src/butler/__tests__/restore.test.ts
+++ b/src/butler/__tests__/restore.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Undo must put back what was there — not a fresh claim wearing its words.
+ *
+ * ## The bug
+ *
+ * The Butler page's undo re-POSTed a plain fact to `POST /butler/facts`, and
+ * that route stamps `channel: "user_chat"` unconditionally — deliberately, with
+ * a comment saying the channel is not caller-supplied. Correct for a new claim
+ * from a person. Wrong for an undo.
+ *
+ * `user_chat` carries provenance tier 1.0. `connector` carries 0.3, and
+ * `ORIGINATE_THRESHOLD` is 0.6. So deleting a fact Butler had read from a
+ * connector — quarantined, not yet acted on — and then pressing undo returned
+ * it at **1.0**, above the threshold, as something you had said yourself.
+ *
+ * The undo button was a trust escalator through the exact barrier the fact
+ * store exists to enforce, and the only visible difference was that the fact
+ * came back.
+ *
+ * The permission undo had the matching defect: it re-granted from three fields
+ * (`domains`, `note`, `perDay`), silently dropping `expiresAt` and
+ * `ceiling.magnitudeBand`, and minted a fresh `id` and `grantedAt`. Undoing an
+ * accidental revoke turned a capped, expiring grant into an uncapped permanent
+ * one with no link to the original.
+ *
+ * ## Why restore is a store method and not a smarter client
+ *
+ * Every input needed to rebuild the row correctly is already on disk: `forget`
+ * writes a tombstone and never removes the original. A client cannot be trusted
+ * to reassemble it — it would have to know the provenance model, and any caller
+ * that gets it wrong fails in the permissive direction, silently.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ButlerFactStore } from "../factStore.js";
+import { StandingPermissionStore } from "../permissionStore.js";
+import { ORIGINATE_THRESHOLD } from "../types.js";
+
+let dir: string;
+const silent = { warn: () => {} };
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "butler-restore-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("factStore.restore", () => {
+  it("returns a connector fact at its ORIGINAL trust, below the originate threshold", () => {
+    const store = new ButlerFactStore({ dir, logger: silent });
+    const original = store.remember({
+      subject: "user",
+      predicate: "diet.avoid",
+      object: "shellfish",
+      channel: "connector",
+      source: "gmail",
+    });
+    expect(original.trust).toBeLessThan(ORIGINATE_THRESHOLD);
+
+    const tomb = store.forget(original.seq, "user_chat");
+    const restored = store.restore(tomb.seq);
+
+    // The whole bug in one assertion: this was 1.0 (user_chat) before.
+    expect(restored.provenance.channel).toBe("connector");
+    expect(restored.provenance.source).toBe("gmail");
+    expect(restored.trust).toBe(original.trust);
+    expect(restored.trust).toBeLessThan(ORIGINATE_THRESHOLD);
+  });
+
+  it("keeps a user_confirmed fact validated", () => {
+    // The other direction: restoring must not DOWNGRADE either.
+    const store = new ButlerFactStore({ dir, logger: silent });
+    const original = store.remember({
+      subject: "user",
+      predicate: "household.spouse",
+      object: "Alex",
+      channel: "user_confirmed",
+    });
+    expect(original.provenance.validated).toBe(true);
+
+    const tomb = store.forget(original.seq);
+    const restored = store.restore(tomb.seq);
+    expect(restored.provenance.validated).toBe(true);
+    expect(restored.trust).toBe(original.trust);
+  });
+
+  it("preserves contentConfidence rather than resetting it to 1", () => {
+    const store = new ButlerFactStore({ dir, logger: silent });
+    const original = store.remember({
+      subject: "user",
+      predicate: "travel.prefers",
+      object: "aisle",
+      channel: "recipe_agent",
+      contentConfidence: 0.4,
+    });
+    const tomb = store.forget(original.seq);
+    const restored = store.restore(tomb.seq);
+    expect(restored.contentConfidence).toBe(0.4);
+  });
+
+  it("links the restoration to the tombstone it undoes", () => {
+    // Without this the log says a fact appeared from nowhere at the moment one
+    // was retracted, and cannot answer "was this put back, or re-entered?".
+    const store = new ButlerFactStore({ dir, logger: silent });
+    const original = store.remember({
+      subject: "user",
+      predicate: "x",
+      object: "y",
+      channel: "connector",
+    });
+    const tomb = store.forget(original.seq);
+    const restored = store.restore(tomb.seq);
+    expect(restored.supersedes).toBe(tomb.seq);
+  });
+
+  it("refuses a seq that is not a tombstone", () => {
+    const store = new ButlerFactStore({ dir, logger: silent });
+    const fact = store.remember({
+      subject: "user",
+      predicate: "x",
+      object: "y",
+      channel: "user_chat",
+    });
+    expect(() => store.restore(fact.seq)).toThrow(/not a retraction/i);
+  });
+
+  it("refuses an unknown seq", () => {
+    const store = new ButlerFactStore({ dir, logger: silent });
+    expect(() => store.restore(9999)).toThrow(/no fact with seq/i);
+  });
+});
+
+describe("permissionStore.restore", () => {
+  it("keeps the SAME grant — id, grantedAt, ceiling and expiry all survive", () => {
+    const store = new StandingPermissionStore({ dir, logger: silent });
+    const granted = store.grant({
+      scope: { domains: ["tasks"] },
+      grantedBy: "owner",
+      ceiling: { perDay: 3, magnitudeBand: "band<=50" },
+      expiresAt: 1_800_000_000_000,
+      note: "errands",
+    });
+
+    store.revoke(granted.id);
+    const restored = store.restore(granted.id);
+
+    // Previously this minted a fresh id/grantedAt and dropped two of these.
+    expect(restored.id).toBe(granted.id);
+    expect(restored.grantedAt).toBe(granted.grantedAt);
+    expect(restored.expiresAt).toBe(granted.expiresAt);
+    expect(restored.ceiling?.perDay).toBe(3);
+    expect(restored.ceiling?.magnitudeBand).toBe("band<=50");
+    expect(restored.revokedAt).toBeUndefined();
+  });
+
+  it("is idempotent on a grant that was never revoked", () => {
+    const store = new StandingPermissionStore({ dir, logger: silent });
+    const granted = store.grant({
+      scope: { domains: ["tasks"] },
+      grantedBy: "owner",
+    });
+    const restored = store.restore(granted.id);
+    expect(restored.id).toBe(granted.id);
+    expect(restored.revokedAt).toBeUndefined();
+  });
+
+  it("refuses an unknown id", () => {
+    const store = new StandingPermissionStore({ dir, logger: silent });
+    expect(() => store.restore("nope")).toThrow(/no standing permission/i);
+  });
+});

--- a/src/butler/factStore.ts
+++ b/src/butler/factStore.ts
@@ -190,6 +190,56 @@ export class ButlerFactStore {
   }
 
   /**
+   * Undo a `forget`, putting the belief back AS IT WAS.
+   *
+   * The client used to do this by re-POSTing a plain fact, and
+   * `POST /butler/facts` stamps `channel: "user_chat"` unconditionally — right
+   * for a new claim from a person, wrong for an undo. A fact Butler had read
+   * from a connector (tier 0.3, below `ORIGINATE_THRESHOLD`) came back as
+   * something you had said yourself (tier 1.0, above it). The undo button was
+   * a trust escalator through the barrier this store exists to enforce, and
+   * the only visible difference was that the fact reappeared.
+   *
+   * Everything needed to rebuild it correctly is already here: `forget` writes
+   * a tombstone and never removes the original row. So this reads the original
+   * and re-appends its provenance verbatim — channel, source, sourceRef and
+   * contentConfidence — rather than asking a caller to reassemble them. A
+   * caller that gets that wrong fails in the permissive direction, silently,
+   * which is the failure that happened.
+   *
+   * Appends rather than mutating: the log must still answer "this was
+   * retracted at T1 and restored at T2", not pretend neither happened.
+   *
+   * @param tombstoneSeq The seq of the tombstone written by `forget`.
+   */
+  restore(tombstoneSeq: number): ButlerFact {
+    this.tail();
+    const tomb = this.facts.find((f) => f.seq === tombstoneSeq);
+    if (!tomb)
+      throw new ButlerNotFoundError(`no fact with seq ${tombstoneSeq}`);
+    if (tomb.retracts === undefined)
+      throw new ButlerValidationError(
+        `fact ${tombstoneSeq} is not a retraction — nothing to restore`,
+      );
+    const original = this.facts.find((f) => f.seq === tomb.retracts);
+    if (!original)
+      throw new ButlerNotFoundError(`no fact with seq ${tomb.retracts}`);
+
+    const recordedAt = this.now();
+    const restored: ButlerFact = {
+      ...original,
+      seq: ++this.seq,
+      recordedAt,
+      validFrom: recordedAt,
+      // Points at the TOMBSTONE, not at the original. The chain reads
+      // "belief → retraction → restoration", which is what happened.
+      supersedes: tombstoneSeq,
+    };
+    this.append(restored);
+    return restored;
+  }
+
+  /**
    * GDPR Art. 17 erasure. THE ONLY method in this class that rewrites the log.
    *
    * A tombstone (`forget`) stops a belief resolving but leaves the words on

--- a/src/butler/permissionStore.ts
+++ b/src/butler/permissionStore.ts
@@ -143,6 +143,37 @@ export class StandingPermissionStore {
   }
 
   /**
+   * Undo a `revoke`, restoring THE SAME grant.
+   *
+   * The client used to do this by calling `grant` again with three fields —
+   * `domains`, `note` and `perDay` — which silently dropped `expiresAt` and
+   * `ceiling.magnitudeBand`, and minted a fresh `id` and `grantedAt`. Undoing
+   * an accidental revoke therefore turned a capped, expiring grant into an
+   * uncapped permanent one with no link to the original. Every exercise
+   * recorded against the old id was orphaned.
+   *
+   * This appends the existing record with `revokedAt` removed. The id,
+   * `grantedAt`, scope, ceiling and expiry all survive because they are not
+   * re-derived from anything — nothing is passed in, so nothing can be lost.
+   *
+   * Idempotent on a grant that was never revoked: an undo racing a page
+   * refresh should be a no-op, not an error.
+   *
+   * Note this deliberately CANNOT widen a grant. There is no parameter to
+   * widen it with. A caller wanting different scope must make a new grant,
+   * visibly, which is a different act with a different record.
+   */
+  restore(id: string): StandingPermission {
+    const current = this.list().find((p) => p.id === id);
+    if (!current)
+      throw new ButlerNotFoundError(`no standing permission with id ${id}`);
+    if (current.revokedAt === undefined) return current; // idempotent
+    const { revokedAt: _dropped, ...restored } = current;
+    this.append(this.file, restored as StandingPermission);
+    return restored as StandingPermission;
+  }
+
+  /**
    * Current state of every grant ever made, newest first.
    *
    * Revoked and expired grants are INCLUDED — filtering them here would make

--- a/src/butlerRoutes.ts
+++ b/src/butlerRoutes.ts
@@ -357,6 +357,34 @@ export function tryHandleButlerRoute(
     return true;
   }
 
+  // ── POST /butler/facts/:seq/restore ───────────────────────────────────────
+  //
+  // Undo a forget. `:seq` is the TOMBSTONE's seq, not the original's — that is
+  // what the caller was handed by DELETE, and it is what identifies the
+  // retraction being undone.
+  //
+  // A dedicated route rather than "just POST the fact again": the create route
+  // stamps `channel: "user_chat"` unconditionally and must keep doing so, so a
+  // client re-posting a deleted fact silently promoted a connector-sourced
+  // belief (tier 0.3) to something the user said (tier 1.0), above
+  // ORIGINATE_THRESHOLD. The store owns restoration because the store is the
+  // only thing that knows what the row was.
+  const restoreFactMatch = /^\/butler\/facts\/([^/]+)\/restore$/.exec(pathname);
+  if (restoreFactMatch && req.method === "POST") {
+    const seq = parseSeq(restoreFactMatch[1] ?? "");
+    if (seq === null) {
+      badRequest(res, "seq must be a positive integer");
+      return true;
+    }
+    try {
+      const fact = deps.factStoreFn().restore(seq);
+      json(res, 200, { ok: true, fact });
+    } catch (err) {
+      respondStoreError(res, err, "butler/facts/restore");
+    }
+    return true;
+  }
+
   // ── Standing permissions ──────────────────────────────────────────────────
   //
   // GET  /butler/permissions            every grant ever made, newest first
@@ -451,6 +479,28 @@ export function tryHandleButlerRoute(
           respondStoreError(res, err, "butler/permissions");
         }
       })();
+      return true;
+    }
+
+    // ── POST /butler/permissions/:id/restore ────────────────────────────────
+    //
+    // Undo a revoke by clearing `revokedAt` on the EXISTING grant. Not a fresh
+    // grant: re-granting minted a new id and grantedAt and dropped `expiresAt`
+    // and `ceiling.magnitudeBand`, quietly turning a capped, expiring
+    // permission into an uncapped permanent one and orphaning every exercise
+    // recorded against the old id. Takes no body, so it cannot widen anything.
+    const restorePermMatch = /^\/butler\/permissions\/([^/]+)\/restore$/.exec(
+      pathname,
+    );
+    if (restorePermMatch && req.method === "POST") {
+      try {
+        const permission = store.restore(
+          decodeURIComponent(restorePermMatch[1] ?? ""),
+        );
+        json(res, 200, { ok: true, permission });
+      } catch (err) {
+        respondStoreError(res, err, "butler/permissions/restore");
+      }
       return true;
     }
 


### PR DESCRIPTION
Butler Phase 1. #1292 deliberately left this — it needs new bridge routes, so it was never a client fix.

## The fact undo laundered provenance upward

The page's undo re-POSTed a plain fact, and `POST /butler/facts` stamps `channel: "user_chat"` **unconditionally** — deliberately, with a comment saying the channel is not caller-supplied. Right for a new claim from a person. Wrong for an undo.

`user_chat` is tier **1.0**. `connector` is **0.3**, and `ORIGINATE_THRESHOLD` is **0.6**.

So deleting a fact Butler had merely *read* somewhere — quarantined, below the floor at which it starts being used — and pressing undo returned it at 1.0, **above** the floor, as something the user had said themselves. The undo button walked data through the exact barrier the fact store exists to enforce, and the only visible difference was that the fact came back.

Undoing a `user_confirmed` fact lost `validated` the same way.

## The permission undo widened the grant

It re-granted from three fields — `domains`, `note`, `perDay` — silently dropping **`expiresAt`** and **`ceiling.magnitudeBand`**, and minting a fresh `randomUUID()` and `grantedAt`. Undoing an accidental revoke turned a capped, expiring permission into an **uncapped permanent one**, with no link to the original and every "done without asking" exercise orphaned against the old id.

## Restore belongs in the stores

Everything needed to rebuild either row correctly is already on disk: `forget` writes a tombstone and never removes the original; `revoke` appends the same record with `revokedAt` set. Neither needs a caller to reassemble anything — and **a caller that gets it wrong fails in the permissive direction, silently**, which is what happened.

- **`ButlerFactStore.restore(tombstoneSeq)`** re-appends the original row's channel, source, sourceRef and contentConfidence verbatim, with `supersedes` pointing at the tombstone. The chain reads *belief → retraction → restoration*, so the log can still answer "was this put back, or re-entered?"
- **`StandingPermissionStore.restore(id)`** appends the existing record with `revokedAt` removed. Id, grantedAt, scope, ceiling and expiry survive because nothing is passed in, so nothing can be lost. It **takes no parameters, so it cannot widen a grant** — a caller wanting different scope must make a new one, visibly, as a different act.

Both append rather than mutate. Idempotent where it matters: restoring a grant that was never revoked is a no-op, because an undo racing a page refresh shouldn't fail.

Two new routes: `POST /butler/facts/:seq/restore` (the seq is the **tombstone's**, which is what DELETE hands back) and `POST /butler/permissions/:id/restore`.

## The fixture had to change to prove anything

The page test's DELETE mock returned `{}`. The real route returns the tombstone, and its seq is what the undo needs — so against that fixture a client reading the tombstone would silently offer **no undo** and the test would still pass. The mock now answers like the server, and the assertion names the restore route specifically: asserting "any POST to `/butler/facts`" passed against the **old** client, which is exactly the bug.

## Still deliberately not done

Persisting undo offers across a reload. They're React state and die with the page. That order is intentional — **persisting the old undo would have made the laundering durable** instead of transient. Now that restore preserves provenance, persistence is safe to build; it's R11's "persistent undo" and belongs with the onboarding work.

## Verified by making it fail

Reverted both stores, the routes and the page to `HEAD` with the new tests in place:

```
PRE-FIX   9 store tests red · 1 page test red
RESTORED  9 green · 42 green
```

128 bridge butler tests, dashboard typecheck, `tsc` tests.core and six audits all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)