### PR TITLE
fix(test): npm 12 changed the pack --json shape, breaking the release

### DIFF
--- a/src/__tests__/npmArtifact.test.ts
+++ b/src/__tests__/npmArtifact.test.ts
@@ -42,8 +42,34 @@ function packedFiles(): string[] {
     maxBuffer: 32 * 1024 * 1024,
     timeout: 90_000,
   });
-  const parsed = JSON.parse(out) as Array<{ files: Array<{ path: string }> }>;
-  return (parsed[0]?.files ?? []).map((f) => f.path.replace(/\\/g, "/"));
+  const parsed: unknown = JSON.parse(out);
+
+  // npm changed this shape in v12: an ARRAY of pack results became an OBJECT
+  // keyed by package name. The publish workflow runs `npm install -g npm@latest`
+  // before testing, so it hit v12 while every PR job was still on v11 — the
+  // release failed on a test that had been green all day. Accept both.
+  //
+  //   npm 11: [ { files: [ { path } ] } ]
+  //   npm 12: { "patchwork-os": { files: [ { path } ] } }
+  const entries = Array.isArray(parsed)
+    ? (parsed as Array<{ files?: Array<{ path: string }> }>)
+    : Object.values(
+        (parsed ?? {}) as Record<string, { files?: Array<{ path: string }> }>,
+      );
+  const files = entries.flatMap((e) => e?.files ?? []);
+
+  // Fail loudly on the NEXT shape change rather than returning an empty list.
+  // Without this the failure reads "expected [] to include <path>", which
+  // accuses the packaging of a defect the packaging does not have — and an
+  // assertion phrased the other way round would have passed vacuously.
+  if (files.length === 0) {
+    throw new Error(
+      `npm pack returned no files — likely another --json shape change ` +
+        `(npm ${execSync("npm -v", { encoding: "utf8" }).trim()}). ` +
+        `Raw output began: ${out.slice(0, 200)}`,
+    );
+  }
+  return files.map((f) => f.path.replace(/\\/g, "/"));
 }
 
 describe("npm artifact", () => {


### PR DESCRIPTION
**Unblocks the v1.2.0-beta.1 publish, which failed.** Nothing was published — the publish step is gated behind `npm test`, so npm still serves `1.1.0-beta.4` and there is no partial release to clean up.

## What happened

`publish-npm.yml` runs `npm install -g npm@latest` before `npm test`. That put the release job on **npm 12** while every PR job was still on **npm 11**, and npm 12 changed `pack --dry-run --json` from an array to an object keyed by package name:

```
npm 11: [ { files: [ { path } ] } ]
npm 12: { "patchwork-os": { files: [ { path } ] } }
```

`parsed[0]?.files` became `undefined`, the list came back empty, and the release failed on a test that had been green all day — including on its own release PR.

## The fix

Accepts both shapes, and throws with the npm version and raw output head if the list is ever empty again.

That guard is the part worth reviewing. The failure I actually got read:

```
AssertionError: expected [] to include 'scripts/patchwork-approval-hook.sh'
```

which accuses the packaging of a defect it doesn't have and sends the next person to the wrong file. Worse, an assertion phrased the other way round would have **passed vacuously** on an empty list — the same hazard this test exists to catch.

## Verified, not reasoned about

- Green on npm **11.5.1** and npm **12.0.2** (installed npm 12 and re-ran via a PATH shim)
- Mutation-probed under npm 12: dropping the hook from `files[]` fails with a populated **1622-file** list, so the parse is genuinely working rather than the assertion passing by accident

## After merge

The `v1.2.0-beta.1` tag points at the pre-fix commit. Since nothing published, the tag can be moved rather than burning a version number:

```bash
git push origin :refs/tags/v1.2.0-beta.1     # delete remote tag
git checkout main && git pull
git tag -f v1.2.0-beta.1 && git push origin v1.2.0-beta.1
```

No in-flight ledger entry: minutes-long hotfix on an in-progress release, and an entry would leave `main` failing `audit-in-flight` until a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)