### PR TITLE
fix(workers): the shadow gate now honours the worker's own forbids

### DIFF
--- a/src/workers/__tests__/shadowGateAgreement.test.ts
+++ b/src/workers/__tests__/shadowGateAgreement.test.ts
@@ -168,4 +168,38 @@ describe("shadowGate agrees with the live gate", () => {
       `context-ceiling divergences:\n  ${mismatches.join("\n  ")}`,
     ).toEqual([]);
   });
+
+  it("honours the worker's OWN forbids with no opts passed", () => {
+    // The case that makes the delegation matter in production. Neither
+    // `workers shadow` nor `workers backtest` passes opts, so if the rules
+    // were not derived from the manifest the instrument would go on reporting
+    // a banned action as one the ramp would let through — which is what it
+    // did.
+    const w = worker({
+      forbids: [{ match: "fs-write", reason: "declared on the manifest" }],
+    } as never);
+    const shadow = recommend(
+      w,
+      "file.write",
+      { path: "notes/example.md", content: "y" },
+      storeAt(4),
+    );
+    expect(shadow.forbidden).toBe(true);
+    expect(shadow.decision).toBe("queue");
+  });
+
+  it("still bypasses a reversible action the manifest does NOT forbid", () => {
+    // The other direction, so the fallback cannot be "forbid everything".
+    const w = worker({
+      forbids: [{ match: "payments", reason: "unrelated" }],
+    } as never);
+    const shadow = recommend(
+      w,
+      "file.write",
+      { path: "notes/example.md", content: "y" },
+      storeAt(0),
+    );
+    expect(shadow.forbidden).toBe(false);
+    expect(shadow.decision).toBe("bypass");
+  });
 });

--- a/src/workers/shadowGate.ts
+++ b/src/workers/shadowGate.ts
@@ -1,4 +1,5 @@
 import { classifyActionClass } from "./actionClass.js";
+import { parseForbidRules } from "./forbidPolicy.js";
 import type { TrustLevel } from "./trustLevel.js";
 import { ownsAction, type WorkerManifest } from "./worker.js";
 import { type AutonomyDecisionOpts, decideWorkerAction } from "./workerGate.js";
@@ -65,6 +66,17 @@ export interface ShadowDecision {
  *     gate allow  → bypass
  *     gate gate   → queue
  *     gate forbid → queue, with `forbidden: true`
+ *
+ * Forbid rules default to the worker's own `forbids:` when the caller supplies
+ * none — the same fallback `boundaryPreview` makes, for the same reason it
+ * gives: without it the manifest field is inert, and the instrument would go
+ * on reporting a banned action as one the ramp would let through. Neither
+ * caller passes rules today, so this is what actually makes the delegation
+ * change anything.
+ *
+ * `contextRisk` has no such fallback and cannot: it is live and situational,
+ * not declared. A caller that has it passes it; one that does not gets the
+ * un-throttled answer, which is the honest reading of "no context supplied".
  */
 export function recommend(
   worker: WorkerManifest,
@@ -77,7 +89,12 @@ export function recommend(
   const owned = ownsAction(worker, ac);
   const earnedLevel = (store.getState(worker.id, ac.key)?.level ??
     0) as TrustLevel;
-  const decided = decideWorkerAction(worker, toolName, params, store, opts);
+  const forbidRules =
+    opts?.forbidRules ?? parseForbidRules(worker.forbids).rules;
+  const decided = decideWorkerAction(worker, toolName, params, store, {
+    ...opts,
+    ...(forbidRules.length > 0 ? { forbidRules } : {}),
+  });
 
   return {
     decision: decided.action === "allow" ? "bypass" : "queue",


### PR DESCRIPTION
Completes #1299. That change made `recommend` delegate to `decideWorkerAction` and accept the same opts — but noted that **no caller passes any**, so the runtime output was unchanged. This is the half that makes it change.

## The rules were always available

Forbid rules are declared on the worker manifest (`forbids:`), and both consumers — `workers shadow` and `workers backtest` — already hold the manifest. So they're derived from it when the caller supplies none: the same fallback `boundaryPreview` makes, for the reason it states — *without it the manifest field is inert and the "not permitted" case can never occur in the running product.*

Before this, a worker could declare `forbids: [{ match: "fs-write" }]` and `patchwork workers shadow` would still report **`bypass`** for a reversible fs-write — the instrument telling an operator the ramp would let through an action their own manifest bans.

## `contextRisk` gets no fallback, deliberately

It's **live and situational, not declared**. There is nowhere to derive it from. A caller that has it passes it; one that doesn't gets the un-throttled answer, which is the honest reading of "no context supplied" rather than a guess.

## This is a behaviour change

`workers shadow` and `workers backtest` output changes for any worker with a `forbids:` entry — those actions now show as not-bypassing, with `forbidden: true`. In the direction of no longer misreporting, but worth stating plainly rather than burying.

## Verified by making it fail

Reverted `shadowGate.ts` with the new tests in place → the manifest-forbids case red. Restored → 5 green, **262 across `src/workers`**.

The second new test asserts the fallback does **not** forbid something the manifest leaves alone, so it can't degenerate into "forbid everything" — a fallback that over-blocks would look like a pass on the first test.

Two of my own mistakes, both caught by running it: the first draft called `recommend` without its `store` argument, and an earlier edit left a stray brace that made the file parse as **zero tests** rather than as a failure — which would have read as success in a hurried glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)