### PR TITLE
docs: the architecture doc claimed a guarantee the code does not give

### DIFF
--- a/documents/architecture.md
+++ b/documents/architecture.md
@@ -74,13 +74,22 @@ The five primitives from the [canonical positioning sentence](../README.md) line
 | *hot-reloadable tools* | Tool Registry | The `--plugin-watch` flag re-registers atomically on plugin file changes |
 | *YAML recipes* | Recipe Engine | RecipeOrchestrator + parser + scheduler |
 | *delegation policy with approval queue* | Delegation Policy (gate-shaped) | Every tool dispatch passes through this — it's a structural checkpoint, not a sidecar |
-| *durable trace memory* | Trace Memory (cylinder) | Three log files under `~/.patchwork/` plus the activity log under `~/.claude/ide/` |
+| *durable trace memory* | Trace Memory (cylinder) | Append-only JSONL under `~/.patchwork/` — runs, decision traces, approvals, gate decisions, permissions and their exercises, effects, file rollback, outcomes, facts, commit↔issue links — plus the activity log under `~/.claude/ide/` |
 
 ## Five things to notice
 
-1. **Every outbound action passes through the policy gate.** The arrow from Tool Registry to External Targets does *not* exist as a direct edge — it goes through Delegation Policy first. This is the structural invariant that makes "delegation policy" load-bearing rather than decorative. See [src/approvalHttp.ts](../src/approvalHttp.ts) for the implementation.
+1. **Every outbound action passes through the policy checkpoint — but "checkpoint" is two different things, and only one of them is on by default.**
 
-2. **Trace Memory is the only multi-source sink.** Tool calls, policy decisions, and recipe runs all write to the same trace store. That's what makes [`patchwork traces export`](../src/commands/tracesExport.ts) a single bundle and what makes the Decision Replay Debugger possible.
+   The arrow from Tool Registry to External Targets does *not* exist as a direct edge. What sits on it:
+
+   - **Path and tool policy (`checkPolicy`) runs unconditionally** on all dispatch paths — [src/bridge.ts](../src/bridge.ts), [src/streamableHttp.ts](../src/streamableHttp.ts). This is the structural invariant, and it holds.
+   - **Human approval does not.** `approvalGate` defaults to `"off"` ([src/config.ts](../src/config.ts)), and with it off [src/approvalHttp.ts](../src/approvalHttp.ts) returns `allow` with reason `gate_off` before any tier or content check. A default install queues nothing for a person.
+
+   This paragraph previously said the whole gate was a structural invariant. It is the claim in this document most likely to be repeated somewhere it matters, and for human approval it was not true — an operator reading it would believe a default install asks before acting. It does not, by design: a laptop that halts on every action is unusable. The design is right; the sentence was wrong.
+
+   Turning it on is `approvalGate: "high" | "all"` in `~/.patchwork/config.json`.
+
+2. **Trace Memory is where the evidence lands, but it is not one file.** Tool calls, policy decisions and recipe runs are written by separate append-only logs that share a directory and a format, not a single store — `runs.jsonl`, `decision_traces.jsonl`, `worker_gate_decisions.jsonl`, `approval_log.jsonl` and the rest. The cylinder in the diagram is a category, not a filename. (An earlier version of this line said "the only multi-source sink", which reads as a single file and is not what is on disk.) That's what makes [`patchwork traces export`](../src/commands/tracesExport.ts) a single bundle and what makes the Decision Replay Debugger possible.
 
 3. **Triggers are inputs, not outputs.** Cron, file save, git, test run, webhook, CLI, and the mobile PWA all enter at the same point — the Recipe Engine. The trigger surface is the *non-developer onboarding* story; recipes don't care which trigger fired them.
 

--- a/scripts/audit-docs-drift.mjs
+++ b/scripts/audit-docs-drift.mjs
@@ -289,9 +289,55 @@ function auditToolCountAcrossDocs(actual) {
   }
 }
 
+/**
+ * The documented default for `approvalGate` must match the code.
+ *
+ * `documents/architecture.md` claimed every outbound action passes through the
+ * policy gate as a "structural invariant". Human approval does not: the gate
+ * defaults to "off" and returns `allow` before any tier check. An operator
+ * reading that sentence would believe a default install asks before acting.
+ *
+ * The sentence is fixed. This is here so the SAME sentence cannot go stale the
+ * other way — flip the default in config.ts and the doc silently becomes wrong
+ * again, in the direction that overstates safety. Cheap to check, and the
+ * failure mode is a security claim, which is the kind worth spending a gate on.
+ */
+function auditApprovalGateDefault() {
+  const config = read("src/config.ts");
+  const m =
+    /approvalGate\?:\s*"off"\s*\|\s*"high"\s*\|\s*"all"\s*\}\)\.approvalGate\s*\?\?\s*"(\w+)"/.exec(
+      config,
+    );
+  if (!m) {
+    drift.push(
+      "approval-gate: could not read the approvalGate default from src/config.ts — this check needs updating, not deleting.",
+    );
+    return;
+  }
+  const actual = m[1];
+  const doc = read("documents/architecture.md");
+  const claimed = /`approvalGate`\s+defaults\s+to\s+`"(\w+)"`/.exec(doc);
+  if (!claimed) {
+    drift.push(
+      "approval-gate: documents/architecture.md no longer states the approvalGate default. It described the gate as a structural invariant while human approval was off by default; the statement of the real default must stay.",
+    );
+    return;
+  }
+  if (claimed[1] !== actual) {
+    drift.push(
+      `approval-gate: documents/architecture.md says the default is "${claimed[1]}", src/config.ts says "${actual}".`,
+    );
+    return;
+  }
+  notes.push(
+    `approval-gate: documented default "${actual}" matches src/config.ts`,
+  );
+}
+
 // ── run ──────────────────────────────────────────────────────────────────────
 
 auditToolCount();
+auditApprovalGateDefault();
 auditCoverageThresholds();
 auditPluginApiDrift();
 


### PR DESCRIPTION
Two claims in `documents/architecture.md` that the code contradicts. The first is the one worth caring about.

## "Every outbound action passes through the policy gate"

Stated as *"the structural invariant that makes delegation policy load-bearing rather than decorative"*. Half of it is true and half is not, and the document didn't distinguish them:

- **Path and tool policy (`checkPolicy`) does run unconditionally** on all dispatch paths ([bridge.ts](src/bridge.ts), [streamableHttp.ts](src/streamableHttp.ts)). That invariant holds.
- **Human approval does not.** `approvalGate` defaults to `"off"` ([config.ts:649-651](src/config.ts#L649-L651)), and with it off [approvalHttp.ts:1107-1109](src/approvalHttp.ts#L1107-L1109) returns `allow` with reason `gate_off` **before any tier or content check**. A default install queues nothing for a person.

An operator reading that paragraph would believe a default install asks before acting. It doesn't — **by design**, because a laptop that halts on every action is unusable. The design is right; the sentence was wrong, and it's the claim in this document most likely to be repeated somewhere it matters.

Rewritten to separate the two, name the real default, and say how to turn approval on.

## "Three log files" and "the only multi-source sink"

There are **thirteen** production JSONL stores under `~/.patchwork`, not three. "The only multi-source sink" also reads as a single file, which isn't what's on disk.

Corrected **without stating a count**. A number in prose rots — that's the entire lesson of the 13 files carrying a stale tool count this week (#1293) — so the row names the stores instead, and the cylinder is described as a category rather than a filename.

## A gate, not just a correction

`audit-docs-drift.mjs` now checks the documented `approvalGate` default against `src/config.ts`. Fixing the sentence stops today's error; this stops the class. If someone flips the default — or deletes the sentence stating it — the build fails. The failure mode this guards is **a security claim that overstates safety**, which is the kind worth spending a gate on.

## Verified by making it fail, both ways

| Probe | Result |
|---|---|
| Flip the code default to `"high"`, doc unchanged | exit 1 — *says the default is "off", src/config.ts says "high"* |
| Remove the statement from the doc | exit 1 — *no longer states the approvalGate default* |
| Restored | clean |

**A near-miss worth recording:** the first version of the first probe was a **no-op** — it used a single-line pattern where `?? "off"` sits on the next line, so the edit never applied and the check "passed" without being tested. The probe now asserts its own anchor exists before editing.

## Deliberately not changed

**The default itself.** Whether approval should be on out of the box is a product decision, not a documentation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)