### PR TITLE
fix(tests): stop the todoist suite deleting a real credential

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-11 `fix/test-suite-deletes-real-credentials` — todoist connector tests unlinked the developer's REAL ~/.patchwork token; sandbox PATCHWORK_HOME for the whole file (touches `src/connectors/__tests__/todoist.test.ts`) — durability session
 
 
 

--- a/src/connectors/__tests__/todoist.test.ts
+++ b/src/connectors/__tests__/todoist.test.ts
@@ -2,7 +2,49 @@ import crypto from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// ── real-store sandbox ────────────────────────────────────────────────────────
+
+/**
+ * Every test in this file runs against a throwaway PATCHWORK_HOME.
+ *
+ * It did not, and that deleted a real credential. `handleTodoistDisconnect` →
+ * `clearTokens` → `deleteSecretJsonSync` unlinks
+ * `<PATCHWORK_HOME>/tokens/patchwork-os.todoist.enc` UNCONDITIONALLY — the
+ * backend branch only decides whether the keychain is also cleared. With
+ * PATCHWORK_HOME unset, that resolves to the developer's real `~/.patchwork`,
+ * so running this file removed a live Todoist connection from the machine.
+ * Reproduced with a canary: write a token to the real store, run this file,
+ * the token is gone.
+ *
+ * PATCHWORK_HOME is the ONLY knob that works here. Overriding `HOME` does not
+ * help: this file calls `delete process.env.HOME`, and `os.homedir()` then
+ * falls back to the passwd entry and returns the real home regardless of what
+ * the parent process set. A HOME-based sandbox therefore looks like isolation
+ * and provides none — it is a check that cannot fail.
+ *
+ * Consequently NOTHING in this file may `delete process.env.PATCHWORK_HOME`.
+ * Restore it to SANDBOX_HOME instead; unsetting it re-points the store at the
+ * developer's machine.
+ */
+const SANDBOX_HOME = mkdtempSync(join(os.tmpdir(), "todoist-sandbox-"));
+
+beforeEach(() => {
+  process.env.PATCHWORK_HOME = SANDBOX_HOME;
+});
+
+afterAll(() => {
+  rmSync(SANDBOX_HOME, { recursive: true, force: true });
+});
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -60,7 +102,7 @@ describe("todoist token helpers", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.HOME;
-    delete process.env.PATCHWORK_HOME;
+    process.env.PATCHWORK_HOME = SANDBOX_HOME;
     delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
     delete process.env.TODOIST_API_KEY;
     if (existsSync(tmpDir)) {
@@ -335,7 +377,7 @@ describe("handleTodoistConnect", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.TODOIST_API_KEY;
-    delete process.env.PATCHWORK_HOME;
+    process.env.PATCHWORK_HOME = SANDBOX_HOME;
     delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
   });
 
@@ -394,7 +436,7 @@ describe("handleTodoistConnect", () => {
     const stored = loadTokens();
     expect(stored?.apiToken).toBe("good-token");
 
-    delete process.env.PATCHWORK_HOME;
+    process.env.PATCHWORK_HOME = SANDBOX_HOME;
     delete process.env.PATCHWORK_TOKEN_STORAGE_BACKEND;
     rmSync(tmpDir2, { recursive: true, force: true });
   });
@@ -417,7 +459,7 @@ describe("handleTodoistTest", () => {
       const result = await handleTodoistTest();
       expect(result.status).toBe(400);
     } finally {
-      delete process.env.PATCHWORK_HOME;
+      process.env.PATCHWORK_HOME = SANDBOX_HOME;
       rmSync(emptyHome, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## What happened

Running `src/connectors/__tests__/todoist.test.ts` **deleted a live Todoist credential from the developer's machine.** Not a temp fixture — `~/.patchwork/tokens/patchwork-os.todoist.enc`.

Confirmed by canary, with the fix as the only variable:

```
without this change → after the suite: DELETED
with this change    → after the suite: still there
```

## Mechanism

`handleTodoistDisconnect` → `clearTokens` → `deleteSecretJsonSync` unlinks `<PATCHWORK_HOME>/tokens/patchwork-os.todoist.enc` **unconditionally** — the backend branch only decides whether the keychain is *also* cleared. Several describes in this file unset `PATCHWORK_HOME` in `afterEach`, so by the time the disconnect test ran, the store resolved to the real `~/.patchwork`.

No single describe does it; the *combination* does. That's why it survived review — bisecting by describe shows every block individually harmless.

## Why `HOME` isolation is not a fix

This file calls `delete process.env.HOME`. `os.homedir()` then falls back to the **passwd entry** and returns the real home regardless of what the parent process set:

```
with HOME set   → /tmp/…/fakehome3
with HOME unset → /Users/wesh
```

My first reproduction attempt used a HOME-based sandbox and "proved" the suite was safe. It was a check that could not fail, against code that escapes it by construction. `PATCHWORK_HOME` is the only knob `getStorageDir` honours ahead of `homedir()`, so the sandbox is built on that, and **nothing in the file may unset it** — the sites that did now restore it.

## Blast radius

Limited to credentials in the current `.enc` format. Legacy `<provider>.json` files (linear, sentry on this machine) use a different filename and were untouched — which is why this went unnoticed for so long. The exposure is therefore "anything connected *recently*", i.e. precisely the credential most likely to be in active use.

## Not fixed here, reported instead

`github.test.ts`, `linear.test.ts`, `sentry.test.ts` and `baseConnector.refreshRace.test.ts` call disconnect/`clearTokens` with **zero** `PATCHWORK_HOME` isolation. A canary run through `github.test.ts` survived, so the hazard is latent there rather than active. A repo-wide guard — failing CI on `delete process.env.PATCHWORK_HOME` in any connector test — is a better answer than editing 40 files on a hunch, and belongs in its own PR alongside the existing `audit-patchwork-home` ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)