### PR TITLE
chore: sweep the in-flight entry for #1307

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-10 `feat/durable-trust-checkpoint` — persist WorkerLevelStore off the rotating run log (backlog #10); adds src/workers/trustCheckpoint.ts, no gate-semantics change — CLI session
+_Nothing in flight._
 
 Swept 2026-08-08: all 10 distinct entries here were MERGED (#1249, #1255,
 #1256, #1257, #1258, #1259, #1278, #1279, #1280, #1281), several listed twice


### PR DESCRIPTION
`main` went red the moment #1307 merged: the Active entry naming `feat/durable-trust-checkpoint` outlived its PR, and `scripts/audit-in-flight.mjs` is a blocking gate.

Mine, and the gate is right. The convention says remove the line when the PR merges; I added the entry and did not remove it — the fourth time this ledger has gone stale, and precisely why the check was made blocking rather than left as a convention.

The difference from the three manual sweeps before it: caught within minutes of the merge instead of four days later. A note would not have caught it at all — I was the session that had just read the convention.

Restores `_Nothing in flight._`; `audit-in-flight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)