### PR TITLE
fix(init): ship the approval hook init writes into the user's CC config

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-10 `fix/npm-artifact-approval-hook` — README-review phase 1 of 3 (onboarding is broken on the published artifact). `patchwork-os init` writes the absolute path of `scripts/patchwork-approval-hook.sh` into the user's real `~/.claude/settings.json` as a PreToolUse command, but `files[]` never shipped that script — so an npm-installed user gets a global Claude Code config pointing at a file that does not exist, on every tool call, in every session. Verified against the published 1.1.0-beta.4 tarball, not inferred. Second half: init printed "open http://localhost:3200" unconditionally, though `dashboard/` is a Next.js app needing its own install+build and is likewise absent from the tarball — adding it to `files[]` would NOT fix that (a 10x bigger tarball and a still-dead port), so the next-steps text now branches on dashboard presence and tells npm users where to get it. New `npmArtifact.test.ts` asserts over `npm pack --dry-run` — the whole suite was green while the artifact was broken because nothing here had ever looked at the tarball. Follow-ups, separate PRs: `patchwork init` vs `patchwork-os init` dispatch (npx lands in the LEGACY installer — `invokedBinaryName()` reads `process.env._`, which npx does not set to the bin), and the `engines.node >=20` claim that no CI job tests.
 
 
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "scripts/gen-mcp-config.sh",
     "scripts/mcp-stdio-shim.cjs",
     "scripts/postinstall.mjs",
+    "scripts/patchwork-approval-hook.sh",
     "scripts/start-vps.sh",
     "scripts/gen-claude-desktop-config.sh",
     "scripts/smoke/run-all.mjs",

--- a/src/__tests__/npmArtifact.test.ts
+++ b/src/__tests__/npmArtifact.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Packaging guard: files the RUNTIME resolves by absolute path must actually
+ * ship in the npm tarball.
+ *
+ * Why this exists: `patchwork-os init` registers a Claude Code PreToolUse hook
+ * in the user's real `~/.claude/settings.json`, writing the absolute path that
+ * `resolveHookScriptPath()` returns. In 1.1.0-beta.4 that script was excluded
+ * from `files[]`, so an npm-installed user got a global CC config pointing at a
+ * script that does not exist — the approval gate silently absent, on every tool
+ * call, in every session. `npm run build` and the whole test suite stayed green,
+ * because nothing here ever looked at the tarball.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveHookScriptPath } from "../preToolUseHook.js";
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+/** File list `npm publish` would produce, without hitting the network. */
+function packedFiles(): string[] {
+  const out = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  const parsed = JSON.parse(out) as Array<{ files: Array<{ path: string }> }>;
+  return (parsed[0]?.files ?? []).map((f) => f.path.replace(/\\/g, "/"));
+}
+
+describe("npm artifact", () => {
+  it("ships the PreToolUse approval hook that init writes into ~/.claude/settings.json", () => {
+    const hookPath = resolveHookScriptPath();
+
+    // Guard the guard: if the script were merely missing from the repo, the
+    // packing assertion below would fail for the wrong reason and this test
+    // would stop meaning what it claims.
+    expect(
+      existsSync(hookPath),
+      `${hookPath} does not exist in the repo — the packaging assertion below would be vacuous`,
+    ).toBe(true);
+
+    const relative = path.relative(repoRoot, hookPath).replace(/\\/g, "/");
+    expect(packedFiles()).toContain(relative);
+  }, 60_000);
+});

--- a/src/__tests__/npmArtifact.test.ts
+++ b/src/__tests__/npmArtifact.test.ts
@@ -15,16 +15,31 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveHookScriptPath } from "../preToolUseHook.js";
+import { ensureCmdShim } from "../winShim.js";
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 
-/** File list `npm publish` would produce, without hitting the network. */
+/**
+ * File list `npm publish` would produce, without hitting the network.
+ *
+ * `ensureCmdShim` because npm on Windows is `npm.cmd` and `execFileSync` with
+ * `shell:false` resolves only `.exe` via PATHEXT — the repo's established
+ * spawn-site pattern (src/winShim.ts).
+ */
 function packedFiles(): string[] {
-  const out = execFileSync("npm", ["pack", "--dry-run", "--json"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    maxBuffer: 32 * 1024 * 1024,
-  });
+  // --ignore-scripts: `npm pack` otherwise runs the `prepare` lifecycle
+  // (husky), which has no bearing on the file list and is not something a
+  // test should be triggering.
+  const out = execFileSync(
+    ensureCmdShim("npm"),
+    ["pack", "--dry-run", "--json", "--ignore-scripts"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+      timeout: 90_000,
+    },
+  );
   const parsed = JSON.parse(out) as Array<{ files: Array<{ path: string }> }>;
   return (parsed[0]?.files ?? []).map((f) => f.path.replace(/\\/g, "/"));
 }
@@ -43,5 +58,5 @@ describe("npm artifact", () => {
 
     const relative = path.relative(repoRoot, hookPath).replace(/\\/g, "/");
     expect(packedFiles()).toContain(relative);
-  }, 60_000);
+  }, 120_000);
 });

--- a/src/__tests__/npmArtifact.test.ts
+++ b/src/__tests__/npmArtifact.test.ts
@@ -10,36 +10,38 @@
  * call, in every session. `npm run build` and the whole test suite stayed green,
  * because nothing here ever looked at the tarball.
  */
-import { execFileSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveHookScriptPath } from "../preToolUseHook.js";
-import { ensureCmdShim } from "../winShim.js";
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 
 /**
  * File list `npm publish` would produce, without hitting the network.
  *
- * `ensureCmdShim` because npm on Windows is `npm.cmd` and `execFileSync` with
- * `shell:false` resolves only `.exe` via PATHEXT — the repo's established
- * spawn-site pattern (src/winShim.ts).
+ * Runs through a shell deliberately. On Windows npm is `npm.cmd`, and since
+ * the CVE-2024-27980 fix Node refuses to spawn a `.cmd`/`.bat` without a
+ * shell — `execFileSync("npm", …)` fails ENOENT and `execFileSync("npm.cmd",
+ * …)` fails EINVAL, which is exactly the pair CI walked through. A shell
+ * resolves the shim via PATHEXT and works unchanged on POSIX. Passing one
+ * command string rather than an args array also avoids Node's DEP0190
+ * warning about unescaped args under `shell: true`; it is safe here because
+ * the command is a constant with nothing interpolated into it.
+ *
+ * --ignore-scripts: `npm pack` otherwise runs the `prepare` lifecycle (husky),
+ * which has no bearing on the file list and is not a test's business to fire.
  */
+const PACK_CMD = "npm pack --dry-run --json --ignore-scripts";
+
 function packedFiles(): string[] {
-  // --ignore-scripts: `npm pack` otherwise runs the `prepare` lifecycle
-  // (husky), which has no bearing on the file list and is not something a
-  // test should be triggering.
-  const out = execFileSync(
-    ensureCmdShim("npm"),
-    ["pack", "--dry-run", "--json", "--ignore-scripts"],
-    {
-      cwd: repoRoot,
-      encoding: "utf8",
-      maxBuffer: 32 * 1024 * 1024,
-      timeout: 90_000,
-    },
-  );
+  const out = execSync(PACK_CMD, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+    timeout: 90_000,
+  });
   const parsed = JSON.parse(out) as Array<{ files: Array<{ path: string }> }>;
   return (parsed[0]?.files ?? []).map((f) => f.path.replace(/\\/g, "/"));
 }

--- a/src/__tests__/patchworkInit.test.ts
+++ b/src/__tests__/patchworkInit.test.ts
@@ -159,6 +159,51 @@ describe("patchwork-init", () => {
     expect(out).not.toMatch(/Restart Claude Code/);
   });
 
+  /** Run init with stdout captured, returning everything it printed. */
+  async function captureInit(
+    argv: string[],
+    opts: Parameters<typeof runPatchworkInit>[1],
+  ): Promise<string> {
+    const writes: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      writes.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await runPatchworkInit(argv, opts);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    return writes.join("");
+  }
+
+  // An npm install ships no `dashboard/` (it's a Next.js app needing its own
+  // build), but init printed "open http://localhost:3200" regardless — sending
+  // every npm-installed user to a dead port on their very first command.
+  it("does not advertise the dashboard when it is not installed", async () => {
+    const out = await captureInit([], { home: fakeHome, dashboardDir: null });
+
+    expect(out).not.toMatch(/localhost:3200/);
+    expect(out).toMatch(/not part of the npm package/);
+    // The zero-connector first-success step must survive the renumbering.
+    expect(out).toMatch(/recipe run daily-status/);
+  });
+
+  it("still advertises the dashboard from a repo checkout", async () => {
+    // findDashboardDir only returns a directory that actually exists, so the
+    // repo-checkout case must be set up that way to be a real rehearsal.
+    const { mkdirSync } = await import("node:fs");
+    const dashboardDir = join(fakeHome, "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    writeFileSync(join(dashboardDir, "package.json"), "{}");
+
+    const out = await captureInit([], { home: fakeHome, dashboardDir });
+
+    expect(out).toMatch(/localhost:3200/);
+    expect(out).not.toMatch(/not part of the npm package/);
+  });
+
   it("preserves unrelated PreToolUse hooks already in settings.json", async () => {
     const { mkdirSync } = await import("node:fs");
     const ccDir = join(fakeHome, ".claude");

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -86,7 +86,10 @@ function findDashboardDir(): string | null {
   return null;
 }
 
-export function ensureDashboardEnv(patchworkDir: string): {
+export function ensureDashboardEnv(
+  patchworkDir: string,
+  dashboardDirOverride?: string | null,
+): {
   password: string;
   generated: boolean;
 } {
@@ -107,7 +110,10 @@ export function ensureDashboardEnv(patchworkDir: string): {
     mode: 0o600,
   });
   // Also write dashboard/.env.local so Next.js picks up credentials without start-all sourcing
-  const dashDir = findDashboardDir();
+  const dashDir =
+    dashboardDirOverride !== undefined
+      ? dashboardDirOverride
+      : findDashboardDir();
   if (dashDir) {
     const localPath = join(dashDir, ".env.local");
     let local = existsSync(localPath) ? readFileSync(localPath, "utf8") : "";
@@ -213,7 +219,17 @@ interface InitResult {
 
 export async function runPatchworkInit(
   argv: string[],
-  opts: { cwd?: string; home?: string; quiet?: boolean } = {},
+  opts: {
+    cwd?: string;
+    home?: string;
+    quiet?: boolean;
+    /**
+     * Override dashboard discovery. Tests inject `null` to exercise the
+     * npm-install shape, where the Next.js app is not on disk at all —
+     * unreachable otherwise, since a repo checkout always finds it.
+     */
+    dashboardDir?: string | null;
+  } = {},
 ): Promise<InitResult> {
   const parsed = parseArgs(argv);
   if ("help" in parsed) {
@@ -244,7 +260,9 @@ export async function runPatchworkInit(
   }
   log(`  ✓ ~/.patchwork scaffolded\n`);
 
-  const dashEnv = ensureDashboardEnv(patchworkDir);
+  const dashboardDir =
+    opts.dashboardDir !== undefined ? opts.dashboardDir : findDashboardDir();
+  const dashEnv = ensureDashboardEnv(patchworkDir, dashboardDir);
   if (dashEnv.generated)
     log(`  ✓ ~/.patchwork/.env created with dashboard credentials\n`);
 
@@ -380,12 +398,27 @@ export async function runPatchworkInit(
     ? `\n  Dashboard password: ${dashEnv.password}  (saved to ~/.patchwork/.env)\n`
     : "";
 
-  log(`${restartLine}${dashPasswordLine}
-Next:
-  1. patchwork start                           # launch bridge + dashboard
+  // The dashboard is a Next.js app that ships only in a repo checkout, not in
+  // the npm tarball (it needs its own `npm install` + `next build`). Printing
+  // "open http://localhost:3200" unconditionally sent every npm-installed user
+  // to a port nothing is listening on.
+  const dashboardSteps =
+    dashboardDir !== null
+      ? `  1. patchwork start                           # launch bridge + dashboard
   2. open http://localhost:3200                # dashboard (use password printed above)
   3. patchwork-os recipe run daily-status      # zero-config: yesterday's commits + today's hints
-  4. patchwork-os init --with-connectors       # add gmail/github/linear/etc. recipes\n`);
+  4. patchwork-os init --with-connectors       # add gmail/github/linear/etc. recipes\n`
+      : `  1. patchwork start                           # launch the bridge
+  2. patchwork-os recipe run daily-status      # zero-config: yesterday's commits + today's hints
+  3. patchwork-os init --with-connectors       # add gmail/github/linear/etc. recipes
+
+  The web dashboard is not part of the npm package — it ships with the repo.
+  To run it: clone https://github.com/Oolab-labs/patchwork-os, then
+  \`cd dashboard && npm install && npm run build && npm start\`.\n`;
+
+  log(`${restartLine}${dashPasswordLine}
+Next:
+${dashboardSteps}`);
 
   return {
     configPath,


### PR DESCRIPTION
## The defect

`patchwork-os init` registers a Claude Code PreToolUse hook by writing the absolute path `resolveHookScriptPath()` returns ([src/preToolUseHook.ts:34](../blob/main/src/preToolUseHook.ts#L34)) into the user's real `~/.claude/settings.json`. `scripts/patchwork-approval-hook.sh` was never listed in `files[]`.

So an npm-installed user ends up with a **global Claude Code config pointing at a script that does not exist** — on every tool call, in every session. This is not "the approval gate is missing"; init actively corrupts CC's configuration.

Verified against the published artifact, not inferred:

```
$ npm pack patchwork-os@beta && tar tzf patchwork-os-1.1.0-beta.4.tgz | grep approval-hook
  (no output)
```

## Why the suite didn't catch it

Nothing in the repo had ever looked at the tarball. `npm run build` and 9k+ tests stay green while the shipped artifact is broken, because every test resolves paths in a repo checkout where the script is present.

The new `npmArtifact.test.ts` asserts over `npm pack --dry-run --json` and derives the expected path from `resolveHookScriptPath()` rather than hardcoding it, so it stays coupled to what the runtime actually resolves. It also asserts the script exists on disk first — otherwise deleting the file would make the packing assertion pass vacuously.

## Second half: the dashboard

init printed `open http://localhost:3200` unconditionally, though `dashboard/` is also absent from the tarball (0 entries).

**Adding `dashboard/` to `files[]` would not fix this.** It's a Next.js app with 16 dependencies needing its own `npm install` + `next build`, neither of which a global install runs. Shipping the source gives a ~10× bigger tarball and a port that still refuses connections — which reads as *more* broken, not less. Prebuilt `next build --standalone` output is the real answer and is separate release-engineering work.

So the next-steps text now branches on dashboard presence and tells npm users where to get it. The `dashboardDir` test seam exists because the broken path is otherwise unreachable — a repo checkout always finds the dashboard.

## Verification

- New packaging test: red before (`expected [...] to include 'scripts/patchwork-approval-hook.sh'`), green after.
- Dashboard test mutation-probed: forcing the old unconditional branch turns `does not advertise the dashboard when it is not installed` red.
- Hook script is `0755`; npm preserves the executable bit.
- `npm run typecheck`: 34 errors before and after — all pre-existing, in `src/ta/desk/` and `src/recipes/tools/{ta,watchlist}`.

## Out of scope, flagged

`npm run build` exits **2 on clean `main`**, entirely in those same TA/watchlist files. Pre-existing and unrelated, but it means the repo's headline build command is currently red.

## Follow-ups (separate PRs)

1. `patchwork init` reaches the *legacy* bridge installer — `invokedBinaryName()` reads `process.env._`, which npx does not set to the bin. Confirmed: `npx patchwork-os@beta init --help` prints `claude-ide-bridge init`.
2. `engines.node: ">=20"` is tested by no CI job (every workflow pins 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)