### PR TITLE
chore(identity): drop a capability this runtime cannot enforce

### DIFF
--- a/src/identity/__tests__/identity.test.ts
+++ b/src/identity/__tests__/identity.test.ts
@@ -45,9 +45,23 @@ function member(over: Partial<Member> = {}): Member {
 describe("roles", () => {
   it("owner holds every capability", () => {
     const caps = capabilitiesFor(["owner"]);
-    expect(caps.has("billing.manage")).toBe(true);
+    expect(caps.has("systems.manage")).toBe(true);
     expect(caps.has("action.approve")).toBe(true);
     expect(caps.has("policy.manage")).toBe(true);
+  });
+
+  it("names no commercial capability", () => {
+    // A gate, not a note. `billing.manage` was declared here with no
+    // implementing code and no enforcement point; a plan or an invoice is a
+    // property of an organisation, which ADR-0019 scopes to the control plane,
+    // not to this single-tenant runtime. The failure mode is quiet — such a
+    // capability reads to a reviewer as a control that exists — so the tree is
+    // asserted rather than the habit trusted.
+    const commercial = /billing|invoice|plan|price|pricing|tier|subscription/i;
+    const offenders = [...capabilitiesFor(["owner"])].filter((c) =>
+      commercial.test(c),
+    );
+    expect(offenders).toEqual([]);
   });
 
   it("auditor can read and can change nothing", () => {
@@ -63,11 +77,6 @@ describe("roles", () => {
     expect(roleGrants(["admin"], "policy.manage")).toBe(true);
     expect(roleGrants(["admin"], "members.manage")).toBe(true);
     expect(roleGrants(["admin"], "action.approve")).toBe(false);
-  });
-
-  it("admin does not get billing.manage", () => {
-    expect(roleGrants(["admin"], "billing.manage")).toBe(false);
-    expect(roleGrants(["owner"], "billing.manage")).toBe(true);
   });
 
   it("operator may propose but not approve", () => {
@@ -369,7 +378,7 @@ describe("resolvePrincipal", () => {
     // do everything — but now with a name a record can hold.
     const p = resolvePrincipal(loadRoster("/nonexistent/members.json"));
     expect(p?.id).toBe(IMPLICIT_OWNER_ID);
-    expect(principalCan(p, "billing.manage")).toBe(true);
+    expect(principalCan(p, "policy.manage")).toBe(true);
   });
 
   it("refuses an anonymous caller once a real roster exists", () => {

--- a/src/identity/roles.ts
+++ b/src/identity/roles.ts
@@ -21,7 +21,7 @@
  *    single-admin workspace to choose between administering and approving, and
  *    the usual workaround is to quietly grant `admin` the approve capability —
  *    which destroys the separation the roles exist to express.
- *  - **Capabilities are coarse.** Nine of them, not fifty. A permission model
+ *  - **Capabilities are coarse.** Eight of them, not fifty. A permission model
  *    nobody can hold in their head gets bypassed, and the audience for this one
  *    includes a controller and a security reviewer, not only an engineer.
  */
@@ -64,9 +64,16 @@ export type Capability =
   /** Change what the workspace permits — limits, ceilings, forbidden actions. */
   | "policy.manage"
   /** Connect and disconnect external systems, and hold their credentials. */
-  | "systems.manage"
-  /** Plan, payment method, invoices. */
-  | "billing.manage";
+  | "systems.manage";
+// Deliberately absent: a billing capability. A plan, a payment method and an
+// invoice are properties of an *organisation*, and this runtime is single-tenant
+// — one bridge, one workspace, one user — so there is nothing here for such a
+// capability to govern and no code that could enforce it. ADR-0019 puts
+// organisation-scoped concerns in `patchwork-control-plane`; that is where a
+// billing authority belongs, next to the identity it would be scoped to. A
+// capability naming an outcome its runtime cannot produce is worse than a
+// missing one: it reads as a control that exists. See the roles test for the
+// gate that keeps this from being re-added by habit.
 
 const ALL: readonly Capability[] = [
   "workspace.read",
@@ -77,7 +84,6 @@ const ALL: readonly Capability[] = [
   "members.manage",
   "policy.manage",
   "systems.manage",
-  "billing.manage",
 ];
 
 /**


### PR DESCRIPTION
`billing.manage` was declared in the `Capability` union with no implementing code and no enforcement point anywhere in the tree. The only references were its own declaration and four test assertions.

**Why remove it.** Not ADR-0019's pricing clause — the capability leaked no prices, tiers or plan names, so that argument is the weak one. The decisive point is ADR-0019 lines 91-93: *organisation-scoped* concerns belong in the control plane. A plan, a payment method and an invoice are properties of an organisation, and this repo is the single-tenant runtime — one bridge, one workspace, one user. There is nothing here for the capability to govern. So it was never role completeness: it named an outcome its runtime cannot produce, which reads to a reviewer as a control that exists.

**A gate, not a note.** The habit that added it will recur, so the roles test now asserts that no capability name matches commercial vocabulary.

**Proof the gate can fail:** re-added `billing.manage` and the new test went red (`expected [ 'billing.manage' ] to deeply equal []`); restored, green. The probe asserted its own anchor first, so a silent no-op could not have passed as green.

**Scope.** No runtime behaviour changes — nothing consulted this capability. The `admin does not get billing.manage` case is dropped rather than rewritten, because the segregation point it guarded is already covered by the `action.approve` case directly above it. Header capability count corrected nine → eight.

**Deliberately NOT changed:** `docs/design/cost-aware-routing.md:133` states "cross-recipe / centralized billing is reserved for Pro" — an OSS-vs-Pro packaging statement, which is closer to ADR-0019's pricing clause than `billing.manage` ever was. Separate call, left alone.

Gates run locally: tests core tsc · audit-test-fixtures · audit-lsp-tools · biome · vitest src/identity (45 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)