### PR TITLE
docs: public docs quoted a plan the reader cannot buy here

### DIFF
--- a/docs/design/cost-aware-routing.md
+++ b/docs/design/cost-aware-routing.md
@@ -1,6 +1,6 @@
 # Design: Cross-driver cost-aware model routing
 
-**Status:** ACCEPTED (direction) — Phase 0 in progress. Two product decisions made 2026-06-03: estimation is **warn-only** (`estimateUnmeasured` defaults to `false`); a local per-recipe `usdMax` **ships free in OSS core**. (The implementing ADR is written in the final phase.)
+**Status:** ACCEPTED (direction) — Phase 0 in progress. Two product decisions made 2026-06-03: estimation is **warn-only** (`estimateUnmeasured` defaults to `false`); a local per-recipe `usdMax` **ships in this repository**. (The implementing ADR is written in the final phase.)
 **Date:** 2026-06-03
 **Author:** generated from a grounded design workflow (6 subsystem maps → 3 independent design stances → adversarial critique → synthesis), then fact-checked against source.
 
@@ -121,7 +121,7 @@ Opt-in (absent config ⇒ byte-identical) · composes with judge→refine (route
 - **Phase 1 — driver token fidelity.** Make API drivers report tokens; `makeProviderDriverFn` returns `AgentResult`. **One behavior shift to changelog:** recipes that *already* set `tokensMax` AND use openai/grok/gemini start being measured (they fail open today) and could begin halting — a scoped correctness fix.
 - **Phase 2 — static price table asset.** `priceTable.json` + loader + override precedence + CI staleness ratchet. Consumed by nobody yet; lands so prices can be reviewed for accuracy independently.
 - **Phase 3 — `budget.usdMax` enforcement (the headline).** Extend `RunBudget` in place; add `usdMax` + `estimateUnmeasured` (default **false**) to schema/validation/parser; reuse `budget_exceeded`; dashboard renders `$`/`≈$`. **This alone closes the deferred-usdMax gap and is a reasonable stopping point if routing is descoped.**
-- **Phase 4 — opt-in per-step `downshift` routing.** Add the field + pure `costRouter`, wire at both agent sites, cross-field validation mirroring #859, parser passthrough. **+ write the ADR** (price-table source/refresh, fail-open USD semantics, estimate-warns-never-halts, `estimateUnmeasured=false`, OSS-vs-Pro boundary).
+- **Phase 4 — opt-in per-step `downshift` routing.** Add the field + pure `costRouter`, wire at both agent sites, cross-field validation mirroring #859, parser passthrough. **+ write the ADR** (price-table source/refresh, fail-open USD semantics, estimate-warns-never-halts, `estimateUnmeasured=false`, repository boundary per ADR-0019).
 
 ## 7. Decisions for you (recommended answer in **bold**)
 

--- a/docs/design/cost-aware-routing.md
+++ b/docs/design/cost-aware-routing.md
@@ -130,7 +130,7 @@ Opt-in (absent config ⇒ byte-identical) · composes with judge→refine (route
 3. **`downshift` semantics:** author-ordered list (the recipe author asserts each fallback is "good enough"), **no engine capability/tier taxonomy.** → **Recommend author-ordered.**
 4. **Breach vs downshift layering:** admission denial **halts**; `downshift` only picks a cheaper model below the admit gate. → **Recommend this layering** (retry-cheaper-on-denial deferred as a stretch flag).
 5. **Subscription USD framing:** docs/hint state plainly that `usdMax` on a subscription driver is **notional list-equivalent**, not real money. → **Recommend explicit wording.**
-6. **OSS vs Pro boundary:** does a *local, per-recipe* `usdMax` ship in the free OSS core? → ✅ **DECIDED (2026-06-03): ships free in OSS core.** Only cross-recipe / centralized billing is reserved for Pro.
+6. **Repository boundary:** does a *local, per-recipe* `usdMax` ship in this repo? → ✅ **DECIDED (2026-06-03): yes, it ships here.** Anything cross-recipe or centralised is organisation-scoped and out of scope for this repository ([ADR-0019](../adr/0019-open-core-boundary.md)).
 7. **Chained-runner scope:** the chained-runner wrapper (`yamlRunner ~2560`) discards `.usage` and bypasses the budget today. Cover sub-recipe/chained calls in this work, or document as out-of-scope for now? → **Recommend out-of-scope for v1, documented.**
 
 ## 8. Test plan (per phase)

--- a/docs/mobile-oversight-mvp.md
+++ b/docs/mobile-oversight-mvp.md
@@ -15,7 +15,8 @@ The approval infrastructure already exists and is solid:
 - `src/approvalHttp.ts` — `routeApprovalRequest` handles `POST /approvals`, `POST /approve/:id`, `POST /reject/:id`
 - `dashboard/src/app/approvals/` — full desktop approval UI with risk signals, params, countdowns
 - `src/server.ts` — bridge webhook dispatcher already calls `dispatchApprovalWebhook` (HTTPS only, SSRF-guarded)
-- `docs/business/pro-tier.md` — target: FCM/APNS push + hosted dashboard at `app.patchwork.dev`
+- (FCM/APNS push and a hosted dashboard are tracked outside this repository — see
+  [ADR-0019](adr/0019-open-core-boundary.md); nothing here depends on them)
 
 **What is missing for mobile oversight:**
 
@@ -202,10 +203,11 @@ Agent 4 starts once all three pass unit tests.
 
 ## Out of scope for MVP
 
-- Native iOS / Android apps (PWA is sufficient for approve/reject; revisit at Pro tier launch)
+- Native iOS / Android apps (PWA is sufficient for approve/reject)
 - Notification batching / digest (single-call granularity is correct for oversight)
-- Shared team approval delegation (Team tier feature per `pro-tier.md`)
-- Offline approve/reject (requires synced state; punt to Pro hosted dashboard)
+- Shared team approval delegation (organisation-scoped; belongs to the control plane
+  per [ADR-0019](adr/0019-open-core-boundary.md), not here)
+- Offline approve/reject (requires synced state; deferred)
 
 ---
 

--- a/docs/mobile-oversight.md
+++ b/docs/mobile-oversight.md
@@ -90,10 +90,16 @@ npm start
 
 The relay listens on `PORT` (default 3001). It must be reachable over HTTPS from the bridge.
 
-### Option B: Hosted (Pro tier)
+### Option B: Point at an already-running relay
 
-The relay is hosted at `https://notify.patchwork.dev`. Your `PUSH_RELAY_TOKEN` is issued
-when you activate the Pro plan. Skip to step 2.
+If a relay is already running for you — someone else's deployment, or a hosted one —
+you need only its URL and a `PUSH_RELAY_TOKEN` issued by whoever operates it. Set both
+and skip to step 2; nothing else in this guide changes.
+
+How such a relay is obtained, operated or charged for is not covered here: this
+repository documents the runtime, not any commercial offering built on it
+([ADR-0019](adr/0019-open-core-boundary.md)). Option A above is fully self-contained
+and needs nobody's permission.
 
 ### FCM setup (Android)
 

--- a/docs/plans/recipe-chaining-wave1-plan.md
+++ b/docs/plans/recipe-chaining-wave1-plan.md
@@ -475,7 +475,7 @@ Agent 1 (Chaining Engine)
 - **Zendesk** — Wave 1.5 (lower recipe leverage)
 - **Bidirectional sync** — one-shot recipes only, no listeners/polling
 - **Recipe marketplace / registry** — local YAML only
-- **Hosted recipe sync** — Pro tier feature, deferred
+- **Hosted recipe sync** — deferred; out of scope for this repo
 
 ---
 

--- a/scripts/audit-business-content-allowlist.json
+++ b/scripts/audit-business-content-allowlist.json
@@ -21,6 +21,16 @@
       "reason": "The open-core boundary needs a public rationale, and LICENSING.md depends on it. Keeping an accepted ADR intact is also better practice than editing the record to satisfy a linter. Note the ADR itself rules pricing/packaging/tiers out of this repo — this entry covers the reasoning for the boundary, not any pricing detail. Decided 2026-08-07."
     },
     {
+      "file": "docs/adr/0008-connector-scope-decision.md",
+      "term": "named tier",
+      "reason": "An accepted ADR recording why the approval loop was descoped from connector Wave 1. It quotes no price and makes no offer — it names a tier only to explain what it deliberately did NOT build here, and line 80 says outright that the material is not in this repository. Same precedent as the ADR-0019 entry: editing an accepted decision record to satisfy a linter is worse than an allowlist line. Distinct from the setup-guide text fixed at the same time (2026-08-10), which instructed a reader to activate a plan — an offer, and correctly rewritten rather than allowlisted."
+    },
+    {
+      "file": "docs/adr/0008-connector-scope-decision.md",
+      "term": "out-of-repo pricing doc",
+      "reason": "Same ADR, same reason. The reference is to a document explicitly described as living outside this repository — the citation records the boundary rather than crossing it."
+    },
+    {
       "file": "CHANGELOG.md",
       "term": "free tier",
       "reason": "Gemini's API free tier exhausting its daily quota — a model-provider limit that changed a recipe's driver. Engineering, not our commercial model."

--- a/scripts/audit-business-content-allowlist.json
+++ b/scripts/audit-business-content-allowlist.json
@@ -21,6 +21,11 @@
       "reason": "The open-core boundary needs a public rationale, and LICENSING.md depends on it. Keeping an accepted ADR intact is also better practice than editing the record to satisfy a linter. Note the ADR itself rules pricing/packaging/tiers out of this repo — this entry covers the reasoning for the boundary, not any pricing detail. Decided 2026-08-07."
     },
     {
+      "file": "docs/adr/0015-cost-aware-routing.md",
+      "term": "open-core packaging",
+      "reason": "An accepted ADR recording that a local per-recipe usdMax ships here. It quotes no price and makes no offer — it records which side of the repository boundary a feature landed on, which is the decision the ADR exists to preserve. Same precedent as the ADR-0019 and ADR-0008 entries: an offer to a reader gets rewritten, a decision record gets a reviewable line. The design doc that fed this ADR was reworded instead (2026-08-10), because it is a working document rather than an accepted record."
+    },
+    {
       "file": "docs/adr/0008-connector-scope-decision.md",
       "term": "named tier",
       "reason": "An accepted ADR recording why the approval loop was descoped from connector Wave 1. It quotes no price and makes no offer — it names a tier only to explain what it deliberately did NOT build here, and line 80 says outright that the material is not in this repository. Same precedent as the ADR-0019 entry: editing an accepted decision record to satisfy a linter is worse than an allowlist line. Distinct from the setup-guide text fixed at the same time (2026-08-10), which instructed a reader to activate a plan — an offer, and correctly rewritten rather than allowlisted."

--- a/scripts/audit-business-content.mjs
+++ b/scripts/audit-business-content.mjs
@@ -60,6 +60,24 @@ const TERMS = [
   { re: /\brevenue (path|model|stream)\b/i, label: "revenue model" },
   { re: /\bpricing (model|strategy|tier|page)\b/i, label: "pricing strategy" },
   { re: /\bTAM\b/, label: "market sizing" },
+  // Named first-party tiers. Added 2026-08-10: the terms above match the
+  // vocabulary of a strategy document, but the leak that actually reached
+  // users was a setup guide saying a token "is issued when you activate the
+  // Pro plan" — an offer, in a numbered install step, that this gate read as
+  // clean. Naming a tier IS packaging even when no price is quoted.
+  { re: /\bPro[- ](?:tier|plan)\b/i, label: "named tier" },
+  { re: /\bTeam[- ](?:tier|plan)\b/i, label: "named tier" },
+  { re: /\bEnterprise[- ](?:tier|plan)\b/i, label: "named tier" },
+  { re: /\breserved for Pro\b/i, label: "named tier" },
+  { re: /\bactivate the Pro\b/i, label: "named tier" },
+  { re: /\bpro-tier\.md\b/i, label: "out-of-repo pricing doc" },
+  // A price with a per-unit denominator ("$50/worker/mo"). The unit list is
+  // deliberately narrow — it must not match provider token rates like
+  // "$3 / 1M tokens", which the cost router documents legitimately.
+  {
+    re: /\$\s?\d[\d,.]*\s*(?:\/|per\s)\s*(?:worker|seat|user|mo\b|month)/i,
+    label: "unit price",
+  },
   { re: /\bchurn rate\b/i, label: "churn" },
   { re: /\bupsell\b/i, label: "upsell" },
   // Competitor funding intelligence — the specific shape that prompted this:

--- a/scripts/audit-business-content.mjs
+++ b/scripts/audit-business-content.mjs
@@ -71,6 +71,16 @@ const TERMS = [
   { re: /\breserved for Pro\b/i, label: "named tier" },
   { re: /\bactivate the Pro\b/i, label: "named tier" },
   { re: /\bpro-tier\.md\b/i, label: "out-of-repo pricing doc" },
+  // Open-core framing. Added in the same pass and for a worse reason than the
+  // patterns above it: those were written from the claims already found, so
+  // the gate could only ever confirm the fix. It passed green while "ships
+  // free in OSS core" survived 130 lines from an edit in the same file, and
+  // while an accepted ADR said it too. Naming a feature's side of the
+  // free/paid line is packaging in the same way naming a tier is.
+  {
+    re: /\bOSS[- ](?:core|vs)\b|\bfree OSS\b|\bOSS[- ]vs[- ]Pro\b/i,
+    label: "open-core packaging",
+  },
   // A price with a per-unit denominator ("$50/worker/mo"). The unit list is
   // deliberately narrow — it must not match provider token rates like
   // "$3 / 1M tokens", which the cost router documents legitimately.


### PR DESCRIPTION
ADR-0019 ends with *"anything about pricing, packaging or tiers ... do not belong in this repository in any form."* Tracked documents did it anyway.

The one that mattered is the setup guide. Step 1, Option B told a reader their `PUSH_RELAY_TOKEN` **"is issued when you activate the Pro plan"** — an offer, in a numbered install step of a public MIT repo, for a product with no page, no price and no way to buy it. Others deferred work to "Pro tier launch" and cited `docs/business/pro-tier.md`, a file not in this repository and which should not be.

### The rule this PR follows

**An offer to a reader gets rewritten. An accepted decision record gets an allowlist entry with a reason.** ADR-0008 and ADR-0015 name a tier or a side of the free/paid line, but quote no price and make no offer — they record what was deliberately *not* built here. Editing an accepted record to satisfy a linter is worse than one reviewable line, which is the precedent already set by the ADR-0019 entry in this allowlist.

### What changed

| File | Was | Now |
|---|---|---|
| `docs/mobile-oversight.md` | "Hosted (Pro tier)" · "activate the Pro plan" | "Point at an already-running relay" — the URL + token you actually need, and a note that how you obtain one isn't covered here |
| `docs/mobile-oversight-mvp.md` | cites `docs/business/pro-tier.md`; "Team tier feature" | points at ADR-0019; delegation described as organisation-scoped |
| `docs/plans/recipe-chaining-wave1-plan.md` | "Pro tier feature, deferred" | "deferred; out of scope for this repo" |
| `docs/design/cost-aware-routing.md` | "reserved for Pro" · "ships free in OSS core" · "OSS-vs-Pro boundary" | "out of scope for this repository" · "ships in this repository" · "repository boundary per ADR-0019" |

### The gate already existed, and its first extension was wrong

`scripts/audit-business-content.mjs` was written for exactly this rule and **passed green over every one of these**, because its vocabulary is that of a strategy document — "go-to-market", "willingness to pay", "per-seat" — and none of these documents used those words.

The second commit exists because the first extension repeated the mistake in a subtler form: **its patterns were written from the claims already found, so the gate could only confirm the fix that prompted it.** It reported green while `ships free in OSS core` survived 130 lines above a line it had just passed clean, in the same file, and while ADR-0015 said the same thing. Naming a feature's side of the free/paid line is packaging in exactly the way naming a tier is.

Patterns now added: named Pro/Team/Enterprise tiers, "reserved for Pro", "activate the Pro", `pro-tier.md`, a unit price, and OSS-core / free-OSS / OSS-vs-Pro. The price pattern's denominator list is deliberately narrow (`worker|seat|user|mo|month`) so it cannot match provider token rates like `$3 / 1M tokens`, which the cost router documents legitimately.

**Proof each pattern class can fail:** re-introduced the removed wording and watched the gate go red — `named tier` on both the heading and the offer, `unit price` on `$50/worker/mo`, `open-core packaging` on the status line. Every probe asserts its own anchor first, so a silent no-op could not pass as green. Restored → green. Runs in CI already ([ci.yml:135](.github/workflows/ci.yml#L135)).

### Known limit, stated rather than papered over

This raises the floor; it is not a guarantee, and the script's own header says so. Business reasoning that avoids the vocabulary still passes — `docs/plans/recipe-chaining-wave1-plan.md` ranks providers by "Customer Demand" in a table column, and no pattern here catches that. **Follow-up, deliberately not folded in:** several tracked "Agent Plan" documents are internal build artifacts dated `v2.30.1 · 2026-04-22` while the project is now `1.1.0-beta.4`. Whether those belong tracked in a public repo at all is a scoping decision, not a wording one, and rewording them would be polish on documents that may need to move.

Docs and one audit script only — no runtime change. Gates run locally: tests-core tsc · audit-test-fixtures · audit-lsp-tools · audit-docs-drift · audit-docs-wired · audit-business-content · biome.