### PR TITLE
fix(docs): the quickstart told users to run a command that does not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,13 @@ jobs:
       # accident, months later. Nothing was going to report it.
       - name: Audit real IP literals (gating)
         run: node scripts/audit-real-ips.mjs
+      # The README's hero block told a new user to run `patchwork connections
+      # connect gmail`. There is no `connections` verb — the second command in
+      # the 90-second start failed for everyone who followed it, and no gate
+      # could see it: docs-drift checks numbers, docs-wired checks features,
+      # neither checks whether an advertised command dispatches.
+      - name: Audit advertised CLI commands (gating)
+        run: node scripts/audit-cli-commands.mjs
       # Inbound licence position. LICENSE-THIRD-PARTY.md was three lines
       # covering connector glyphs while the four workspaces ship 327
       # production packages between them. An MIT project asserting an

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Prereqs: Node 22+. macOS, Linux, and native Windows (no WSL).
 The hero workflow — Morning Brief:
 
 ```bash
-patchwork connections connect gmail
-patchwork connections connect google-calendar
+patchwork init --with-connectors   # seeds the connector-backed recipes too
+patchwork connect gmail
+patchwork connect google-calendar
 patchwork recipe run morning-brief
 ```
 

--- a/examples/recipes/advanced-patterns/README.md
+++ b/examples/recipes/advanced-patterns/README.md
@@ -27,7 +27,7 @@ topologies in Patchwork.
 Requires: `--driver subprocess` (or `api`), `file-mcp`, `notify-mcp`.
 
 ```bash
-patchwork run multi-agent-research --question "What are the main failure modes of solo founder companies?"
+patchwork recipe run multi-agent-research --question "What are the main failure modes of solo founder companies?"
 ```
 
 ---

--- a/scripts/audit-cli-commands.mjs
+++ b/scripts/audit-cli-commands.mjs
@@ -1,0 +1,176 @@
+/**
+ * Every `patchwork <verb>` in tracked documentation must be a real verb.
+ *
+ * ## Why this exists
+ *
+ * The README's hero block — the second thing a new user runs, in a section
+ * titled "90-second start" — said:
+ *
+ *     patchwork connections connect gmail
+ *
+ * There is no `connections` verb. The CLI answers
+ * `Unknown command: 'connections'. Did you mean: connect?` and stops. Someone
+ * following the quickstart hit that on their second command.
+ *
+ * Nothing could have caught it. The docs-drift gate checks numeric claims,
+ * `audit-docs-wired` checks that documented FEATURES exist, and neither looks
+ * at whether an advertised command dispatches. A wrong number in a doc is
+ * embarrassing; a wrong command in the quickstart is the first impression.
+ *
+ * ## The verb list is read, not restated
+ *
+ * `KNOWN_SUBCOMMANDS` in `src/index.ts` is what the dispatcher itself matches
+ * against — the same array that produces the "Did you mean" suggestion. Any
+ * list maintained here would be a second copy that drifts, which is the bug
+ * this repository keeps finding in itself.
+ *
+ * Read statically rather than by running the CLI: this needs no build, so it
+ * cannot silently pass by checking a stale `dist/`.
+ *
+ * ## What is checked
+ *
+ * Fenced code blocks only. Prose says things like "the connections page" and
+ * "patchwork will connect", and matching those produces noise that gets the
+ * check switched off. A command in a fenced block is an instruction someone
+ * will paste.
+ *
+ * Flags, paths and sub-verbs are ignored — only the FIRST word after
+ * `patchwork` is checked. Whether `recipe run` is a valid sub-verb of `recipe`
+ * is a deeper question this deliberately does not answer; the failure it
+ * exists for is a top-level verb that does not exist at all.
+ *
+ * Usage:  node scripts/audit-cli-commands.mjs
+ * Exit:   0 clean · 1 unknown verb advertised · 2 script error
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+/** Documents that record what a command used to be. */
+const HISTORICAL = [
+  /^CHANGELOG\.md$/,
+  /^docs\/migration\.md$/, // by definition documents older invocations
+  /^docs\/dogfood\//,
+  /^docs\/plans\//,
+  /-\d{4}-\d{2}-\d{2}\.md$/,
+];
+
+/**
+ * `patchwork <verb>` where it STARTS a command — at the beginning of a line,
+ * after a `$` prompt, or after a shell operator.
+ *
+ * A bare `\bpatchwork\s+(\w+)` was the first attempt and it was unusable. It
+ * matched `npm install -g patchwork-os typescript-language-server`, reporting
+ * `typescript-language-server` as an unknown verb, and a diagram line reading
+ * `launchd → patchwork bridge (node) → claude CLI`. Neither is something a
+ * reader would paste. A check whose output is mostly its own noise gets
+ * switched off, and then it guards nothing.
+ */
+const INVOCATION =
+  /(?:^|[$;|]|&&|\|\|)\s*(?:npx\s+)?patchwork(?:-os)?(?:@[\w.-]+)?\s+([a-z][a-z0-9-]*)/g;
+
+/**
+ * Words that follow the binary name but are not verbs: global flags, and the
+ * bare-binary forms. `--workspace` is documented as `patchwork --workspace .`,
+ * which is correct and has no subcommand.
+ */
+const NOT_A_VERB = new Set(["is", "will", "can", "and", "or", "the", "to"]);
+
+function knownSubcommands() {
+  const src = readFileSync(path.join(root, "src/index.ts"), "utf8");
+  const start = src.indexOf("const KNOWN_SUBCOMMANDS = [");
+  if (start === -1) {
+    console.error(
+      "[cli-commands] could not find KNOWN_SUBCOMMANDS in src/index.ts — this check needs updating, not deleting.",
+    );
+    process.exit(2);
+  }
+  const end = src.indexOf("]", start);
+  const block = src.slice(start, end);
+  const verbs = Array.from(block.matchAll(/"([a-z][a-z0-9-]*)"/g), (m) => m[1]);
+  if (verbs.length < 5) {
+    console.error(
+      `[cli-commands] parsed only ${verbs.length} subcommands — the array shape changed.`,
+    );
+    process.exit(2);
+  }
+  return new Set(verbs);
+}
+
+function trackedMarkdown() {
+  return execFileSync("git", ["ls-files", "*.md"], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  })
+    .split("\n")
+    .filter(Boolean)
+    .filter((f) => !HISTORICAL.some((re) => re.test(f)));
+}
+
+/** Lines inside ``` fences, with their 1-based line numbers. */
+function fencedLines(text) {
+  const out = [];
+  let inFence = false;
+  text.split("\n").forEach((line, i) => {
+    if (line.trimStart().startsWith("```")) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence) out.push({ line, n: i + 1 });
+  });
+  return out;
+}
+
+function main() {
+  const known = knownSubcommands();
+  const files = trackedMarkdown();
+  const bad = [];
+  let checked = 0;
+
+  for (const file of files) {
+    let text;
+    try {
+      text = readFileSync(path.join(root, file), "utf8");
+    } catch {
+      continue;
+    }
+    for (const { line, n } of fencedLines(text)) {
+      // A comment in a shell block is prose.
+      const code = line.split("#")[0] ?? "";
+      for (const m of code.matchAll(INVOCATION)) {
+        const verb = m[1];
+        if (!verb || verb.startsWith("-") || NOT_A_VERB.has(verb)) continue;
+        checked++;
+        if (!known.has(verb)) bad.push({ file, n, verb, line: line.trim() });
+      }
+    }
+  }
+
+  console.log(
+    `[cli-commands] ${checked} invocation(s) in ${files.length} tracked markdown files · ${known.size} known verbs`,
+  );
+
+  if (bad.length === 0) {
+    console.log("[cli-commands] OK — every advertised command exists.");
+    process.exit(0);
+  }
+
+  console.error(`\n[cli-commands] FAIL — ${bad.length} unknown verb(s):\n`);
+  for (const b of bad) {
+    console.error(`  ${b.file}:${b.n}  patchwork ${b.verb}\n    ${b.line}`);
+  }
+  console.error(
+    "\nThe verb does not exist, so this command fails for anyone who runs it.\n" +
+      "Fix the doc, or add the subcommand. `KNOWN_SUBCOMMANDS` in src/index.ts\n" +
+      "is the list the dispatcher matches against.\n",
+  );
+  process.exit(1);
+}
+
+main();

--- a/templates/policies/README.md
+++ b/templates/policies/README.md
@@ -44,7 +44,8 @@ jq -s '.[0] * (.[1] | with_entries(select(.key | startswith("_") | not)))' \
 ### Restart
 
 ```sh
-patchwork stop
+# Restart the bridge so it picks up the change
+# (Ctrl-C the running process, then:)
 patchwork start
 ```
 

--- a/templates/recipes/webhook/README.md
+++ b/templates/recipes/webhook/README.md
@@ -21,7 +21,8 @@ file is a copy-and-adjust starting point.
 
 ```sh
 cp templates/recipes/webhook/capture-thought.yaml ~/.patchwork/recipes/
-patchwork stop
+# Restart the bridge so it picks up the change
+# (Ctrl-C the running process, then:)
 patchwork start
 ```
 


### PR DESCRIPTION
## The bug

README's hero block — the section titled **"90-second start"** — said:

```bash
patchwork connections connect gmail
patchwork connections connect google-calendar
```

There is no `connections` verb. The CLI answers `Unknown command: 'connections'. Did you mean: connect?` and stops. **Anyone following the quickstart hit that on their second command.**

The same block then ran `patchwork recipe run morning-brief`, which a default `init` does not seed — `morning-brief.yaml` isn't in `LOCAL_ONLY_RECIPES` ([patchworkInit.ts:41-47](src/commands/patchworkInit.ts#L41-L47)), so it's gated out unless `--with-connectors` is passed, and the README never mentioned the flag. **So the third command failed too, differently.**

Three more found by the gate: `patchwork run <recipe>` (→ `recipe run`) and two `patchwork stop` (no such verb).

## Nothing could have caught this

`audit-docs-drift` checks numeric claims. `audit-docs-wired` checks that documented *features* exist. Neither looks at whether an advertised **command dispatches**. A stale number is embarrassing; a broken command in the quickstart is the first impression — and it had been wrong long enough that nobody following the README could reach step three.

`scripts/audit-cli-commands.mjs` reads `KNOWN_SUBCOMMANDS` from `src/index.ts` — the array the dispatcher matches against, and the same one that produces the "Did you mean" suggestion. A list maintained in the gate would be a second copy that drifts, which is the bug this repo keeps finding in itself. Read **statically**, so it needs no build and can't pass by checking a stale `dist/`.

## Calibrated by running it

The first version matched any `patchwork <word>` and was unusable — it flagged `npm install -g patchwork-os typescript-language-server` (reporting the language server as an unknown verb) and a diagram line reading `launchd → patchwork bridge (node) → claude CLI`. Neither is something a reader pastes.

It now requires the invocation to **start a command** — line start, after a `$` prompt, or after a shell operator. That took 9 findings down to 3, all real.

Deliberately does **not** validate sub-verbs. Whether `recipe run` is valid under `recipe` is a deeper question; the failure this exists for is a top-level verb that doesn't exist at all.

## Verified by making it fail

| Probe | Result |
|---|---|
| Reintroduce the exact README line | exit 1 — `README.md:41 patchwork connections` |
| An `npm install -g patchwork-os …` line | silent |
| The same words in prose outside a fence | silent |

All ten gating audits pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)