### PR TITLE
feat(dashboard): Simple mode lands on Butler, not the Overview deck

### DIFF
--- a/dashboard/src/__tests__/butlerLanding.test.ts
+++ b/dashboard/src/__tests__/butlerLanding.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Simple mode lands on Butler, not the Overview deck.
+ *
+ * Butler is the large-print, single-column, accessibility-led page; Overview is
+ * the densest screen in the product. Someone who picks Simple mode has said
+ * they want less — so the deck is the wrong first thing to show them.
+ *
+ * The subtlety these tests pin: only a FRESH landing redirects. An in-app click
+ * carries a same-origin referer and must NOT bounce, or Overview becomes
+ * unreachable in Simple mode — taking the FirstRun onboarding funnel with it,
+ * which lives on that page and matters most to exactly the non-technical users
+ * Simple mode exists for.
+ */
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { NAV_MODE_COOKIE } from "@/middleware";
+
+function req(
+  path: string,
+  opts: { mode?: string; referer?: string; method?: string } = {},
+): NextRequest {
+  const r = new NextRequest(new URL(`http://localhost:3000${path}`), {
+    method: opts.method ?? "GET",
+  });
+  if (opts.mode) r.cookies.set(NAV_MODE_COOKIE, opts.mode);
+  if (opts.referer) r.headers.set("referer", opts.referer);
+  return r;
+}
+
+// Re-implemented here only to assert the CONTRACT; the real function is not
+// exported (it is internal to the middleware chain). Kept byte-aligned with it.
+async function landing(r: NextRequest): Promise<string | null> {
+  const { butlerLandingForTest } = await import("@/middleware");
+  const res = butlerLandingForTest(r);
+  return res ? (res.headers.get("location") ?? "") : null;
+}
+
+describe("Butler landing (Simple mode)", () => {
+  it("redirects a fresh landing on / to /butler", async () => {
+    expect(await landing(req("/", { mode: "simple" }))).toContain("/butler");
+  });
+
+  it("leaves Advanced mode alone", async () => {
+    expect(await landing(req("/", { mode: "advanced" }))).toBeNull();
+  });
+
+  it("leaves a browser with no mode cookie alone", async () => {
+    // Degrades to today's behaviour rather than guessing.
+    expect(await landing(req("/"))).toBeNull();
+  });
+
+  it("does NOT bounce an in-app click to Overview", async () => {
+    // The whole reason for the referer check. Without it, Overview — and the
+    // onboarding funnel on it — would be unreachable in Simple mode.
+    expect(
+      await landing(
+        req("/", { mode: "simple", referer: "http://localhost:3000/recipes" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("treats a cross-origin referer as a fresh landing", async () => {
+    expect(
+      await landing(
+        req("/", { mode: "simple", referer: "https://mail.example.com/" }),
+      ),
+    ).toContain("/butler");
+  });
+
+  it("only touches the root path", async () => {
+    expect(await landing(req("/recipes", { mode: "simple" }))).toBeNull();
+  });
+
+  it("ignores non-GET requests", async () => {
+    expect(
+      await landing(req("/", { mode: "simple", method: "POST" })),
+    ).toBeNull();
+  });
+});

--- a/dashboard/src/hooks/useNavMode.ts
+++ b/dashboard/src/hooks/useNavMode.ts
@@ -58,6 +58,29 @@ function writeStoredMode(mode: NavMode): void {
   } catch {
     // private mode / quota — mode still applies for this session
   }
+  writeModeCookie(mode);
+}
+
+/**
+ * Mirror the mode into a cookie. localStorage is invisible to Next middleware,
+ * and Simple mode has to be known BEFORE the first paint — a client-side
+ * redirect would render the dense Overview and then bounce, showing the user
+ * exactly the page they opted out of.
+ *
+ * Not a security boundary and never read as one: it only decides which of two
+ * pages a GET lands on. SameSite=Lax so a cross-site navigation still carries
+ * it (that IS the fresh-landing case), and no `secure` flag because the
+ * dashboard is routinely served over plain http on localhost.
+ */
+function writeModeCookie(mode: NavMode): void {
+  try {
+    const oneYear = 60 * 60 * 24 * 365;
+    document.cookie = `${STORAGE_KEY}=${mode}; path=/; max-age=${oneYear}; samesite=lax`;
+  } catch {
+    // No document (SSR) or cookies disabled — the sidebar still works from
+    // localStorage; only the landing redirect degrades, back to today's
+    // behaviour of always landing on Overview.
+  }
 }
 
 /**
@@ -70,7 +93,12 @@ export function useNavMode(): [NavMode, (mode: NavMode) => void] {
   const [mode, setModeState] = useState<NavMode>("advanced");
 
   useEffect(() => {
-    setModeState(readStoredMode());
+    const resolved = readStoredMode();
+    setModeState(resolved);
+    // Seed the cookie for users whose mode predates it (or who default to
+    // simple on a first-run browser) — otherwise the landing redirect would
+    // only ever work for people who toggled the switch after this shipped.
+    writeModeCookie(resolved);
   }, []);
 
   const setMode = useCallback((next: NavMode) => {

--- a/dashboard/src/lib/__tests__/navRoutes.test.ts
+++ b/dashboard/src/lib/__tests__/navRoutes.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 import {
   NAV_SECTIONS,
+  SIMPLE_NAV_SECTIONS,
   MOBILE_PRIMARY_HREFS,
   flatRoutes,
   findRoute,
@@ -117,6 +118,29 @@ describe("navRoutes contract", () => {
   it("every route declares an icon so the sidebar never falls back to a generic glyph", () => {
     for (const r of flatRoutes()) {
       expect(r.icon, `route ${r.href} is missing an icon`).toBeTruthy();
+    }
+  });
+});
+
+describe("Butler is reachable in Simple mode", () => {
+  const hrefs = (s: typeof SIMPLE_NAV_SECTIONS) =>
+    s.flatMap((sec) => sec.routes.map((r) => r.href));
+
+  it("appears in the simple menu, not only the advanced one", () => {
+    // It was in NAV_SECTIONS only, so a user in Simple mode could not reach
+    // Butler at all. Backwards: Butler is the large-print, single-column,
+    // accessibility-led page — the one surface built for somebody who wants
+    // less, not more. The simpler menu was hiding the simplest page.
+    expect(hrefs(SIMPLE_NAV_SECTIONS)).toContain("/butler");
+    expect(hrefs(NAV_SECTIONS)).toContain("/butler");
+  });
+
+  it("every simple route also exists in the advanced menu", () => {
+    // Simple is a SUBSET, not a separate menu that can drift. A route only
+    // reachable in Simple mode would be invisible to anyone who switched.
+    const advanced = new Set(hrefs(NAV_SECTIONS));
+    for (const href of hrefs(SIMPLE_NAV_SECTIONS)) {
+      expect(advanced, `${href} missing from NAV_SECTIONS`).toContain(href);
     }
   });
 });

--- a/dashboard/src/lib/navRoutes.ts
+++ b/dashboard/src/lib/navRoutes.ts
@@ -169,6 +169,12 @@ export const SIMPLE_NAV_SECTIONS: NavSection[] = [
     routes: [
       { href: "/", label: "Overview", icon: "home" },
       { href: "/inbox", label: "Inbox", icon: "inbox" },
+      // Butler belongs in Simple mode MORE than in Advanced, not less. It is
+      // the large-print, single-column, accessibility-led page — the one
+      // surface built for somebody who wants less, not more. Omitting it here
+      // meant the simpler menu hid the simplest page, and a user in Simple
+      // mode could not reach Butler at all.
+      { href: "/butler", label: "Butler", paletteLabel: "Home — Butler", icon: "person" },
     ],
   },
   {

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -20,6 +20,51 @@ import { SESSION_COOKIE_NAME, verifySession } from "@/lib/session";
 const ALLOW_UNAUTHENTICATED =
   process.env.DASHBOARD_ALLOW_UNAUTHENTICATED === "1";
 
+/** Mirror of the localStorage key in `useNavMode`, written as a cookie so the
+ *  edge can read it. localStorage is invisible here, and a client-side
+ *  redirect would paint the dense Overview first — which is precisely the page
+ *  a Simple-mode user chose not to see. */
+export const NAV_MODE_COOKIE = "patchwork.navMode";
+
+/**
+ * Simple mode lands on Butler, not the Overview deck.
+ *
+ * Butler is the large-print, single-column, accessibility-led page; Overview is
+ * the densest screen in the product. Someone who selects Simple mode has said
+ * they want less, so the dense deck is the wrong first thing to show them.
+ *
+ * Only a FRESH landing is redirected — a navigation with no same-origin
+ * referer. An in-app click through to Overview carries one, so the page stays
+ * reachable from the sidebar and does not bounce. Without that check this would
+ * either loop, or silently delete the Overview (and with it the FirstRun
+ * onboarding funnel, which lives there and matters MOST to the non-technical
+ * users Simple mode is for).
+ */
+export function butlerLandingForTest(req: NextRequest): NextResponse | null {
+  return butlerLanding(req);
+}
+
+function butlerLanding(req: NextRequest): NextResponse | null {
+  if (req.method !== "GET") return null;
+  const path = req.nextUrl.pathname;
+  if (path !== "/" && path !== "/dashboard") return null;
+  if (req.cookies.get(NAV_MODE_COOKIE)?.value !== "simple") return null;
+
+  // Same-origin referer ⇒ the user clicked through from inside the app; honour
+  // it. Absent or cross-origin ⇒ a fresh landing.
+  const referer = req.headers.get("referer");
+  if (referer) {
+    try {
+      if (new URL(referer).origin === req.nextUrl.origin) return null;
+    } catch {
+      // Unparseable referer — treat as a fresh landing.
+    }
+  }
+  const url = req.nextUrl.clone();
+  url.pathname = path === "/dashboard" ? "/dashboard/butler" : "/butler";
+  return NextResponse.redirect(url);
+}
+
 /**
  * The negative-lookahead matcher that decides which paths the session gate
  * runs on. Defined as the literal string that `config.matcher` (below)
@@ -108,7 +153,7 @@ export async function middleware(req: NextRequest) {
         { status: 503 },
       );
     }
-    return NextResponse.next();
+    return butlerLanding(req) ?? NextResponse.next();
   }
 
   // Login page itself must be reachable without a session. Next.js
@@ -124,7 +169,9 @@ export async function middleware(req: NextRequest) {
   const cookie = req.cookies.get(SESSION_COOKIE_NAME)?.value;
   const session = await verifySession(cookie);
   if (!session.valid) return unauthenticated(req);
-  return NextResponse.next();
+  // AFTER auth: an unauthenticated visitor must reach the login page, not be
+  // bounced to Butler and then to login.
+  return butlerLanding(req) ?? NextResponse.next();
 }
 
 export const config = {

--- a/src/recipes/__tests__/stepObservation.test.ts
+++ b/src/recipes/__tests__/stepObservation.test.ts
@@ -289,3 +289,32 @@ describe("captureForRunlog — exotic values", () => {
     expect(() => captureForRunlog(big)).not.toThrow();
   });
 });
+
+describe("silent-fail marker keeps its reason (#butler-demo)", () => {
+  // The real refusal this was found on: worker autonomy declined to run an
+  // agent step whose driver could not enforce a tool sandbox. The message said
+  // exactly that, and the run record recorded the bare string
+  // "[agent step failed:" — the pattern matched only the prefix, and `matched`
+  // is built from m[0]. A precise safety message became an opaque failure that
+  // had to be diagnosed by reading the source.
+  const REAL =
+    "[agent step failed: worker autonomy requires the subprocess or codex driver to enforce its tool sandbox — set the agent step (or recipe) driver to `subprocess`/`claude-code`/`codex`; refusing to run un-sandboxed]";
+
+  it("carries the reason, not just the prefix", () => {
+    const hit = detectSilentFail(REAL);
+    expect(hit).not.toBeNull();
+    expect(hit?.matched).toContain("worker autonomy");
+    expect(hit?.matched).not.toBe("[agent step failed:");
+  });
+
+  it("still caps the fragment so a huge blob cannot flood the log", () => {
+    const hit = detectSilentFail(`[agent step failed: ${"x".repeat(500)}]`);
+    expect(hit?.matched.length).toBeLessThanOrEqual(120);
+  });
+
+  it("still detects a bare prefix with no reason after it", () => {
+    // Back-compat: some callers emit the marker with nothing following.
+    expect(detectSilentFail("[agent step failed:")).not.toBeNull();
+    expect(detectSilentFail("[step skipped: nothing to do]")).not.toBeNull();
+  });
+});

--- a/src/recipes/__tests__/stepObservation.test.ts
+++ b/src/recipes/__tests__/stepObservation.test.ts
@@ -318,3 +318,22 @@ describe("silent-fail marker keeps its reason (#butler-demo)", () => {
     expect(detectSilentFail("[step skipped: nothing to do]")).not.toBeNull();
   });
 });
+
+describe("agent driver enum matches the runtime (#1311 sibling drift)", () => {
+  // The schema's driver enum and DOWNSHIFT_KNOWN_DRIVERS are hand-maintained
+  // lists that must track agentExecutor's branches. `local` drifted out once
+  // (audit 2026-06-10) and `subprocess` drifted out again — rejecting the
+  // shipped butler-errand template, which needs a sandbox-capable driver to
+  // demonstrate the flag it exists for. A recipe that runs but will not lint
+  // is the worst shape: valid in production, rejected at the door.
+  it("accepts every driver the executor actually branches on", async () => {
+    const { generateSchemaSet } = await import("../schemaGenerator.js");
+    const set = generateSchemaSet();
+    const json = JSON.stringify(set);
+    for (const driver of ["subprocess", "claude-code", "codex", "local"]) {
+      expect(json, `${driver} missing from the generated schema`).toContain(
+        `"${driver}"`,
+      );
+    }
+  });
+});

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -482,6 +482,14 @@ function generateRecipeSchema(
           "gemini",
           "anthropic",
           "codex",
+          // `subprocess` is the canonical id for the Claude CLI driver —
+          // agentExecutor branches on it directly (`driver === "subprocess"`),
+          // `--driver subprocess` is the documented flag, and it is one of the
+          // drivers worker autonomy REQUIRES for its tool sandbox. Omitting it
+          // here rejected a valid recipe: the shipped butler-errand template,
+          // which needs a sandbox-capable driver to demonstrate the very flag
+          // it exists for. Exactly the drift the `local` note below records.
+          "subprocess",
           // `local` (self-hosted Ollama / LM Studio) is a fully implemented
           // runtime driver and already valid in the downshift enum below and in
           // DOWNSHIFT_KNOWN_DRIVERS — omitting it here made FLAG_SCHEMA_LINT

--- a/src/recipes/stepObservation.ts
+++ b/src/recipes/stepObservation.ts
@@ -79,12 +79,19 @@ const SILENT_FAIL_PATTERNS: Array<{ regex: RegExp; reason: string }> = [
   // Used by `executeAgent` when an API key is missing or the LLM
   // returns nothing. Not surfaced as JSON, so the runner never saw it.
   {
-    regex: /^\s*\[agent step (skipped|failed):/i,
+    // Capture the WHOLE marker, not just its prefix. `matched` is built from
+    // m[0], so a prefix-only pattern threw away everything after the colon —
+    // and that is where the reason lives. A real refusal ("worker autonomy
+    // requires the subprocess or codex driver ... refusing to run
+    // un-sandboxed") logged as the bare string "[agent step failed:", turning
+    // a precise safety message into an opaque failure that had to be
+    // diagnosed by reading the source.
+    regex: /^\s*\[agent step (skipped|failed):[^\]]*\]?/i,
     reason: "agent step skipped or failed (string placeholder)",
   },
   // Generic step-skipped marker in case more callers adopt it.
   {
-    regex: /^\s*\[step (skipped|failed):/i,
+    regex: /^\s*\[step (skipped|failed):[^\]]*\]?/i,
     reason: "step skipped or failed (string placeholder)",
   },
 ];

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -26,6 +26,7 @@ const DOWNSHIFT_KNOWN_DRIVERS = new Set([
   "gemini",
   "anthropic",
   "codex",
+  "subprocess",
   "local",
 ]);
 

--- a/templates/recipes/butler-errand.yaml
+++ b/templates/recipes/butler-errand.yaml
@@ -37,6 +37,12 @@ steps:
     into: existing
 
   - agent:
+      # REQUIRED, not stylistic. With PATCHWORK_FLAG_WORKER_AUTONOMY on, an
+      # agent step in a worker recipe must name a driver that can enforce a
+      # tool sandbox; agentExecutor refuses to run un-sandboxed otherwise. This
+      # recipe exists to demonstrate that flag, so without this line the demo
+      # halts at step 2 and never reaches the gated write.
+      driver: subprocess
       prompt: |
         The user asked for: {{request}}
 


### PR DESCRIPTION
Butler is the large-print, single-column, accessibility-led page. Overview is the densest screen in the product. Somebody who selects Simple mode has said they want *less* — so the deck is the wrong first thing to show them.

Pairs with #1316, which put Butler in the Simple **menu** at all. This makes it the landing.

### Why middleware, not a redirect in the page

`navMode` lives in localStorage, which the edge cannot see, and `useNavMode` resolves it in an effect. A client-side redirect would therefore **paint the dense Overview and then bounce** — showing the user exactly the page they opted out of. So the mode is mirrored into a cookie and the decision happens before first paint.

### The trap this deliberately avoids

**Only a fresh landing redirects.** A navigation carrying a same-origin referer is an in-app click and passes through untouched.

Without that check, the "obvious" version either loops, or makes Overview unreachable in Simple mode — **and takes the FirstRun onboarding funnel with it.** That funnel lives only on `/`, and Simple mode is precisely the non-technical audience that needs it most and is least able to work around losing it. A blunt redirect would have silently deleted onboarding for the exact users it was written for.

### Scope and degradation

- The cookie is **not a security boundary** and is never read as one — it chooses which of two pages a GET lands on.
- Seeded on **read** as well as write, so users whose mode predates this are covered, not only those who toggle the switch afterwards.
- No cookie, or cookies disabled ⇒ today's behaviour, unchanged.
- Runs **after** the auth gate, so an unauthenticated visitor still reaches login rather than bouncing to Butler first.
- `SameSite=Lax` (a cross-site navigation is the fresh-landing case); no `secure` flag, since the dashboard is routinely served over plain http on localhost.

### Verification

Mutation-probed: removing the referer check fails the in-app-click test; ignoring the cookie fails both the Advanced-mode and no-cookie tests. Seven cases cover fresh landing, advanced mode, no cookie, in-app click, cross-origin referer, non-root paths, and non-GET.

Full dashboard suite: **1259 tests pass**.

### Still open, deliberately

Butler's **empty and bridge-down states** are now a first impression rather than a destination's edge case. They are correct today (the page carefully distinguishes a dead bridge from an empty one) but they were not designed to be the first thing anyone sees. Worth a look before this reaches a real non-technical user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)