### PR TITLE
fix(butler): three things the first real errand run found

### DIFF
--- a/dashboard/src/lib/__tests__/navRoutes.test.ts
+++ b/dashboard/src/lib/__tests__/navRoutes.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 import {
   NAV_SECTIONS,
+  SIMPLE_NAV_SECTIONS,
   MOBILE_PRIMARY_HREFS,
   flatRoutes,
   findRoute,
@@ -117,6 +118,29 @@ describe("navRoutes contract", () => {
   it("every route declares an icon so the sidebar never falls back to a generic glyph", () => {
     for (const r of flatRoutes()) {
       expect(r.icon, `route ${r.href} is missing an icon`).toBeTruthy();
+    }
+  });
+});
+
+describe("Butler is reachable in Simple mode", () => {
+  const hrefs = (s: typeof SIMPLE_NAV_SECTIONS) =>
+    s.flatMap((sec) => sec.routes.map((r) => r.href));
+
+  it("appears in the simple menu, not only the advanced one", () => {
+    // It was in NAV_SECTIONS only, so a user in Simple mode could not reach
+    // Butler at all. Backwards: Butler is the large-print, single-column,
+    // accessibility-led page — the one surface built for somebody who wants
+    // less, not more. The simpler menu was hiding the simplest page.
+    expect(hrefs(SIMPLE_NAV_SECTIONS)).toContain("/butler");
+    expect(hrefs(NAV_SECTIONS)).toContain("/butler");
+  });
+
+  it("every simple route also exists in the advanced menu", () => {
+    // Simple is a SUBSET, not a separate menu that can drift. A route only
+    // reachable in Simple mode would be invisible to anyone who switched.
+    const advanced = new Set(hrefs(NAV_SECTIONS));
+    for (const href of hrefs(SIMPLE_NAV_SECTIONS)) {
+      expect(advanced, `${href} missing from NAV_SECTIONS`).toContain(href);
     }
   });
 });

--- a/dashboard/src/lib/navRoutes.ts
+++ b/dashboard/src/lib/navRoutes.ts
@@ -169,6 +169,12 @@ export const SIMPLE_NAV_SECTIONS: NavSection[] = [
     routes: [
       { href: "/", label: "Overview", icon: "home" },
       { href: "/inbox", label: "Inbox", icon: "inbox" },
+      // Butler belongs in Simple mode MORE than in Advanced, not less. It is
+      // the large-print, single-column, accessibility-led page — the one
+      // surface built for somebody who wants less, not more. Omitting it here
+      // meant the simpler menu hid the simplest page, and a user in Simple
+      // mode could not reach Butler at all.
+      { href: "/butler", label: "Butler", paletteLabel: "Home — Butler", icon: "person" },
     ],
   },
   {

--- a/src/recipes/__tests__/stepObservation.test.ts
+++ b/src/recipes/__tests__/stepObservation.test.ts
@@ -289,3 +289,32 @@ describe("captureForRunlog — exotic values", () => {
     expect(() => captureForRunlog(big)).not.toThrow();
   });
 });
+
+describe("silent-fail marker keeps its reason (#butler-demo)", () => {
+  // The real refusal this was found on: worker autonomy declined to run an
+  // agent step whose driver could not enforce a tool sandbox. The message said
+  // exactly that, and the run record recorded the bare string
+  // "[agent step failed:" — the pattern matched only the prefix, and `matched`
+  // is built from m[0]. A precise safety message became an opaque failure that
+  // had to be diagnosed by reading the source.
+  const REAL =
+    "[agent step failed: worker autonomy requires the subprocess or codex driver to enforce its tool sandbox — set the agent step (or recipe) driver to `subprocess`/`claude-code`/`codex`; refusing to run un-sandboxed]";
+
+  it("carries the reason, not just the prefix", () => {
+    const hit = detectSilentFail(REAL);
+    expect(hit).not.toBeNull();
+    expect(hit?.matched).toContain("worker autonomy");
+    expect(hit?.matched).not.toBe("[agent step failed:");
+  });
+
+  it("still caps the fragment so a huge blob cannot flood the log", () => {
+    const hit = detectSilentFail(`[agent step failed: ${"x".repeat(500)}]`);
+    expect(hit?.matched.length).toBeLessThanOrEqual(120);
+  });
+
+  it("still detects a bare prefix with no reason after it", () => {
+    // Back-compat: some callers emit the marker with nothing following.
+    expect(detectSilentFail("[agent step failed:")).not.toBeNull();
+    expect(detectSilentFail("[step skipped: nothing to do]")).not.toBeNull();
+  });
+});

--- a/src/recipes/__tests__/stepObservation.test.ts
+++ b/src/recipes/__tests__/stepObservation.test.ts
@@ -318,3 +318,22 @@ describe("silent-fail marker keeps its reason (#butler-demo)", () => {
     expect(detectSilentFail("[step skipped: nothing to do]")).not.toBeNull();
   });
 });
+
+describe("agent driver enum matches the runtime (#1311 sibling drift)", () => {
+  // The schema's driver enum and DOWNSHIFT_KNOWN_DRIVERS are hand-maintained
+  // lists that must track agentExecutor's branches. `local` drifted out once
+  // (audit 2026-06-10) and `subprocess` drifted out again — rejecting the
+  // shipped butler-errand template, which needs a sandbox-capable driver to
+  // demonstrate the flag it exists for. A recipe that runs but will not lint
+  // is the worst shape: valid in production, rejected at the door.
+  it("accepts every driver the executor actually branches on", async () => {
+    const { generateSchemaSet } = await import("../schemaGenerator.js");
+    const set = generateSchemaSet();
+    const json = JSON.stringify(set);
+    for (const driver of ["subprocess", "claude-code", "codex", "local"]) {
+      expect(json, `${driver} missing from the generated schema`).toContain(
+        `"${driver}"`,
+      );
+    }
+  });
+});

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -482,6 +482,14 @@ function generateRecipeSchema(
           "gemini",
           "anthropic",
           "codex",
+          // `subprocess` is the canonical id for the Claude CLI driver —
+          // agentExecutor branches on it directly (`driver === "subprocess"`),
+          // `--driver subprocess` is the documented flag, and it is one of the
+          // drivers worker autonomy REQUIRES for its tool sandbox. Omitting it
+          // here rejected a valid recipe: the shipped butler-errand template,
+          // which needs a sandbox-capable driver to demonstrate the very flag
+          // it exists for. Exactly the drift the `local` note below records.
+          "subprocess",
           // `local` (self-hosted Ollama / LM Studio) is a fully implemented
           // runtime driver and already valid in the downshift enum below and in
           // DOWNSHIFT_KNOWN_DRIVERS — omitting it here made FLAG_SCHEMA_LINT

--- a/src/recipes/stepObservation.ts
+++ b/src/recipes/stepObservation.ts
@@ -79,12 +79,19 @@ const SILENT_FAIL_PATTERNS: Array<{ regex: RegExp; reason: string }> = [
   // Used by `executeAgent` when an API key is missing or the LLM
   // returns nothing. Not surfaced as JSON, so the runner never saw it.
   {
-    regex: /^\s*\[agent step (skipped|failed):/i,
+    // Capture the WHOLE marker, not just its prefix. `matched` is built from
+    // m[0], so a prefix-only pattern threw away everything after the colon —
+    // and that is where the reason lives. A real refusal ("worker autonomy
+    // requires the subprocess or codex driver ... refusing to run
+    // un-sandboxed") logged as the bare string "[agent step failed:", turning
+    // a precise safety message into an opaque failure that had to be
+    // diagnosed by reading the source.
+    regex: /^\s*\[agent step (skipped|failed):[^\]]*\]?/i,
     reason: "agent step skipped or failed (string placeholder)",
   },
   // Generic step-skipped marker in case more callers adopt it.
   {
-    regex: /^\s*\[step (skipped|failed):/i,
+    regex: /^\s*\[step (skipped|failed):[^\]]*\]?/i,
     reason: "step skipped or failed (string placeholder)",
   },
 ];

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -26,6 +26,7 @@ const DOWNSHIFT_KNOWN_DRIVERS = new Set([
   "gemini",
   "anthropic",
   "codex",
+  "subprocess",
   "local",
 ]);
 

--- a/templates/recipes/butler-errand.yaml
+++ b/templates/recipes/butler-errand.yaml
@@ -37,6 +37,12 @@ steps:
     into: existing
 
   - agent:
+      # REQUIRED, not stylistic. With PATCHWORK_FLAG_WORKER_AUTONOMY on, an
+      # agent step in a worker recipe must name a driver that can enforce a
+      # tool sandbox; agentExecutor refuses to run un-sandboxed otherwise. This
+      # recipe exists to demonstrate that flag, so without this line the demo
+      # halts at step 2 and never reaches the gated write.
+      driver: subprocess
       prompt: |
         The user asked for: {{request}}
 


### PR DESCRIPTION
Running the Butler errand loop end-to-end for the first time — a worker proposing a real external action, a human approving it — surfaced three defects. **None could have been found by unit tests.** All three needed the thing to actually run.

### 1. The shipped template could not run under the flag it demonstrates

`templates/recipes/butler-errand.yaml` declares no `driver` on its agent step. With `PATCHWORK_FLAG_WORKER_AUTONOMY` on, `agentExecutor` refuses it — *"worker autonomy requires the subprocess or codex driver to enforce its tool sandbox … refusing to run un-sandboxed"*.

**That refusal is correct and stays.** The template was wrong: the demo halted at step 2 and never reached the gated write it exists to show. Anyone following the runbook would have hit the same wall.

### 2. That refusal was invisible

`detectSilentFail` matched only the marker **prefix** (`\[agent step (skipped|failed):`) and builds `matched` from `m[0]` — so everything after the colon was thrown away. A precise safety message was recorded as the bare string `"[agent step failed:"`.

Diagnosing it meant reading the source. The pattern now spans the whole marker; the 120-char cap still applies, and a bare prefix with no reason still matches.

### 3. Butler was missing from the Simple menu

`/butler` was in `NAV_SECTIONS` but not `SIMPLE_NAV_SECTIONS`, so a user in Simple mode could not reach it **at all**.

Backwards, and worth naming: Butler is the large-print, single-column, accessibility-led page — the one surface built for somebody who wants *less*, not more. The simpler menu was hiding the simplest page. A second test now asserts Simple is a strict **subset** of Advanced, so the two cannot drift apart again.

### Verified by running it, not only by tests

From the **shipped template**, against a real Todoist account:

| Step | Result |
|---|---|
| `todoist.list_tasks` | allowed un-gated (reversible) |
| agent drafts title | allowed (sandboxed driver) |
| `todoist.create_task` | **STOPS** — `tasks:compensable:medium`, gated |
| approve → | task created, receipt written naming how to undo it |
| reject → | run halts `approval_rejected`, **nothing created** |

The Decision Record shows `action: gate` with `standingPermissionId: None` — a human was genuinely asked, not silently waved through by a stored grant.

Each fix is mutation-probed: reverting the regex fails the reason test, removing Butler from Simple fails the nav test.

313 + 513 tests pass (bridge + dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)