### PR TITLE
fix(runlog): sweep a run only when its owner is provably gone

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-11 `fix/in-flight-step-evidence-durability` — persist evidence-bearing steps to a `run_steps.jsonl` sibling ledger so an interruption before `completeRun` no longer erases the record of actions that already happened (touches `src/runLog.ts`) — durability session
+- 2026-08-11 `fix/run-sweep-owner-liveness` — stamp running rows with their owning pid so the startup sweep only recovers runs whose process is provably gone; a concurrent reader was marking live runs `interrupted`, which made `completeRun` no-op and lost a successful run's whole record (touches `src/runLog.ts`) — durability session
 
 
 

--- a/src/__tests__/runLogSweepOwnership.test.ts
+++ b/src/__tests__/runLogSweepOwnership.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type RecipeRun, RecipeRunLog } from "../runLog.js";
+
+/**
+ * `loadExisting`'s sweep marks every `status:"running"` row `interrupted` — the
+ * recovery path for a bridge that died mid-run. It ran unconditionally, in the
+ * constructor, against a file shared by EIGHT construction sites. So any
+ * short-lived reader (a `patchwork` CLI verb, the dashboard, a second bridge)
+ * declared every OTHER process's in-flight runs dead.
+ *
+ * That is not a cosmetic mislabel. `syncFromDisk` feeds the terminal row back
+ * to the owning bridge (a terminal row beats a live one, by design), and
+ * `completeRun` no-ops on a run that is no longer `"running"` — so the real
+ * completion is never written. A run that SUCCEEDED records
+ * `interrupted, steps: 0`, and `runs.jsonl` is the autonomy gate's evidence.
+ *
+ * The sweep now runs only for rows whose owning process is provably gone.
+ * Where liveness is unknowable (a legacy row with no owner stamp) it sweeps,
+ * preserving the previous behaviour for old logs.
+ */
+describe("run sweep respects a live owner", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "runsweep-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function find(log: RecipeRunLog, taskId: string): RecipeRun | undefined {
+    return log.query({ limit: 20 }).find((r) => r.taskId === taskId);
+  }
+
+  it("a concurrent reader does not kill a live run's record", () => {
+    // Process A — the owning bridge, with a run genuinely in flight.
+    const a = new RecipeRunLog({ dir });
+    const seq = a.startRun({
+      taskId: "live-run",
+      recipeName: "butler-errand",
+      trigger: "recipe",
+      createdAt: Date.now(),
+    });
+
+    // Process B — any short-lived reader that opens the same log.
+    const b = new RecipeRunLog({ dir });
+    expect(find(b, "live-run")?.status).toBe("running");
+
+    // A polls its own log the way the dashboard does, then finishes normally.
+    a.query({ limit: 20 });
+    a.completeRun(seq, {
+      status: "done",
+      doneAt: Date.now(),
+      durationMs: 1000,
+      stepResults: [
+        { id: "s1", tool: "githubCreateIssue", status: "ok", durationMs: 5 },
+      ],
+    });
+
+    const after = new RecipeRunLog({ dir });
+    const final = find(after, "live-run");
+    expect(final?.status).toBe("done");
+    expect(final?.stepResults).toHaveLength(1);
+  });
+
+  it("still sweeps a run whose owner is gone — restart recovery is the point", () => {
+    const a = new RecipeRunLog({ dir });
+    a.startRun({
+      taskId: "orphan-run",
+      recipeName: "butler-errand",
+      trigger: "recipe",
+      createdAt: Date.now(),
+      // A pid that cannot be alive. 0 and negative pids are not addressable
+      // process ids, so this is "provably gone" rather than "unknown".
+      ownerPid: -1,
+    });
+
+    const after = new RecipeRunLog({ dir });
+    expect(find(after, "orphan-run")?.status).toBe("interrupted");
+  });
+
+  it("sweeps a legacy row that carries no owner stamp", () => {
+    // Hand-write a pre-ownership row: liveness is unknowable, so the old
+    // behaviour (sweep) must survive rather than leaving it stuck "running".
+    const seed = new RecipeRunLog({ dir });
+    seed.appendDirect({
+      taskId: "legacy-run",
+      recipeName: "butler-errand",
+      trigger: "recipe",
+      status: "running",
+      createdAt: Date.now(),
+      doneAt: Date.now(),
+      durationMs: 0,
+      stepResults: [],
+    });
+
+    const after = new RecipeRunLog({ dir });
+    expect(find(after, "legacy-run")?.status).toBe("interrupted");
+  });
+});

--- a/src/__tests__/runStepDurability.test.ts
+++ b/src/__tests__/runStepDurability.test.ts
@@ -36,7 +36,16 @@ describe("in-flight step evidence survives an interruption", () => {
     return { status: "ok", durationMs: 5, ...over };
   }
 
-  /** Start a run, report steps, and abandon the instance without completing. */
+  /**
+   * Start a run, report steps, and abandon the instance without completing.
+   *
+   * `ownerPid: -1` stands in for the crashed process. The sweep that recovers
+   * these steps now fires only when the owning pid is provably gone (see
+   * `runLogSweepOwnership.test.ts`), and a single-process test would otherwise
+   * be simulating a crash while its own pid is still alive — which is the one
+   * case that must NOT sweep. A real crash leaves a dead pid, so this is the
+   * closer simulation, not a weaker one.
+   */
   function crashAfterSteps(steps: RunStepResult[]): void {
     const log = new RecipeRunLog({ dir });
     const seq = log.startRun({
@@ -44,6 +53,7 @@ describe("in-flight step evidence survives an interruption", () => {
       recipeName: "errand",
       trigger: "recipe",
       createdAt: Date.now(),
+      ownerPid: -1,
     });
     log.updateRunSteps(seq, steps);
     // No completeRun — this is the interruption.

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -161,6 +161,22 @@ export interface RecipeRun {
    */
   manualRunId?: string;
   /**
+   * PID of the process that started this run.
+   *
+   * Exists so the startup sweep can tell "the bridge died mid-run" from
+   * "another process is running this right now". `runs.jsonl` is shared by
+   * eight construction sites, and the sweep marked every `"running"` row
+   * `interrupted` in the constructor — so any short-lived reader (a CLI verb,
+   * the dashboard, a second bridge) declared a live sibling's runs dead. That
+   * terminal row then beat the live one in `syncFromDisk`, and `completeRun`
+   * no-ops on a non-running row, so a run that SUCCEEDED recorded
+   * `interrupted` with zero steps.
+   *
+   * Optional: rows written before this field existed carry no stamp, and are
+   * swept exactly as before — an unknown owner is not evidence of a live one.
+   */
+  ownerPid?: number;
+  /**
    * Phase 0β provenance — files this run delivered to the inbox
    * (`~/.patchwork/inbox/`). One entry per `file.write` step whose
    * resolved path is inside the inbox dir; populated by yamlRunner.
@@ -229,6 +245,34 @@ const MAX_ARCHIVE_BYTES = 8 * 1024 * 1024;
  */
 function runKey(r: RecipeRun): string {
   return r.taskId ? `task:${r.taskId}` : `seq:${r.seq}`;
+}
+
+/**
+ * Is the process that owns a running row still alive?
+ *
+ * `kill(pid, 0)` sends no signal — it only asks whether the pid is addressable.
+ * `EPERM` means the process exists but belongs to another user, which is still
+ * alive for our purposes.
+ *
+ * An ABSENT stamp returns false (⇒ sweep). Rows predating `ownerPid` must keep
+ * being recovered, and "we don't know" is not evidence of a live owner.
+ *
+ * The residual risk is pid reuse: an unrelated process inheriting a dead
+ * bridge's pid leaves a run stuck `"running"` forever. That is the direction to
+ * fail in — a visibly stuck row is recoverable and obvious, whereas the
+ * alternative silently rewrites a completed run's history, which is the bug
+ * being fixed.
+ */
+function isProcessAlive(pid: number | undefined): boolean {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
+  }
 }
 
 /**
@@ -540,9 +584,12 @@ export class RecipeRunLog {
     model?: string;
     parentSeq?: number;
     manualRunId?: string;
+    /** Test seam — defaults to this process. See `RecipeRun.ownerPid`. */
+    ownerPid?: number;
   }): number {
     const seq = ++this.seq;
     const run: RecipeRun = {
+      ownerPid: opts.ownerPid ?? process.pid,
       seq,
       taskId: opts.taskId,
       recipeName: opts.recipeName,
@@ -1005,10 +1052,17 @@ export class RecipeRunLog {
     if (this.runs.length > this.memoryCap) {
       this.runs.splice(0, this.runs.length - this.memoryCap);
     }
-    // Sweep: any run that is still `status:"running"` after loading was
-    // interrupted by a bridge restart. Flip in memory and append the
-    // corrected terminal record so future reads see "interrupted" instead
-    // of a permanently-stuck running entry.
+    // Sweep: a run still `status:"running"` after loading was interrupted by a
+    // bridge restart. Flip in memory and append the corrected terminal record
+    // so future reads see "interrupted" instead of a permanently-stuck entry.
+    //
+    // ONLY when its owning process is provably gone. This ran unconditionally,
+    // in the constructor, against a file eight construction sites share — so a
+    // `patchwork` CLI verb or a dashboard poll declared a live sibling's runs
+    // dead. The damage was not cosmetic: `syncFromDisk` hands the terminal row
+    // back to the owning bridge (terminal beats live, by design) and
+    // `completeRun` no-ops on a non-running row, so the real completion was
+    // never written and a SUCCESSFUL run recorded `interrupted`, zero steps.
     const now = this.now();
     // Fold in-flight evidence back onto the runs it belongs to. Read lazily —
     // most restarts sweep nothing, and this is startup path.
@@ -1016,6 +1070,7 @@ export class RecipeRunLog {
     for (let i = 0; i < this.runs.length; i++) {
       const run = this.runs[i];
       if (!run || run.status !== "running") continue;
+      if (isProcessAlive(run.ownerPid)) continue;
       evidence ??= loadStepEvidence(this.opts.dir, this.opts.logger);
       const recovered = run.taskId ? evidence.get(run.taskId) : undefined;
       const interrupted: RecipeRun = {


### PR DESCRIPTION
## The bug

`loadExisting`'s sweep marks every `status:"running"` row `interrupted` — the recovery path for a bridge that died mid-run. It ran **unconditionally, in the constructor**, against a file **eight construction sites** share. So any short-lived reader — a `patchwork` CLI verb, a dashboard poll, a second bridge — declared every *other* process's in-flight runs dead.

That is not a mislabel. `syncFromDisk` hands the terminal row back to the owning bridge (terminal beats live, by design), and `completeRun` no-ops on a row that is no longer `"running"`. So the real completion is **never written**:

```
with a concurrent reader → FINAL: interrupted steps=0   ← the run SUCCEEDED
without one             → FINAL: done        steps=1
```

The reader is the only variable between those two lines. `runs.jsonl` is the autonomy gate's outcome corpus, so this silently destroys trust evidence for actions that completed successfully — the third data-loss path found in this file, after #1333 (seq collision) and #1340 (in-flight steps).

It is visible in the live log: a `butler-errand` run recorded `interrupted, steps=0` with `durationMs` of 2191 s — a figure that measures when some unrelated process next opened the file, not anything about the run.

## The fix

Running rows carry `ownerPid`. The sweep skips any row whose owner still answers `kill(pid, 0)`. Restart recovery is untouched — a dead bridge's pid is dead, which is exactly what the sweep is for.

**An absent stamp still sweeps.** Rows predating this field must keep being recovered, and "we don't know" is not evidence of a live owner.

**Residual risk, taken deliberately:** pid reuse could leave a row stuck `"running"` forever. That is the right direction to fail — a visibly stuck row is recoverable and obvious, whereas silently rewriting a completed run's history is the bug being fixed.

## Interaction with #1340

This also closes a gap there: that fold only runs during the sweep, so a row already forced terminal by a concurrent reader never consulted the step ledger at all.

`runStepDurability`'s crash simulation now passes a dead `ownerPid`. A single-process test was simulating a crash while its own pid was alive — the one case that must *not* sweep — so this is the closer simulation, not a weaker one.

## Verification that could have failed

Test written first, red before the fix. Then mutated in both directions:

- every pid reported alive ⇒ both recovery tests (dead owner, legacy row) go red
- guard removed ⇒ the concurrent-reader test goes red

Confirmed end to end against the built artifact: a real `SIGKILL`ed process still recovers its steps (`interrupted steps=3`), and the original concurrent-reader probe now yields `done steps=1`.

Full suite green apart from the known local noise (3 `tokenEfficiency` tests that read the live lock file, 4 pre-existing `ta/*` files). All gate audits pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)