### PR TITLE
fix(runlog): in-flight step evidence survives an interruption

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-11 `fix/in-flight-step-evidence-durability` — persist evidence-bearing steps to a `run_steps.jsonl` sibling ledger so an interruption before `completeRun` no longer erases the record of actions that already happened (touches `src/runLog.ts`) — durability session
 
 
 

--- a/src/__tests__/runStepDurability.test.ts
+++ b/src/__tests__/runStepDurability.test.ts
@@ -1,0 +1,108 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RecipeRunLog, type RunStepResult } from "../runLog.js";
+
+/**
+ * A run's step results reached disk ONLY via `completeRun`'s single append —
+ * `updateRunSteps` mutated the in-memory row and returned. Any interruption
+ * (bridge restart, session death, SIGKILL) therefore erased the entire
+ * evidence record of a run whose actions had ALREADY happened. Measured on a
+ * live errand: approval in ~20 min → 0 steps recorded, status "interrupted";
+ * the identical recipe approved in 12 s → 4 steps recorded.
+ *
+ * That matters beyond the dashboard: `runs.jsonl` is the autonomy gate's
+ * outcome corpus, so a lost row is lost trust evidence for an action that was
+ * really taken.
+ *
+ * The fix persists only EVIDENCE-BEARING steps as they complete (non-reversible
+ * or errored, never reads, never agent steps per #1320) to a sibling ledger.
+ * Volume is load-bearing, not fastidiousness: `runs.jsonl`'s byte budget is
+ * exactly what starved the trust ledger to 17 h against a 24 h durability
+ * window, so the in-flight writes deliberately do NOT land in that file.
+ */
+describe("in-flight step evidence survives an interruption", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "runstep-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function step(over: Partial<RunStepResult> & { id: string }): RunStepResult {
+    return { status: "ok", durationMs: 5, ...over };
+  }
+
+  /** Start a run, report steps, and abandon the instance without completing. */
+  function crashAfterSteps(steps: RunStepResult[]): void {
+    const log = new RecipeRunLog({ dir });
+    const seq = log.startRun({
+      taskId: "task-crash",
+      recipeName: "errand",
+      trigger: "recipe",
+      createdAt: Date.now(),
+    });
+    log.updateRunSteps(seq, steps);
+    // No completeRun — this is the interruption.
+  }
+
+  it("recovers non-reversible and errored steps after a restart", () => {
+    crashAfterSteps([
+      step({ id: "s1", tool: "getBufferContent" }), // read — reversible
+      step({ id: "s2", tool: "githubCreateIssue" }), // irreversible
+      step({ id: "s3", tool: "gitPush", status: "error", error: "rejected" }),
+    ]);
+
+    const reopened = new RecipeRunLog({ dir });
+    const run = reopened
+      .query({ limit: 10 })
+      .find((r) => r.taskId === "task-crash");
+
+    expect(run?.status).toBe("interrupted");
+    const ids = (run?.stepResults ?? []).map((s) => s.id);
+    expect(ids).toContain("s2");
+    expect(ids).toContain("s3");
+  });
+
+  it("does not persist reversible reads — the byte budget is the constraint", () => {
+    crashAfterSteps([
+      step({ id: "r1", tool: "getBufferContent" }),
+      step({ id: "r2", tool: "getGitStatus" }),
+      step({ id: "r3", tool: "agent" }), // #1320 — never evidence, either way
+    ]);
+
+    const ledger = path.join(dir, "run_steps.jsonl");
+    const written = existsSync(ledger)
+      ? readFileSync(ledger, "utf-8").trim()
+      : "";
+    expect(written).toBe("");
+  });
+
+  it("keeps the completed path intact — completeRun still wins", () => {
+    const log = new RecipeRunLog({ dir });
+    const steps = [step({ id: "s1", tool: "githubCreateIssue" })];
+    const seq = log.startRun({
+      taskId: "task-done",
+      recipeName: "errand",
+      trigger: "recipe",
+      createdAt: Date.now(),
+    });
+    log.updateRunSteps(seq, steps);
+    log.completeRun(seq, {
+      status: "done",
+      doneAt: Date.now(),
+      durationMs: 10,
+      stepResults: steps,
+    });
+
+    const reopened = new RecipeRunLog({ dir });
+    const run = reopened
+      .query({ limit: 10 })
+      .find((r) => r.taskId === "task-done");
+    expect(run?.status).toBe("done");
+    expect(run?.stepResults).toHaveLength(1);
+  });
+});

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -10,6 +10,11 @@ import {
 import path from "node:path";
 import { withFileLockSync } from "./fileLockSync.js";
 import type { Logger } from "./logger.js";
+import {
+  appendStepEvidence,
+  isEvidenceBearing,
+  loadStepEvidence,
+} from "./runStepLedger.js";
 
 /**
  * RecipeRunLog — persistent audit trail of every recipe execution.
@@ -225,6 +230,22 @@ const MAX_ARCHIVE_BYTES = 8 * 1024 * 1024;
 function runKey(r: RecipeRun): string {
   return r.taskId ? `task:${r.taskId}` : `seq:${r.seq}`;
 }
+
+/**
+ * Union of a run's own step list and the recovered in-flight rows, keyed by
+ * step id. The persisted row wins on a tie: the in-memory list of an
+ * interrupted run is whatever the crashed process last managed to hand over,
+ * and the ledger row is what actually reached disk.
+ */
+function mergeStepResults(
+  existing: RunStepResult[] | undefined,
+  recovered: RunStepResult[],
+): RunStepResult[] {
+  const byId = new Map<string, RunStepResult>();
+  for (const s of existing ?? []) if (s?.id) byId.set(s.id, s);
+  for (const s of recovered) if (s?.id) byId.set(s.id, s);
+  return Array.from(byId.values());
+}
 /** Disk-retention line cap. Exported so a reader that must see the FULL retained
  *  history (e.g. worker trust replay) can size its in-memory ring to match the
  *  disk, instead of being silently bounded by DEFAULT_MEMORY_CAP. */
@@ -266,6 +287,10 @@ export class RecipeRunLog {
   private readonly memoryCap: number;
   private lastFileSize = 0;
   private _lastSyncMs = 0;
+  /** seq → step ids already written to the in-flight evidence ledger. Keeps
+   *  `updateRunSteps` (which receives the FULL step list each call) from
+   *  re-appending every prior step on every step completion. */
+  private readonly persistedStepIds = new Map<number, Set<string>>();
   private readonly now: () => number;
 
   constructor(private readonly opts: RunLogOptions) {
@@ -552,6 +577,43 @@ export class RecipeRunLog {
     const run = this.runs[idx];
     if (!run || run.status !== "running") return;
     this.runs[idx] = { ...run, stepResults: [...stepResults] };
+    this.persistInFlightEvidence(this.runs[idx], stepResults);
+  }
+
+  /**
+   * Write the evidence-bearing steps of a still-running run to the sibling
+   * step ledger, so an interruption before `completeRun` no longer erases the
+   * record of actions that already happened. Only the steps this instance has
+   * not already written, and only the ones that carry evidence — see
+   * `isEvidenceBearing`. Rows land in `run_steps.jsonl`, never in `runs.jsonl`,
+   * because that file's byte cap is what starved the trust ledger.
+   */
+  private persistInFlightEvidence(
+    run: RecipeRun,
+    stepResults: RunStepResult[],
+  ): void {
+    if (!run.taskId) return; // no join key ⇒ nothing to fold it back onto
+    let written = this.persistedStepIds.get(run.seq);
+    if (!written) {
+      written = new Set();
+      this.persistedStepIds.set(run.seq, written);
+    }
+    for (const step of stepResults) {
+      if (!step?.id || written.has(step.id)) continue;
+      if (!isEvidenceBearing(step)) continue;
+      written.add(step.id);
+      appendStepEvidence(
+        this.opts.dir,
+        {
+          taskId: run.taskId,
+          seq: run.seq,
+          recipeName: run.recipeName,
+          at: this.now(),
+          step,
+        },
+        this.opts.logger,
+      );
+    }
   }
 
   /**
@@ -626,6 +688,10 @@ export class RecipeRunLog {
       }),
     };
     this.runs[idx] = finalized;
+    // The terminal row now carries the full step list, so the in-flight
+    // tracking for this run is dead weight. (The ledger's own rows age out via
+    // its size cap — they are only ever read for runs still marked "running".)
+    this.persistedStepIds.delete(seq);
     mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });
     this.append(finalized);
   }
@@ -834,8 +900,11 @@ export class RecipeRunLog {
             // A row for a run we already hold. Take it only when it represents
             // PROGRESS, never when it would rewind.
             //
-            // `updateRunSteps` mutates the in-memory row and does NOT write to
-            // disk, so a live run's step results exist only here. Blindly
+            // `updateRunSteps` mutates the in-memory row; it writes only
+            // EVIDENCE-BEARING steps to the sibling step ledger, and never
+            // rewrites this run's row in `runs.jsonl`. So a live run's full
+            // step list still exists only here (the ledger is a crash-recovery
+            // subset, folded in at load, not a mirror). Blindly
             // replacing with the on-disk row would wipe the progress the
             // dashboard is streaming. The old `seq > this.seq` gate protected
             // this by accident (it skipped every existing run); removing that
@@ -941,14 +1010,22 @@ export class RecipeRunLog {
     // corrected terminal record so future reads see "interrupted" instead
     // of a permanently-stuck running entry.
     const now = this.now();
+    // Fold in-flight evidence back onto the runs it belongs to. Read lazily —
+    // most restarts sweep nothing, and this is startup path.
+    let evidence: Map<string, RunStepResult[]> | null = null;
     for (let i = 0; i < this.runs.length; i++) {
       const run = this.runs[i];
       if (!run || run.status !== "running") continue;
+      evidence ??= loadStepEvidence(this.opts.dir, this.opts.logger);
+      const recovered = run.taskId ? evidence.get(run.taskId) : undefined;
       const interrupted: RecipeRun = {
         ...run,
         status: "interrupted",
         doneAt: now,
         durationMs: now - run.createdAt,
+        ...(recovered?.length
+          ? { stepResults: mergeStepResults(run.stepResults, recovered) }
+          : {}),
       };
       this.runs[i] = interrupted;
       this.append(interrupted);

--- a/src/runStepLedger.ts
+++ b/src/runStepLedger.ts
@@ -1,0 +1,138 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type { Logger } from "./logger.js";
+import type { RunStepResult } from "./runLog.js";
+import { AGENT_STEP_TOOL, classifyActionClass } from "./workers/actionClass.js";
+
+/**
+ * In-flight evidence ledger — `run_steps.jsonl`, a sibling of `runs.jsonl`.
+ *
+ * A run's steps reached disk only when `completeRun` fired, so an interruption
+ * erased the record of actions that had already happened. This file carries the
+ * steps that MATTER between `startRun` and the terminal append; `RecipeRunLog`
+ * folds them back onto the interrupted run at load, so every existing reader of
+ * `runs.jsonl` (dashboard, trust replay) sees the evidence without learning
+ * about a second file.
+ *
+ * Deliberately NOT written into `runs.jsonl`. That file is byte-capped, and its
+ * budget is exactly what starved the trust ledger to a 17 h span against a 24 h
+ * durability window — adding per-step writes to it would buy durability by
+ * spending retention, which is the same evidence loss wearing different clothes.
+ */
+export interface RunStepLedgerRow {
+  taskId: string;
+  seq: number;
+  recipeName: string;
+  at: number;
+  step: RunStepResult;
+}
+
+/** Cap on `run_steps.jsonl`. Rows only matter until their run reaches a
+ *  terminal record, so this is a crash-window buffer, not history. */
+const MAX_LEDGER_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Is this step worth persisting mid-flight?
+ *
+ * Only steps that carry evidence: a non-reversible action (it happened and
+ * cannot simply be re-derived) or any error (the halt reason is the whole
+ * point of the record). Reads are excluded because volume is the constraint.
+ *
+ * Agent steps are excluded on BOTH outcomes, matching #1320: the gate carves
+ * them out as "not a gated action-class", and a failed agent step reports on a
+ * model call, not on whether the worker can be trusted with a side effect.
+ */
+export function isEvidenceBearing(step: RunStepResult): boolean {
+  if (step.tool === AGENT_STEP_TOOL) return false;
+  if (step.status === "error") return true;
+  if (!step.tool) return false;
+  return classifyActionClass(step.tool).reversibility !== "reversible";
+}
+
+export function stepLedgerPath(dir: string): string {
+  return path.join(dir, "run_steps.jsonl");
+}
+
+/** Append one evidence row. Never throws — losing a mid-flight row must not
+ *  take down the run that produced it. */
+export function appendStepEvidence(
+  dir: string,
+  row: RunStepLedgerRow,
+  logger?: Logger,
+): void {
+  const file = stepLedgerPath(dir);
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    trimIfOversized(file);
+    appendFileSync(file, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+  } catch (err) {
+    logger?.warn?.(
+      `[runsteps] append failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Read the ledger, grouped by taskId, newest-wins per step id. Returns an empty
+ * map when the file is missing or unreadable — fail-soft, exactly as before
+ * this ledger existed.
+ */
+export function loadStepEvidence(
+  dir: string,
+  logger?: Logger,
+): Map<string, RunStepResult[]> {
+  const file = stepLedgerPath(dir);
+  let raw: string;
+  try {
+    statSync(file);
+    raw = readFileSync(file, "utf-8");
+  } catch {
+    return new Map();
+  }
+  const byTask = new Map<string, Map<string, RunStepResult>>();
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    try {
+      const parsed = JSON.parse(line) as RunStepLedgerRow;
+      if (!parsed?.taskId || !parsed.step?.id) continue;
+      let steps = byTask.get(parsed.taskId);
+      if (!steps) {
+        steps = new Map();
+        byTask.set(parsed.taskId, steps);
+      }
+      steps.set(parsed.step.id, parsed.step);
+    } catch {
+      // skip malformed row — one bad line must not hide the rest
+      logger?.debug?.("[runsteps] skipped malformed row");
+    }
+  }
+  const out = new Map<string, RunStepResult[]>();
+  for (const [taskId, steps] of byTask)
+    out.set(taskId, Array.from(steps.values()));
+  return out;
+}
+
+/** Keep the newest half when the buffer exceeds its cap. */
+function trimIfOversized(file: string): void {
+  let size: number;
+  try {
+    size = statSync(file).size;
+  } catch {
+    return;
+  }
+  if (size <= MAX_LEDGER_BYTES) return;
+  const lines = readFileSync(file, "utf-8").split("\n").filter(Boolean);
+  const keep = lines.slice(Math.floor(lines.length / 2));
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, keep.length > 0 ? `${keep.join("\n")}\n` : "", {
+    mode: 0o600,
+  });
+  renameSync(tmp, file);
+}


### PR DESCRIPTION
## The bug

A run's step results reached disk **only** via `completeRun`'s single append. `updateRunSteps` mutated `this.runs[idx]` and returned. Any interruption before the terminal record erased the entire evidence trail of a run whose actions had **already happened**.

Live measurement, same recipe, one variable:

| approval latency | outcome |
|---|---|
| ~20 min | 0 steps recorded, status `interrupted` |
| 12 s | 4 steps recorded, status `done` |

Proven directly rather than inferred: a process was SIGKILLed mid-run against a control that called `completeRun` first.

```
kill    → running steps=0        ← 4 steps completed, evidence gone
control → running steps=0
          done    steps=4        ← same steps, completeRun ran → survives
```

The control is the mutation check — had `updateRunSteps` persisted, the killed run would have shown `steps>0`.

This is not only a dashboard gap. `runs.jsonl` is the autonomy gate's outcome corpus, so an erased row is erased **trust evidence** for an action that was really taken.

## The fix

Evidence-bearing steps append to a sibling `run_steps.jsonl` as they complete, and fold back onto the run during the existing startup sweep that marks it `interrupted`. Every existing reader of `runs.jsonl` — dashboard, trust replay — sees the recovered steps without learning about a second file.

**Evidence-bearing** = non-reversible or errored. Never reads. Never agent steps, on either outcome, matching #1320.

## Why not `runs.jsonl`

That file is byte-capped, and its budget is exactly what starved the trust ledger to a 17 h span against a 24 h durability window (#1337). Buying durability by spending retention is the same evidence loss wearing different clothes. Reads are filtered for the same reason — the volume filter is load-bearing, not fastidiousness.

## Verification that could have failed

Test written first, confirmed red before the fix. Then mutated in both directions:

- `isEvidenceBearing → false` ⇒ the recovery test goes red
- `isEvidenceBearing → true` ⇒ the "reads are not persisted" guard goes red

Full suite green apart from the known local noise (3 `tokenEfficiency` tests that read the live lock file, 4 pre-existing `ta/*` files). All six gate audits pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)