### PR TITLE
docs(readme): describe what the software actually does on a clean machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Three ideas, one runtime:
 
 ## Status: beta
 
-Version `1.1.0-beta.x`. The decision layer, recipes, connectors and IDE bridge all work and are dogfooded daily, but interfaces still move between betas and some surfaces are rougher than others. Pin an exact version if you are building on it.
+Version `1.2.0-beta.x`. The decision layer, recipes, connectors and IDE bridge all work and are dogfooded daily, but interfaces still move between betas and some surfaces are rougher than others. Pin an exact version if you are building on it.
 
 **The safety features are opt-in, not the default.** This matters more than any other line in this README:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 > **You don't have an automation problem. You have a decision problem.**
 
-Every AI-agent horror story ends the same way: an action nobody stopped to question. Patchwork OS is the layer between the agent's impulse and the action — a local-first runtime where your AI can automate real work across your editor, GitHub, Slack, Gmail, and 45+ services, while **anything consequential stops and asks you first**.
+Every AI-agent horror story ends the same way: an action nobody stopped to question. Patchwork OS is the layer between the agent's impulse and the action — a local-first runtime where your AI can automate real work across your editor, GitHub, Slack, Gmail, and 45+ services, while **anything consequential can be made to stop and ask you first**.
+
+**Who it's for:** developers and technical operators who already run agents against real systems — a repo that ships, an inbox that matters, a production service — and who want a record of what was allowed and why. It expects a terminal, a Node install, and comfort editing YAML.
 
 Three ideas, one runtime:
 
@@ -17,50 +19,97 @@ Three ideas, one runtime:
 
 - **Every decision leaves a receipt.** What was done, why it was allowed, and how it turned out — durable, replayable, explainable via `patchwork judgments`, the dashboard's traces page, and `patchwork gate explain`. When you approve something, you find out later whether you were right.
 
-All of it runs on your machine: your model (Claude, GPT, Gemini, Grok, or local Ollama), your credentials, your logs. Nothing phones home unless you opt in to [anonymous analytics](#telemetry).
-
 ![Patchwork OS dashboard](docs/images/dashboard-overview.png)
 
----
+## Status: beta
 
-## 90-second start (no editor required)
+Version `1.1.0-beta.x`. The decision layer, recipes, connectors and IDE bridge all work and are dogfooded daily, but interfaces still move between betas and some surfaces are rougher than others. Pin an exact version if you are building on it.
 
-```bash
-npx patchwork-os@beta init   # scaffolds ~/.patchwork, prints your dashboard login
-patchwork start              # bridge + dashboard
+**The safety features are opt-in, not the default.** This matters more than any other line in this README:
+
+| Feature | Default | Turn it on with |
+|---|---|---|
+| Approval queue | **off** (`approvalGate: "off"`) | `--approval-gate high` or `all` |
+| Worker autonomy gate | **off** | `PATCHWORK_FLAG_WORKER_AUTONOMY=1` (needs `--driver subprocess`) |
+| Kill switch | available always | `patchwork panic` |
+| Telemetry | **off** | opt in explicitly ([details](#telemetry)) |
+
+Install Patchwork and nothing is gated until you say so. A fresh install is an automation runtime, and it becomes a decision layer when you switch the gate on. Everything above about "stops and asks you first" describes what the gate does once enabled — not what happens out of the box.
+
+## The loop
+
+```
+trigger → recipe/worker → reversible?           → runs
+                        → risky, gate on        → approval queue → your yes → receipt
+                        → risky, gate off       → runs
+                        → forbidden by policy   → refused (no approval unlocks it)
 ```
 
-Open http://localhost:3200. From the browser: run and schedule YAML recipes, connect services (Gmail, Calendar, Slack, GitHub…), review what your agents drafted, and approve — or refuse — anything that wants to leave the machine.
+`patchwork panic` blocks every write-tier tool call across all running bridges, immediately. Reads keep working, and in-flight reasoning is not killed — it is a write block, not a full stop.
 
-Prereqs: Node 22+. macOS, Linux, and native Windows (no WSL).
-
-The hero workflow — Morning Brief:
+## Install
 
 ```bash
-patchwork init --with-connectors   # seeds the connector-backed recipes too
+npm install -g patchwork-os@beta
+patchwork-os init
+```
+
+`init` scaffolds `~/.patchwork`, seeds local-only recipes, and registers Patchwork's PreToolUse hook in `~/.claude/settings.json`. Restart Claude Code afterwards — it reads hooks at session start.
+
+**Prereqs:** Node 22+. macOS, Linux, and native Windows (no WSL).
+
+Two things worth knowing before you start:
+
+- **Use a global install, not `npx`.** `npx` does not persist the binary, so the very next command in any guide will not be found.
+- **The web dashboard is not in the npm package.** It's a Next.js app that needs its own build, so it ships with the repo:
+  ```bash
+  git clone https://github.com/Oolab-labs/patchwork-os && cd patchwork-os/dashboard
+  npm install && npm run build && npm start   # http://localhost:3200
+  ```
+  Everything below works from the CLI without it. The dashboard is where approvals, traces and connector setup are pleasant rather than possible.
+
+## First run: zero connectors
+
+Prove the runtime works before wiring any service to it. `daily-status` touches only git and local files — no accounts, no network:
+
+```bash
+patchwork recipe run daily-status
+```
+
+It reads your commits since yesterday plus `~/.patchwork/planned.md`, and writes a Markdown digest to `~/.patchwork/inbox/daily-status-<date>.md`. If that file exists, your install is sound.
+
+Useful neighbours: `patchwork recipe list`, `patchwork status`, `patchwork recipe doctor <name>` when something misbehaves.
+
+## Morning Brief: the connected workflow
+
+```bash
+patchwork-os init --with-connectors   # seeds the connector-backed recipes
 patchwork connect gmail
 patchwork connect google-calendar
+patchwork connect github
+patchwork connect linear
 patchwork recipe run morning-brief
 ```
 
-Every morning: a digest of your email, calendar, and overnight agent activity lands in your inbox as Markdown, with any drafted replies waiting for your approval — never auto-sent. No connectors yet? `--local` runs it against Ollama with your clipboard and recent files.
+The recipe pulls unread mail, today's calendar, your open GitHub issues and PRs, Linear issues, and local git activity, then has a model summarise them into one Markdown brief in `~/.patchwork/inbox/`. Its email step is **triage** — it lists what needs an answer; it does not compose or send replies. Nothing leaves your machine except the API calls to the services you connected.
 
-## How it works
+All four connectors are required as written — no step is guarded, so a missing one halts the run. Drop the steps you don't want, or start from `daily-status` and add sources one at a time.
 
-Recipes are plain YAML: a trigger (cron, file save, git commit, test run, or any webhook — iPhone Shortcut, Stream Deck, Home Assistant) plus steps. Share them like dotfiles, install them from the marketplace, or let the dashboard generate one from a sentence.
+Requires a working model driver (`--driver subprocess` with the Claude CLI on PATH, or an API key). `patchwork recipe preflight templates/recipes/morning-brief.yaml` lists exactly what a recipe needs before you run it.
 
-Workers are recipes with an identity and a track record. A worker that triages failing CI starts by only proposing ("this looks like a real break — file an issue?"). Confirm its filings were real and it earns a longer leash — for that job only. It can be demoted in one bad day. You can cap any worker permanently with one line of YAML.
+## Two ways to run this
 
-The queue is where impulse meets judgment. Requests arrive sorted by blast radius with evidence inline. `patchwork panic` stops all automation instantly.
+**As an automation runtime** — recipes, workers, connectors, the decision layer. Needs `~/.patchwork` and a model driver; an editor is optional.
 
+```bash
+patchwork start        # bridge + Claude + dashboard
 ```
-trigger → recipe/worker → [reversible? → run]
-                           [risky?      → approval queue → your yes → receipt]
-```
 
-### Also in the box: the Claude IDE Bridge
+`patchwork start` launches `claude --ide` alongside the bridge, so it expects the **Claude CLI on your PATH**. Use `patchwork start --no-dashboard`, or run the bridge alone with `patchwork --workspace .`, if you don't want that.
 
-The foundation layer is a standalone MCP bridge that gives Claude Code eyes and hands in your editor — 180 tools: diagnostics, LSP navigation, refactoring with risk analysis, debugger, terminal, git/GitHub, file ops.
+On a global npm install there is no `dashboard/` to start, so it logs a dashboard warning and carries on with bridge + Claude; pass `--no-dashboard` to silence it. From a repo clone it starts all three.
+
+**As a standalone IDE bridge** — 180 MCP tools giving Claude Code eyes and hands in your editor: diagnostics, LSP navigation, refactoring with risk analysis, debugger, terminal, git/GitHub, file ops. No `~/.patchwork`, no recipes, no gate.
 
 ```bash
 npm install -g patchwork-os
@@ -71,7 +120,17 @@ claude --ide                            # in another terminal
 
 JetBrains via a companion plugin. Claude Desktop, Gemini CLI, Codex CLI, Grok Build, and claude.ai connect over stdio or HTTP. Use the bridge alone forever if that's all you need; the runtime is an optional layer on top.
 
-`claude --ide` can't find an IDE? Set `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true` (`patchwork init` does this for you).
+`claude --ide` can't find an IDE? Set `CLAUDE_CODE_IDE_SKIP_VALID_CHECK=true` (`init` does this for you).
+
+## What "local-first" does and doesn't mean
+
+**On your machine:** the runtime, every recipe and worker, all credentials and connector tokens, the approval queue, and every log and decision receipt under `~/.patchwork/`. Nothing is uploaded, and no Patchwork-operated server sits in any path.
+
+**Over the network, necessarily:** calls to whatever model you point it at (Anthropic, OpenAI, Google, xAI) and to every connector you authorise (Gmail, GitHub, Slack…). Prompts, and whatever context a step feeds them, go to that model provider. Choosing a local Ollama endpoint keeps inference on your machine too; connector calls still leave it, because that is what a connector is.
+
+**Only if you opt in:** [anonymous analytics](#telemetry).
+
+Other boundaries worth knowing: `runCommand` executes only allowlisted commands, `sendHttpRequest` blocks private and loopback ranges, and file tools refuse symlink escapes out of the workspace. Remote deployments must sit behind TLS with OAuth 2.0 — see [docs/remote-access.md](docs/remote-access.md).
 
 ## What's here
 
@@ -86,6 +145,10 @@ JetBrains via a companion plugin. Claude Desktop, Gemini CLI, Codex CLI, Grok Bu
 - **Oversight** — web dashboard · mobile push approvals (PWA) · halts/judgments CLI · trace memory across sessions
 
 - **Deployment** — your laptop · headless VPS with OAuth 2.0 ([guide](docs/remote-access.md)) · native Windows
+
+Recipes are plain YAML: a trigger (cron, file save, git commit, test run, or any webhook — iPhone Shortcut, Stream Deck, Home Assistant) plus steps. Share them like dotfiles, install them from the marketplace, or let the dashboard generate one from a sentence.
+
+Workers are recipes with an identity and a track record. A worker that triages failing CI starts by only proposing ("this looks like a real break — file an issue?"). Confirm its filings were real and it earns a longer leash — for that job only. It can be demoted in one bad day. You can cap any worker permanently with one line of YAML.
 
 Why not Zapier / an MCP server / a hosted assistant? Honest tradeoffs: [documents/comparison.md](documents/comparison.md).
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-10 `docs/readme-onboarding-accuracy` — README-review phase 3 of 3 (the README itself). Rewrites the top half against the nine-part structure while preserving the headline, three-part decision model, feature map, comparison link and telemetry section. Every corrected claim was re-verified against the code, not the review notes: `approvalGate` defaults to "off" (src/server.ts) and worker autonomy is flag-gated, so both are now stated as OPT-IN with a defaults table — the previous text presented them as baseline behaviour, which is the one inaccuracy that could actually get someone hurt. Morning Brief rewritten from the real recipe (gmail/calendar/github/linear/git + claude-code): no drafted replies, no overnight-agent inspection, no clipboard, no Ollama-via-`--local` (`--local` skips bridge dispatch). `panic` blocks write-tier tools, not "all automation". Adds the zero-connector `daily-status` first-success step, the npm-install-vs-repo split for the dashboard, and a local-first section that says plainly which traffic DOES leave the machine (model + connector calls). Two claims I wrote and then had to correct before shipping: the Linear step is NOT optional (no `when:` guard, so a missing connector halts the run) and `patchwork start` warns rather than starting a dashboard that isn't in the npm package. Depends on #1324/#1325/#1326 being PUBLISHED, not just merged — the install section describes fixes that are on main but not on npm.
 
 
 


### PR DESCRIPTION
Phase 3 of the README review. Rewrites the top half against the agreed nine-part structure, preserving the headline, three-part decision model, feature map, comparison link and telemetry section.

## ⚠️ Sequencing

**The install section describes #1324/#1325/#1326 — merged to `main`, not yet on npm.** Today `npm install -g patchwork-os@beta` still ships `1.1.0-beta.4`, whose `init` writes a broken hook path into the user's `~/.claude/settings.json`. This PR should land **with or after** that release, not before.

## The correction that matters most

The README presented the approval queue and worker autonomy as baseline behavior. **Both are opt-in:**

| Feature | Default | Verified at |
|---|---|---|
| `approvalGate` | `"off"` | [src/server.ts:491](../blob/main/src/server.ts#L491), plus 3 more sites |
| Worker autonomy | off | `PATCHWORK_FLAG_WORKER_AUTONOMY` |

A fresh install gates nothing. The README now says so in a defaults table rather than implying protection nobody enabled — the one inaccuracy here that could actually get someone hurt.

## Other corrections, each re-verified against code

| Claim | Reality |
|---|---|
| Morning Brief drafts replies, reads clipboard/recent files, inspects overnight agent activity, runs on Ollama via `--local` | Recipe uses gmail, calendar, github, linear, git, claude-code. Email step is **triage**. `--local` skips bridge dispatch — unrelated to model choice |
| `patchwork panic` "stops all automation" | Blocks **write-tier** tools; reads keep working |
| `npx patchwork-os@beta init` | npx doesn't persist the binary; the next command 404s. Global install |
| Dashboard "just works" | Next.js app needing its own build — **not in the npm package**. Documented as repo-only |
| `patchwork start` | Launches `claude --ide`; needs the Claude CLI. Warns about the absent dashboard on npm installs |
| Node 22+ vs `engines >=20` | Resolved by #1326; README was already right |

Plus the two structural additions: a zero-connector `daily-status` first success (prove the runtime before wiring accounts to it), and a local-first section stating which traffic **does** leave the machine — model calls and connector calls. Claiming otherwise while shipping 45+ connectors would be exactly the kind of claim this project exists to argue against.

## Two claims I got wrong and caught before shipping

- I wrote that the Linear step was optional. It has no `when:` guard, so a missing connector halts the run. Corrected to "all four required as written."
- I wrote that `patchwork start` starts the dashboard. `DASH_DIR` resolves inside the package, so on a global install it tries to `npm install` a directory that doesn't exist and warns.

Both came from checking rather than assuming, which is the same reason the phase-1 findings held up.

## Verification

- All 15 link targets exist.
- `audit-docs-wired` and `audit-in-flight` exit 0.
- No secrets/domains in the diff.

## Not addressed here

The hero screenshot is still the existing dashboard image. The review asked for an approval → decision-receipt capture; that needs a real run against a real queue, and I'm not going to fabricate a receipt image. Worth doing as a follow-up with a genuine capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)