### PR TITLE
chore(release): bump to 1.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.0-beta.1] — 2026-08-10
+
+A minor bump rather than another `beta.N`, because this is a feature line: workspace identity, a third terminal gate state (`forbid`), the prospective control boundary, durable approvals and trust evidence, and the Butler surface — plus, at the end, four fixes to onboarding that a review of the public README turned up.
+
+**The published onboarding path was broken, and these are the fixes.** If you installed `1.1.0-beta.4` from npm, `patchwork-os init` wrote a PreToolUse hook into your real `~/.claude/settings.json` pointing at a script that was never shipped in the tarball. Re-run `patchwork-os init` after upgrading to repair the entry.
+
+### Added
+
+- **Workspace identity** (`src/identity/`): members, roles (`owner`/`admin`/`operator`/`approver`/`auditor`/`worker`) and segregation of duties, loaded from `members.json` at bridge startup. Fail-soft — a missing or malformed roster yields one implicit owner, byte-identical to previous behaviour. Not yet wired to authorisation: it exists so a decision record can name a real member (#1228, #1230).
+- **`forbid` — a third terminal gate state** that no approval unlocks, evaluated before the agent carve-out, reversibility short-circuit and all trust maths, because any branch running earlier is a path around it. Configured via `forbidRules`, entirely opt-in (#1231, #1233, #1249).
+- **Control boundary**: `previewActions` buckets candidate actions into *may do now / needs approval / not permitted* **before** anything is attempted, routed through the same decision path as enforcement so preview and gate cannot drift. Exposed as `GET /workers/boundary` and a three-column dashboard view (#1236, #1239–#1244).
+- **Durable approvals** (ADR-0018): approval requests survive a bridge restart, with risk-tiered timeouts (low 5 min / medium 1 h / high 4 h), live-configurable (#1214, #1245, #1246).
+- **Durable trust evidence**: per-recipe trust checkpoints so a worker is no longer silently un-earned when its runs rotate out of `runs.jsonl` (#1307).
+- **Actor attribution** on gate decisions, stored as a snapshot rather than a roster reference so a rename cannot rewrite history (#1232, #1235).
+- **Butler**: durable fact store and memory tools, an ambient memory card in the MCP instructions block, task-management action classes with an errands worker, standing permissions, an HTTP surface, and a large-print page (#1271–#1273, #1278–#1280, #1317).
+- **Codex driver**: `--driver codex`, selectable as a recipe agent-step driver (#1199–#1201).
+- **`fan_out` agent sub-steps**, budget-admitted per iteration (#1257).
+- **MCP elicitation** for missing required recipe vars (#1223).
+
+### Fixed
+
+#### Onboarding — the published npm artifact
+- `scripts/patchwork-approval-hook.sh` is now in `files[]`. `init` writes its absolute path into the user's `~/.claude/settings.json`, so excluding it left an npm-installed user with a global Claude Code config pointing at a nonexistent script (#1324).
+- `init` no longer advertises a dashboard that is not in the npm package; the next-steps text branches on whether one is present (#1324).
+- `init` means the same command whichever bin you type. The check keyed off `process.env._`, which npx does not set to the resolved bin, so `npx patchwork-os@beta init` silently ran the *legacy* IDE-bridge installer instead of the documented setup (#1325).
+- `engines.node` raised to `>=22.0.0` to match the only Node version CI tests, with a guard that fails if the declared floor drifts below the CI matrix again (#1326).
+
+#### Trust evidence integrity
+Four related fixes, each closing a path where unconfirmed work became earned trust:
+- Outcomes key on the action (`tool:id`) rather than a URL that no tool in the real run log ever returned (#1318).
+- The strict outcome join is now the default: a non-reversible success with no recorded human disposition is withheld, not credited (#1319).
+- Agent (reasoning) steps stop counting as evidence in either direction — the gate always carved them out, the fold never mirrored it, and 50 unconfirmed agent successes were folding as earned trust (#1320).
+- An action that cannot be identified is not an approved one: unkeyable non-reversible successes are withheld rather than falling through (#1322).
+
+#### Other
+- The shadow gate now agrees with the gate it shadows, and honours the worker's own forbids (#1299, #1300).
+- Connector reads were classified as irreversible and gated; irreversible writes were missing a real domain (#1313, #1314).
+- Audit ledgers ignored `PATCHWORK_HOME` (#1308).
+- Butler: undo was a trust escalator; the approvals section could not render and reject reported the wrong outcome (#1292, #1296, #1316).
+- Todoist targeted a retired API version (#1315).
+- `--help` advertised a verb that does not exist, and omitted two that do (#1304).
+- 40+ further fixes across recipes, dashboard, OAuth, CI and deploy scripts.
+
+### Notes
+
+- The VS Code extension stays at `1.4.25` — only its docs changed this cycle, no handler code.
+- **The safety features remain opt-in.** `approvalGate` defaults to `"off"` and the worker autonomy gate is behind `PATCHWORK_FLAG_WORKER_AUTONOMY`. Nothing is gated on a fresh install until you enable it.
+
+---
+
 ## [1.1.0-beta.4] — 2026-07-17
 
 Five new trust-architecture layers (deterministic policy enforcement, circuit breakers, ephemeral rollback, flight-recorder replay for flat recipes) plus dashboard/copilot recipe & worker creation, followed by a 20-pass bug-mining sweep that found and fixed 28 defects — most in a recurring class: a safety gate, audit-reason capture, cache-freshness rule, or response-check present on one code path but silently absent from a logically-identical sibling (single-item vs. bulk action, one dashboard entry point vs. another, one write chokepoint vs. another).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Patchwork OS ships an npm package, IDE extensions, a Docker image, an OAuth 2.0 
 
 ## Supported Versions
 
-The current prerelease channel is **beta** (`patchwork-os@1.1.0-beta.x`).
+The current prerelease channel is **beta** (`patchwork-os@1.2.0-beta.x`).
 
 | Channel | Status | Get fixes? |
 |---|---|---|
@@ -72,7 +72,7 @@ Out of scope (please do not test against without permission):
 
 For users running Patchwork OS:
 
-- Pin to a specific `1.1.0-beta.X` rather than the floating `@beta` or `@latest` tag if reproducibility matters more than fast updates.
+- Pin to a specific `1.2.0-beta.X` rather than the floating `@beta` or `@latest` tag if reproducibility matters more than fast updates.
 - The bridge auth token in `~/.claude/ide/<port>.lock` is mode `0o600`; preserve those permissions.
 - The write kill switch (`PATCHWORK_WRITES_DISABLED`) is captured at startup and frozen — do not rely on runtime mutation to disable writes.
 - For remote deployments, always front the bridge with a TLS-terminating reverse proxy. See [docs/remote-access.md](docs/remote-access.md).

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -137,7 +137,7 @@ Your preference is stored in `~/.claude/ide/analytics.json` (mode `0600`).
 
 At the end of each session, a single anonymized summary is POSTed to `https://analytics.claude-ide-bridge.dev/v1/usage`:
 
-- Bridge version (e.g. `1.1.0-beta.4`)
+- Bridge version (e.g. `1.2.0-beta.1`)
 - Session duration in milliseconds
 - Per-tool counts: `{tool: string, calls: number, errors: number, p50Ms: number, p95Ms: number}`
   - **Built-in tool names** (a fixed allowlist — `getDiagnostics`, `readFile`, `runCommand`, etc.) are sent verbatim

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchwork-os",
-  "version": "1.1.0-beta.4",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patchwork-os",
-      "version": "1.1.0-beta.4",
+      "version": "1.2.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -43,7 +43,7 @@
         "vitest": "^4.1.8"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "1.1.0-beta.4",
+  "version": "1.2.0-beta.1",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release PR for **1.2.0-beta.1**. 124 commits since `1.1.0-beta.4` (33 `feat`, 48 `fix`).

## Why a minor bump, not `beta.5`

This is a feature line, not a patch: workspace identity, `forbid` as a third terminal gate state, the prospective control boundary, durable approvals, durable trust evidence, the Butler surface, and a Codex driver. `1.2.0-beta.1` tells a user something `1.1.0-beta.5` doesn't.

It still matches the `v*-beta*` publish trigger. (A stable `v1.2.0` would **not** have — `publish-npm.yml` only fires on `v*-alpha*` / `v*-beta*` tags, so a stable release needs a workflow change first. Worth knowing before the next one.)

## Why this release matters more than its size

The published `1.1.0-beta.4` artifact broke onboarding: `patchwork-os init` wrote a PreToolUse hook into the user's real `~/.claude/settings.json` pointing at a script excluded from the tarball, and `npx patchwork-os@beta init` silently ran the *legacy* installer. Fixed in #1324–#1326.

**The changelog tells upgraders to re-run `patchwork-os init`**, because nothing else repairs the bad settings entry already written to their machine.

## Contents

| File | Change |
|---|---|
| `package.json` | `1.1.0-beta.4` → `1.2.0-beta.1` |
| `package-lock.json` | synced via `npm install --package-lock-only` |
| `CHANGELOG.md` | new section |
| `SECURITY.md`, `docs/privacy-policy.md` | version references |

The `audit-version-drift` gate caught those last two pinning `1.1.0-beta.x`; updated rather than allowlisted, since they're live claims and not historical references.

**Extension stays at `1.4.25`** — only its docs changed this cycle, no handler code. The bump rule exists for `.vsix` cache-busting, which doesn't apply.

## Verification

- `audit-version-drift`, `audit-in-flight`, `audit-docs-wired`, `audit-lsp-tools`: all exit 0
- Onboarding tests green (`npmArtifact`, `enginesMatchCi`, `initDispatch`, `patchworkInit`)
- Tag pattern confirmed to match `v*-beta*`

**Correction to something I reported earlier in this campaign:** I said `npm run build` was red on `main`. It isn't. Those errors come from untracked local TA/watchlist files that were never committed — a `git archive` of `main` contains no `src/ta/` at all, and CI's Build step has passed throughout. This matters here because `publish-npm.yml` runs `npm run build` before publishing; that path is clean.

## After merge

Publishing is tag-triggered, so this PR alone ships nothing:

```bash
git checkout main && git pull                      # pull FIRST — tag fires CI instantly
node -p "require('./package.json').version"        # must print 1.2.0-beta.1
git tag v1.2.0-beta.1 && git push origin v1.2.0-beta.1
```

Then verify with `npm view patchwork-os dist-tags`. Promoting to `latest` is a separate manual `npm dist-tag` step.

Depends on nothing; [#1328](https://github.com/Oolab-labs/patchwork-os/pull/1328) (README) is updated to the `1.2.0-beta` line and should merge **after** this publishes, since it documents the fixed install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)