### PR TITLE
fix(workers): the shadow gate disagreed with the gate it shadows

### DIFF
--- a/src/workers/__tests__/shadowGate.test.ts
+++ b/src/workers/__tests__/shadowGate.test.ts
@@ -63,7 +63,7 @@ describe("shadowGate.recommend — compensable at L2", () => {
     const d = recommend(w, "gitPush", {}, storeWithL2("w", "gitPush"));
     expect(d.earnedLevel).toBeGreaterThanOrEqual(2);
     expect(d.decision).toBe("bypass");
-    expect(d.reason).toContain("autonomous");
+    expect(d.reason).toContain("earned autonomy");
   });
 
   it("queues compensable at effective L1 (below L2 threshold)", () => {
@@ -73,7 +73,7 @@ describe("shadowGate.recommend — compensable at L2", () => {
     const d = recommend(w, "gitPush", {}, store);
     expect(d.earnedLevel).toBeLessThan(2);
     expect(d.decision).toBe("queue");
-    expect(d.reason).toContain("below-autonomy");
+    expect(d.reason).toContain("unearned");
   });
 
   it("queues compensable when ceiling=1 even at earned L4", () => {
@@ -87,7 +87,7 @@ describe("shadowGate.recommend — compensable at L2", () => {
     expect(d.earnedLevel).toBe(4);
     expect(d.effectiveLevel).toBe(1);
     expect(d.decision).toBe("queue");
-    expect(d.reason).toContain("capped-by-autonomy-ceiling");
+    expect(d.reason).toContain("capped by autonomy ceiling");
   });
 
   it("bypasses compensable when ceiling=2 and earned L4 (effectiveLevel meets threshold)", () => {
@@ -121,7 +121,7 @@ describe("shadowGate.recommend — irreversible", () => {
     expect(d.owned).toBe(false);
     expect(d.effectiveLevel).toBe(0);
     expect(d.decision).toBe("queue");
-    expect(d.reason).toBe("outside-worker-domain");
+    expect(d.reason).toContain("outside the worker");
   });
 
   it("bypasses irreversible only at earned L4", () => {

--- a/src/workers/__tests__/shadowGateAgreement.test.ts
+++ b/src/workers/__tests__/shadowGateAgreement.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `shadowGate.recommend` must agree with `decideWorkerAction`.
+ *
+ * ## Why this test did not exist and should have
+ *
+ * `previewActions` has exactly this test, and CLAUDE.md explains why in terms
+ * that apply here word for word: a second copy of the decision "would drift,
+ * and the failure is silent and permissive". Preview got the treatment because
+ * it renders a screen. `shadowGate` never did, and it is arguably the more
+ * dangerous of the two — it is what `patchwork workers shadow` and
+ * `patchwork workers backtest` run, which the dogfood runbook calls the
+ * primary monitoring instrument for the trust ramp.
+ *
+ * A monitoring instrument that disagrees with the thing it monitors does not
+ * fail loudly. It reports a number, and the number is wrong.
+ *
+ * ## What diverged
+ *
+ * `shadowGate` reimplements the trust maths rather than calling the gate. It
+ * has the reversibility short-circuit and the autonomy ceiling, and it is
+ * missing both of the concepts added later:
+ *
+ *   - **`forbid`.** `decideWorkerAction` evaluates forbid rules FIRST, ahead
+ *     of everything including the reversibility short-circuit, precisely
+ *     because any branch that runs earlier is a path around the ban. Shadow
+ *     has no notion of it — so for a forbidden REVERSIBLE action it reports
+ *     `bypass`: the instrument says the ramp would let through an action that
+ *     is banned outright.
+ *   - **`contextCeiling`.** A live de-rater that can only lower the effective
+ *     level. Shadow ignores it, so it reports `bypass` where the gate would
+ *     hold.
+ *
+ * Both divergences run in the permissive direction, which is the direction
+ * that does not get noticed.
+ *
+ * ## What this test does NOT do
+ *
+ * It does not assert the two are the same function. They answer different
+ * questions — the gate returns three terminal states (`allow` / `gate` /
+ * `forbid`), shadow returns two (`bypass` / `queue`) because it predates the
+ * third. The mapping asserted here is the honest one:
+ *
+ *     gate allow  ⇒ shadow bypass
+ *     gate gate   ⇒ shadow queue
+ *     gate forbid ⇒ shadow MUST NOT say bypass
+ *
+ * A forbidden action reported as `bypass` is the failure worth failing on.
+ */
+
+import { describe, expect, it } from "vitest";
+import { recommend } from "../shadowGate.js";
+import type { WorkerManifest } from "../worker.js";
+import { decideWorkerAction } from "../workerGate.js";
+import type { WorkerLevelStore } from "../workerLevelStore.js";
+
+/** A store returning a fixed level for everything — the variable under test
+ *  is the decision logic, not the evidence maths. */
+function storeAt(level: number): WorkerLevelStore {
+  return {
+    getState: () => ({ level, alpha: 1, beta: 1, outcomes: [] }),
+  } as unknown as WorkerLevelStore;
+}
+
+const worker = (over: Partial<WorkerManifest> = {}): WorkerManifest =>
+  ({
+    id: "w1",
+    name: "test-worker",
+    owns: ["issue", "fs-write", "other"],
+    autonomyCeiling: 4,
+    ...over,
+  }) as WorkerManifest;
+
+/** Tools spanning the three reversibility classes. */
+/**
+ * Real classifications, read from `classifyActionClass` rather than assumed —
+ * the first draft of this test guessed the domains and the forbid rule matched
+ * nothing, so the case it existed to cover never ran.
+ */
+const TOOLS: Array<[string, Record<string, unknown> | undefined]> = [
+  ["github.search_issues", undefined], // other:irreversible:low
+  ["github.create_issue", { title: "x" }], // issue:compensable:high
+  ["git.push", { branch: "main" }], // other:irreversible:medium
+  ["file.write", { path: "notes/example.md", content: "y" }], // fs-write:REVERSIBLE:medium
+];
+
+const LEVELS = [0, 1, 2, 3, 4];
+const CEILINGS = [0, 2, 4];
+
+describe("shadowGate agrees with the live gate", () => {
+  it("maps allow/gate identically across levels, ceilings and tools", () => {
+    const mismatches: string[] = [];
+    for (const level of LEVELS) {
+      for (const ceiling of CEILINGS) {
+        const w = worker({ autonomyCeiling: ceiling as never });
+        const store = storeAt(level);
+        for (const [tool, params] of TOOLS) {
+          const live = decideWorkerAction(w, tool, params, store);
+          const shadow = recommend(w, tool, params, store);
+          const expected = live.action === "allow" ? "bypass" : "queue";
+          if (shadow.decision !== expected) {
+            mismatches.push(
+              `${tool} L${level}/C${ceiling}: gate=${live.action} shadow=${shadow.decision}`,
+            );
+          }
+        }
+      }
+    }
+    expect(mismatches, `divergences:\n  ${mismatches.join("\n  ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("NEVER reports bypass for an action the gate forbids", () => {
+    // The sharpest case: a forbidden REVERSIBLE action. Shadow's first branch
+    // short-circuits on reversibility and returns bypass without ever looking
+    // at a forbid rule, so the monitoring output says the ramp would let
+    // through something that is banned outright.
+    const w = worker();
+    const store = storeAt(4);
+    // `fs-write` is REVERSIBLE, which is the whole point: shadow returns
+    // bypass from its first branch without ever consulting a forbid rule.
+    const forbidRules = [
+      { match: "fs-write", reason: "banned in this test" },
+    ] as const;
+    const forbidden: string[] = [];
+    const mismatches: string[] = [];
+    for (const [tool, params] of TOOLS) {
+      const opts = { forbidRules } as never;
+      const live = decideWorkerAction(w, tool, params, store, opts);
+      if (live.action !== "forbid") continue;
+      forbidden.push(tool);
+      const shadow = recommend(w, tool, params, store, opts);
+      if (shadow.decision === "bypass") {
+        mismatches.push(`${tool}: gate=forbid shadow=bypass`);
+      }
+    }
+    // Without this the test passes by never entering the loop — which is
+    // exactly how its first draft passed while proving nothing.
+    expect(
+      forbidden.length,
+      "no action was forbidden — the case never ran",
+    ).toBeGreaterThan(0);
+    expect(
+      mismatches,
+      `forbidden actions reported as bypass:\n  ${mismatches.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("does not report bypass when a context ceiling de-rates the gate", () => {
+    // contextRisk can only LOWER the effective level. Shadow ignores it, so it
+    // reports the un-throttled answer while the gate holds.
+    const w = worker();
+    const store = storeAt(4);
+    const mismatches: string[] = [];
+    for (const [tool, params] of TOOLS) {
+      const opts = { contextRisk: { score: 0.95 } } as never;
+      const live = decideWorkerAction(w, tool, params, store, opts);
+      const shadow = recommend(w, tool, params, store, opts);
+      const expected = live.action === "allow" ? "bypass" : "queue";
+      if (shadow.decision !== expected) {
+        mismatches.push(
+          `${tool}: gate=${live.action} shadow=${shadow.decision}`,
+        );
+      }
+    }
+    expect(
+      mismatches,
+      `context-ceiling divergences:\n  ${mismatches.join("\n  ")}`,
+    ).toEqual([]);
+  });
+});

--- a/src/workers/shadowGate.ts
+++ b/src/workers/shadowGate.ts
@@ -1,6 +1,7 @@
 import { classifyActionClass } from "./actionClass.js";
 import type { TrustLevel } from "./trustLevel.js";
 import { ownsAction, type WorkerManifest } from "./worker.js";
+import { type AutonomyDecisionOpts, decideWorkerAction } from "./workerGate.js";
 import type { WorkerLevelStore } from "./workerLevelStore.js";
 
 /**
@@ -29,71 +30,63 @@ export interface ShadowDecision {
   /** What the gate would operate at: min(earned, ceiling), 0 if not owned. */
   effectiveLevel: TrustLevel;
   reason: string;
+  /**
+   * The gate FORBIDS this outright — no earned trust and no human approval
+   * unlocks it (ADR-0017's third terminal state).
+   *
+   * `decision` collapses to `queue` for a forbidden action because this type
+   * predates `forbid` and its two consumers count queue-vs-bypass. Collapsing
+   * without saying so would report a ban as an ordinary approval, so the fact
+   * is carried separately rather than lost.
+   */
+  forbidden: boolean;
 }
 
-const COMPENSABLE_AUTONOMY_LEVEL = 2;
-const AUTONOMOUS_LEVEL = 4;
-
+/**
+ * Delegates to `decideWorkerAction`. It used to reimplement the trust maths,
+ * and had drifted: it has the reversibility short-circuit and the autonomy
+ * ceiling, and never gained `forbid` or the context ceiling. Measured on a
+ * spread of tools and context scores, HALF the combinations disagreed — and
+ * every disagreement ran permissive, including reporting `bypass` for a
+ * forbidden reversible action.
+ *
+ * That matters more here than almost anywhere: this is what
+ * `patchwork workers shadow` and `patchwork workers backtest` run, which the
+ * dogfood runbook calls the primary instrument for watching the ramp. An
+ * instrument that disagrees with what it measures does not fail loudly — it
+ * reports a number, and the number is wrong.
+ *
+ * CLAUDE.md already states the rule, for `previewActions`: a second copy of
+ * the decision "would drift, and the failure is silent and permissive". Same
+ * rule, same reason. Not correct one copy — leave only one.
+ *
+ * The mapping is the honest one, and lossy in a stated direction:
+ *
+ *     gate allow  → bypass
+ *     gate gate   → queue
+ *     gate forbid → queue, with `forbidden: true`
+ */
 export function recommend(
   worker: WorkerManifest,
   toolName: string,
   params: Record<string, unknown> | undefined,
   store: WorkerLevelStore,
+  opts?: AutonomyDecisionOpts,
 ): ShadowDecision {
   const ac = classifyActionClass(toolName, params);
   const owned = ownsAction(worker, ac);
-
-  // Reversible actions always bypass — no trust threshold applies. Short-
-  // circuiting here prevents false divergence-log noise (the dial would
-  // otherwise compare against L4 and always report a "miss" for reads).
-  if (ac.reversibility === "reversible") {
-    const earnedLevel = (store.getState(worker.id, ac.key)?.level ??
-      0) as TrustLevel;
-    return {
-      decision: "bypass",
-      classKey: ac.key,
-      owned,
-      earnedLevel,
-      autonomyCeiling: worker.autonomyCeiling,
-      effectiveLevel: owned ? earnedLevel : (0 as TrustLevel),
-      reason: "reversible — flows un-gated regardless of earned level",
-    };
-  }
   const earnedLevel = (store.getState(worker.id, ac.key)?.level ??
     0) as TrustLevel;
-
-  let effectiveLevel: TrustLevel = owned ? earnedLevel : 0;
-  if (effectiveLevel > worker.autonomyCeiling)
-    effectiveLevel = worker.autonomyCeiling;
-
-  const decision: "bypass" | "queue" =
-    ac.reversibility === "compensable"
-      ? effectiveLevel >= COMPENSABLE_AUTONOMY_LEVEL
-        ? "bypass"
-        : "queue"
-      : effectiveLevel >= AUTONOMOUS_LEVEL
-        ? "bypass"
-        : "queue";
-
-  const threshold =
-    ac.reversibility === "compensable"
-      ? COMPENSABLE_AUTONOMY_LEVEL
-      : AUTONOMOUS_LEVEL;
-  let reason: string;
-  if (!owned) reason = "outside-worker-domain";
-  else if (worker.autonomyCeiling < threshold)
-    reason = `capped-by-autonomy-ceiling (L${worker.autonomyCeiling} < L${threshold}, earned L${earnedLevel})`;
-  else if (decision === "bypass")
-    reason = `autonomous (earned L${effectiveLevel}, threshold L${threshold})`;
-  else reason = `below-autonomy (effective L${effectiveLevel} < L${threshold})`;
+  const decided = decideWorkerAction(worker, toolName, params, store, opts);
 
   return {
-    decision,
+    decision: decided.action === "allow" ? "bypass" : "queue",
+    forbidden: decided.action === "forbid",
     classKey: ac.key,
     owned,
     earnedLevel,
     autonomyCeiling: worker.autonomyCeiling,
-    effectiveLevel,
-    reason,
+    effectiveLevel: decided.effectiveLevel ?? (owned ? earnedLevel : 0),
+    reason: decided.reason,
   };
 }


### PR DESCRIPTION
`shadowGate.recommend` reimplemented the trust maths instead of calling `decideWorkerAction`. It had the reversibility short-circuit and the autonomy ceiling, and never gained either concept added afterwards: **`forbid`** or the **context ceiling**.

CLAUDE.md already states this rule, for `previewActions`: a second copy of the decision *"would drift, and the failure is silent and permissive"*, and a test asserts preview and gate agree. Preview got that treatment because it renders a screen. This never did — and it's the more consequential of the two, because it's what `patchwork workers shadow` and `patchwork workers backtest` run, which the dogfood runbook calls **the primary instrument for watching the ramp**.

An instrument that disagrees with what it measures doesn't fail loudly. It reports a number, and the number is wrong.

## Measured before deciding what to do

Across four tools and four context-risk scores: **8 of 16 combinations diverged.** Every divergence ran **permissive** — shadow said `bypass` where the gate would hold.

The sharpest case is a **forbidden reversible** action (`file.write` → `fs-write:reversible:medium`). Shadow's first branch short-circuits on reversibility and returns `bypass` without ever consulting a forbid rule — so the monitoring output reported that the ramp would let through an action banned outright. `forbid` is evaluated *first* in the live gate precisely because any branch running earlier is a path around the ban; shadow had exactly such a branch.

## The fix

`recommend` delegates. Not *correct one copy* — **leave only one**.

```
gate allow  → bypass
gate gate   → queue
gate forbid → queue, with a new `forbidden: true` on ShadowDecision
```

Lossy in a stated direction: `decision` stays queue/bypass because the type predates the third terminal state and its two consumers count those values. Collapsing a ban into "queued for approval" without saying so would misreport it, so the fact is carried separately rather than dropped.

## Runtime behaviour today is unchanged

`recommend` now accepts the same `AutonomyDecisionOpts` and passes them through. **No caller passes any yet**, and `decideWorkerAction` with absent opts is byte-identical to the pre-forbid gate — so `workers shadow` and `workers backtest` produce the same decisions as before. What changes is that they can no longer drift, and threading opts through the callers now makes both sides agree instead of one side silently ignoring them.

## One visible change

`reason` is now the **gate's** wording rather than a parallel phrasing maintained here — `"earned autonomy (L2) on compensable class — auto-allowed at L2+"` instead of `"autonomous (earned L2, threshold L2)"`. Four existing assertions updated. That's the intended direction: a monitoring instrument should quote what the gate said, and a second vocabulary for the same decision is the drift this removes.

## Verified by making it fail

Reverted `shadowGate.ts` to `HEAD` with the agreement test in place → **2 red**, naming `file.write: gate=forbid shadow=bypass` and three context-ceiling divergences. Restored → 3 green.

Worth recording: **the first draft of the forbid test passed while proving nothing** — it used `pattern` where the rule field is `match`, so no action was ever forbidden and the loop body never ran. It now asserts the case actually occurred before asserting anything about it.

260 tests green across `src/workers`, 307 with the orchestration consumers. The repo's own fixture audit caught a literal `/tmp` path in the new test; fixed rather than allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)