### PR TITLE
chore(release): bump to 1.2.0-beta.2 — republish for the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.2.0-beta.2] — 2026-08-11
+
+Documentation-only republish. No code changes — `dist/` is byte-for-byte the same as `1.2.0-beta.1`.
+
+`1.2.0-beta.1` was tagged before the rewritten README (#1328) and the approval-loop screenshots (#1332) merged, so npmjs.com served the pre-rewrite README: the old install instructions, no opt-in defaults table, and the old hero image. npm renders the README from the published tarball, so a README change only reaches it via a publish — hence a version bump for a docs change.
+
+### Changed
+
+- Ships the rewritten README: verified install path, the zero-connector `daily-status` first run, the corrected Morning Brief, the local-first network boundaries, and the defaults table stating that `approvalGate` and worker autonomy are **opt-in**.
+- Ships the approval → decision-receipt screenshots in place of the idle dashboard hero.
+
+---
+
 ## [1.2.0-beta.1] — 2026-08-10
 
 A minor bump rather than another `beta.N`, because this is a feature line: workspace identity, a third terminal gate state (`forbid`), the prospective control boundary, durable approvals and trust evidence, and the Butler surface — plus, at the end, four fixes to onboarding that a review of the public README turned up.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "patchwork-os",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "patchwork-os",
-      "version": "1.2.0-beta.1",
+      "version": "1.2.0-beta.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patchwork-os",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "Your personal AI runtime, local-first. Patchwork OS gives any AI model a consistent set of tools, YAML recipes, a delegation policy with approval queue, and a durable trace memory — all on your machine, all under your policy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
**Documentation-only republish.** No code changes — `dist/` is byte-for-byte identical to `1.2.0-beta.1`.

## The problem

npmjs.com still shows the **pre-rewrite README**. `1.2.0-beta.1` was tagged before #1328 (README rewrite) and #1332 (screenshots) merged, and npm serves the README from the published tarball — so a README change only reaches npm through a publish.

Confirmed against the published artifact:

```
$ npm pack patchwork-os@1.2.0-beta.1 && tar xzf … package/README.md
$ grep -c "Status: beta"       package/README.md   → 0
$ grep -c "approval-queue.png" package/README.md   → 0
```

## What it is NOT

I checked the obvious explanation before acting on it: **relative image paths are not the issue.** npm rewrites them to `raw.githubusercontent.com/Oolab-labs/patchwork-os/HEAD/docs/images/…` and renders them — verified in a browser against the live page, with zero broken images.

That also means the images resolve against **HEAD**, not the published ref, so the new screenshots will appear as soon as the README text referencing them ships. No absolute-URL rewrite needed.

## Contents

`package.json`, synced `package-lock.json`, changelog entry. `audit-version-drift` passes (it compares MAJOR.MINOR.PATCH, so the `1.2.0` docs references still match).

## After merge

```bash
git checkout main && git pull
node -p "require('./package.json').version"     # must print 1.2.0-beta.2
git tag v1.2.0-beta.2 && git push origin v1.2.0-beta.2
```

`latest` will need moving again afterwards — it's pinned to `1.2.0-beta.1` and that's a manual `npm dist-tag` step requiring your credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)