### PR TITLE
fix(connectors): Todoist targeted a retired API version

### DIFF
--- a/src/connectors/__tests__/todoist.test.ts
+++ b/src/connectors/__tests__/todoist.test.ts
@@ -469,3 +469,52 @@ describe("TodoistConnector.normalizeError", () => {
     expect(err.retryable).toBe(true);
   });
 });
+
+describe("Todoist API v1 (REST v2 was retired)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.TODOIST_API_KEY;
+    vi.resetModules();
+  });
+
+  it("unwraps the v1 list envelope", async () => {
+    // The reason this connector was entirely non-functional: REST v2 answers
+    // 410 Gone, and v1 wraps lists in { results, next_cursor } rather than
+    // returning a bare array. Verified against the live API on 2026-08-10.
+    process.env.TODOIST_API_KEY = "test-token";
+    const tasks = [makeFakeTask(), makeFakeTask({ id: "t2", content: "Walk" })];
+    global.fetch = mockFetch(true, 200, { results: tasks, next_cursor: null });
+
+    vi.resetModules();
+    const { TodoistConnector } = await import("../todoist.js");
+    const out = await new TodoistConnector().getTasks();
+
+    expect(out).toHaveLength(2);
+    expect(out[0]?.id).toBe(tasks[0]?.id);
+  });
+
+  it("still accepts a bare array", async () => {
+    // Deliberately tolerant: an endpoint that never adopted the envelope, or a
+    // future shape change, degrades to the old behaviour instead of throwing.
+    process.env.TODOIST_API_KEY = "test-token";
+    global.fetch = mockFetch(true, 200, [makeFakeTask()]);
+
+    vi.resetModules();
+    const { TodoistConnector } = await import("../todoist.js");
+    expect(await new TodoistConnector().getTasks()).toHaveLength(1);
+  });
+
+  it("calls the v1 base URL, not the retired REST v2 one", async () => {
+    process.env.TODOIST_API_KEY = "test-token";
+    global.fetch = mockFetch(true, 200, { results: [], next_cursor: null });
+
+    vi.resetModules();
+    const { TodoistConnector } = await import("../todoist.js");
+    await new TodoistConnector().getTasks();
+
+    const url = (global.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as string;
+    expect(url).toContain("/api/v1/");
+    expect(url).not.toContain("/rest/v2/");
+  });
+});

--- a/src/connectors/todoist.ts
+++ b/src/connectors/todoist.ts
@@ -24,7 +24,27 @@ import {
   storeSecretJsonSync,
 } from "./tokenStorage.js";
 
-const TODOIST_BASE = "https://api.todoist.com/rest/v2";
+// Todoist retired REST v2 — it answers 410 Gone, so every call through this
+// connector failed regardless of the token. The unified API is v1; it keeps the
+// same paths but wraps LIST responses in { results, next_cursor }.
+const TODOIST_BASE = "https://api.todoist.com/api/v1";
+
+/** A v1 list response. Single-resource endpoints still return the object. */
+interface TodoistListEnvelope<T> {
+  results: T[];
+  next_cursor: string | null;
+}
+
+/**
+ * Unwrap a v1 list response. Tolerates a bare array so a future shape change,
+ * or an endpoint that never adopted the envelope, degrades to the old
+ * behaviour instead of throwing.
+ */
+function unwrapList<T>(body: unknown): T[] {
+  if (Array.isArray(body)) return body as T[];
+  const env = body as TodoistListEnvelope<T> | null;
+  return env && Array.isArray(env.results) ? env.results : [];
+}
 
 export interface TodoistTokens {
   apiToken: string;
@@ -279,7 +299,7 @@ export class TodoistConnector extends BaseConnector {
           status: res.status,
         });
       }
-      return res.json() as Promise<TodoistTask[]>;
+      return unwrapList<TodoistTask>(await res.json());
     });
     if ("error" in result) throw new Error(result.error.message);
     return result.data;
@@ -425,7 +445,7 @@ export class TodoistConnector extends BaseConnector {
           status: res.status,
         });
       }
-      return res.json() as Promise<TodoistProject[]>;
+      return unwrapList<TodoistProject>(await res.json());
     });
     if ("error" in result) throw new Error(result.error.message);
     return result.data;


### PR DESCRIPTION
**Every call this connector made returned 410 Gone.** Todoist has retired REST v2; the unified API is v1. The connector was not degraded — it was entirely non-functional, and no test noticed.

Found while trying to run the Butler errand loop end-to-end against a real account. The account and token were fine:

| Request | Result |
|---|---|
| `GET /rest/v2/projects` | **410 Gone** |
| `GET /api/v1/projects` (same token) | **200** |

### The change

v1 keeps the same paths but wraps LIST responses in `{ results, next_cursor }`. So: the base URL, plus unwrapping the two list endpoints. Single-resource endpoints still return the object directly.

`unwrapList` deliberately tolerates a bare array as well as the envelope, so an endpoint that never adopted it — or a future shape change — degrades to the old behaviour rather than throwing.

### Verified against the live API, not just mocks

```
healthCheck: {"ok":true}
getTasks -> array(0)
```

Both previously failed. The three new tests are mutation-probed: reverting the base URL fails the URL test, removing the unwrap fails the envelope test.

### The part worth dwelling on

**The 26 pre-existing tests passed before this change and after it.** They mock `fetch` with bare arrays, so they never exercised either the URL or the response shape. A connector can be completely dead against production while its suite is green — which is exactly the failure mode this repo has been hunting all week, showing up in a place nobody had looked.

That suggests a broader question I have not answered: **how many of the other 20-odd connectors target endpoints that no longer exist?** Every one of them is mock-tested the same way. I would not assume Todoist is unique, and a cheap health-probe sweep across connectors with real credentials would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)