### PR TITLE
fix(recipes): show the approver the write they are approving

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-11 `fix/approval-shows-resolved-write` — render a gated step's templates before queueing the approval, so a human sees the write they are authorising instead of `content: "{{title}}"` (touches `src/recipes/yamlRunner.ts`) — durability session
 
 
 

--- a/src/connectors/__tests__/todoist.test.ts
+++ b/src/connectors/__tests__/todoist.test.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -404,10 +404,22 @@ describe("handleTodoistConnect", () => {
 
 describe("handleTodoistTest", () => {
   it("returns 400 when not connected", async () => {
-    vi.resetModules();
-    const { handleTodoistTest } = await import("../todoist.js");
-    const result = await handleTodoistTest();
-    expect(result.status).toBe(400);
+    // Point PATCHWORK_HOME at an empty dir. "Not connected" was asserted
+    // against the DEVELOPER'S real ~/.patchwork, so the test passed only while
+    // nobody running it had Todoist connected — it went intermittently red the
+    // moment someone did. A test about the absent-credential path must supply
+    // its own absence rather than borrow the machine's.
+    const emptyHome = mkdtempSync(join(os.tmpdir(), "todoist-unconnected-"));
+    process.env.PATCHWORK_HOME = emptyHome;
+    try {
+      vi.resetModules();
+      const { handleTodoistTest } = await import("../todoist.js");
+      const result = await handleTodoistTest();
+      expect(result.status).toBe(400);
+    } finally {
+      delete process.env.PATCHWORK_HOME;
+      rmSync(emptyHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/recipes/__tests__/approvalParamsResolved.test.ts
+++ b/src/recipes/__tests__/approvalParamsResolved.test.ts
@@ -1,0 +1,146 @@
+/**
+ * An approval request must show the write that will actually happen.
+ *
+ * The gate handed the approver `step` verbatim — the raw YAML, before
+ * `executeStep` renders its `{{templates}}`. So a person authorising a gated
+ * write saw `content: "{{title}}"`, never the text. Observed live on
+ * `butler-errand`: the queue entry read `{"content":"{{title}}", …}` while the
+ * task actually filed was "Check the smoke alarm batteries".
+ *
+ * That is not cosmetic. The gate exists so a human can judge a compensable or
+ * irreversible action before it happens, and approving an unrendered template
+ * is consent to whatever an earlier step happened to produce. It also weakens
+ * the Decision Record as evidence: it preserved what was PROPOSED, not what was
+ * APPROVED, and for a gated action those must be the same string.
+ *
+ * Resolution is safe to do early — `deepRender` is pure string substitution
+ * over the run context, with no execution — but the resolved values can carry
+ * secrets the raw template did not, so the payload goes through
+ * `captureForRunlog` (redaction + size cap) exactly as step outputs do.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "approval-params-"));
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+function deps(extra: Partial<RunnerDeps> = {}): RunnerDeps {
+  return {
+    now: () => new Date("2026-08-11T12:00:00Z"),
+    logDir: TMP,
+    testMode: true,
+    readFile: () => {
+      throw new Error("nf");
+    },
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    gitLogSince: () => "",
+    gitStaleBranches: () => "",
+    getDiagnostics: () => "",
+    ...extra,
+  };
+}
+
+describe("approval payload shows the resolved write", () => {
+  it("renders templates before asking a human to approve", async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const requireApprovalFn = vi.fn(
+      async (i: { params?: Record<string, unknown> }) => {
+        seen.push(i.params);
+        return true;
+      },
+    );
+
+    // `content` derives from an earlier step's output — the shape every
+    // interesting gated write has, and the one the raw-step payload loses.
+    const recipe = {
+      name: "approval-params",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          tool: "github.create_issue",
+          repo: "acme/widgets",
+          title: "x",
+          into: "prior",
+        },
+        {
+          tool: "file.write",
+          path: `${TMP}/out`,
+          content: "{{prior.title}}",
+          into: "created",
+        },
+      ],
+    } as unknown as YamlRecipe;
+
+    await runYamlRecipe(
+      recipe,
+      deps({
+        requireApprovalFn,
+        mockConnectors: {
+          "github.create_issue": {
+            invoke: async <TOutput = unknown>() =>
+              JSON.stringify({
+                ok: true,
+                number: 1,
+                title: "Descale the coffee machine",
+              }) as TOutput,
+          },
+        },
+      }),
+    );
+
+    const writeApproval = seen.find((p) => p?.tool === "file.write");
+    expect(writeApproval).toBeDefined();
+    expect(writeApproval?.content).toBe("Descale the coffee machine");
+    // The raw placeholder must not survive into what a person is shown.
+    expect(JSON.stringify(writeApproval)).not.toContain("{{title}}");
+  });
+
+  it("redacts secrets that only appear once the template is resolved", async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    const requireApprovalFn = vi.fn(
+      async (i: { params?: Record<string, unknown> }) => {
+        seen.push(i.params);
+        return true;
+      },
+    );
+
+    // NOTE: the key is `token`, not `api_key`, and that is a finding rather
+    // than a convenience. `SENSITIVE_KEY_PATTERNS` matches "apikey"/"api-key"
+    // but NOT the snake_case `api_key` that recipe YAML naturally uses, so a
+    // resolved `api_key` is NOT redacted today. Reported separately — shaping
+    // this test around the gap would hide it; naming it keeps the redaction
+    // wiring proven here while leaving the hole visible.
+    const recipe = {
+      name: "approval-secret",
+      trigger: {
+        type: "manual",
+        vars: [{ name: "secret_value", default: "" }],
+      },
+      steps: [
+        {
+          tool: "file.write",
+          path: `${TMP}/secret`,
+          content: "ok",
+          token: "{{secret_value}}",
+        },
+      ],
+    } as unknown as YamlRecipe;
+
+    await runYamlRecipe(recipe, deps({ requireApprovalFn }), {
+      secret_value: "NOT-A-REAL-CREDENTIAL-SUPERSECRET",
+    });
+
+    const payload = JSON.stringify(seen.find((p) => p?.tool === "file.write"));
+    expect(payload).not.toContain("SUPERSECRET");
+  });
+});

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -2138,7 +2138,7 @@ export async function runYamlRecipe(
           summary: step.agent
             ? `agent step${step.agent.into ? ` → ${step.agent.into}` : ""}`
             : `tool ${approvalToolId}`,
-          params: step.agent ? undefined : (step as Record<string, unknown>),
+          params: step.agent ? undefined : resolveParamsForApproval(step, ctx),
           ...(effectiveRunSignal && { signal: effectiveRunSignal }), // L1
         });
         if (!approved) {
@@ -3145,6 +3145,46 @@ export function render(template: string, ctx: RunContext): string {
         ? JSON.stringify(val)
         : String(val);
   });
+}
+
+/**
+ * The params a human is shown when asked to approve a gated step.
+ *
+ * The gate previously passed `step` verbatim — the raw YAML, BEFORE
+ * `executeStep` renders it — so an approver saw `content: "{{title}}"` and
+ * never the text that would be written. Observed live on `butler-errand`. The
+ * gate exists so a person can judge a compensable or irreversible action
+ * before it happens; approving an unrendered template is consent to whatever
+ * an earlier step happened to produce. It also made the persisted Decision
+ * Record evidence of what was PROPOSED rather than what was APPROVED, and for
+ * a gated action those must be the same string.
+ *
+ * Rendering here is safe: `deepRender` is pure string substitution over the run
+ * context — it executes nothing, so resolving early cannot double-run a step.
+ * The key skip-list mirrors `executeStep`'s param build, including leaving `do`
+ * raw (its `{{item.*}}` placeholders belong to a per-iteration scope and would
+ * render to empty strings against the outer ctx — showing an approver an empty
+ * sub-step would be worse than showing the template).
+ *
+ * The result passes through `captureForRunlog` because resolution can surface
+ * secrets the template did not contain: `{{api_key}}` is inert, its resolved
+ * value is not, and this payload is both displayed and PERSISTED (ADR-0018).
+ * Falls back to the raw step if rendering throws — an approval prompt that
+ * shows something is better than a run that dies building one.
+ */
+function resolveParamsForApproval(
+  step: Record<string, unknown>,
+  ctx: RunContext,
+): Record<string, unknown> {
+  try {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(step)) {
+      out[key] = key === "do" ? value : deepRender(value, ctx);
+    }
+    return (captureForRunlog(out) ?? out) as Record<string, unknown>;
+  } catch {
+    return step;
+  }
 }
 
 /** Recursively render all string leaves in a value (for nested params like blocks). */


### PR DESCRIPTION
## The bug

The gate handed `requireApprovalFn` the **raw YAML step** — before `executeStep` renders its templates ([yamlRunner.ts:2141](https://github.com/Oolab-labs/patchwork-os/blob/main/src/recipes/yamlRunner.ts#L2141)). So a human authorising a gated write saw:

```json
{"content": "{{title}}", "project_id": "{{project_id}}", ...}
```

Observed live on `butler-errand` today. The task actually filed was *"Check the smoke alarm batteries"* — a string the approver was never shown.

This is not cosmetic. The gate exists so a person can judge a compensable or irreversible action **before** it happens; approving an unrendered template is consent to whatever an earlier step happened to produce. It also weakens the Decision Record as evidence: it preserved what was *proposed*, not what was *approved*, and for a gated action those must be the same string.

It generalises well past this recipe — any gated step whose params derive from an earlier step's output had the same hole, which is most of the interesting ones.

## The fix

`resolveParamsForApproval` renders the step against the run context using the same key rules `executeStep` uses — including leaving `do` raw, since its `{{item.*}}` placeholders belong to a per-iteration scope and would render to empty strings against the outer ctx (showing an approver an empty sub-step is worse than showing a template).

**Rendering early is safe.** `deepRender` is pure string substitution and executes nothing, so this cannot double-run a step. I verified that before writing the fix rather than assuming it.

**Redaction is required, not defensive.** Resolution can surface secrets the template did not contain — `{{api_key}}` is inert, its resolved value is not — and this payload is both displayed and *persisted* (ADR-0018). So it passes through `captureForRunlog`, exactly as step outputs do. Falls back to the raw step if rendering throws: an approval prompt that shows something beats a run that dies building one.

## Also: an unrelated flake, fixed because I caused it

The todoist `returns 400 when not connected` test asserted the absent-credential path against the **developer's real `~/.patchwork`**. It passed only while nobody running it had Todoist connected — and went intermittently red the moment someone did (me, today, setting up a governed errand). It now supplies its own empty `PATCHWORK_HOME`. A test about absence must not borrow the machine's.

## Verification that could have failed

Both new tests confirmed red against the specific mutant they exist to catch:

- restore the raw-step payload ⇒ the rendering test reddens
- drop `captureForRunlog` ⇒ the redaction test reddens

The second matters especially: before the fix that test passed **vacuously** — the value was unrendered, so no secret was present to leak. It only became a real assertion once rendering worked.

## Known gap, deliberately not fixed here

`SENSITIVE_KEY_PATTERNS` matches `apikey`/`api-key` but **not** the snake_case `api_key` that recipe YAML naturally uses, so a resolved `api_key` is not redacted. The test names this in a comment rather than quietly picking a key that works — shaping the test around the gap would have hidden it. Worth a separate fix, since changing redaction matching affects every capture site in the tree.

Full suite green apart from the known local noise (3 `tokenEfficiency`, 4 pre-existing `ta/*`). All gate audits pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)