### PR TITLE
fix(workers): Butler's manifest now covers the writes its recipe declares

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-11 `fix/butler-manifest-covers-recipe-writes` — Butler accrued evidence on fs-write its manifest did not own, so it could never become trust; guard test asserts every shipped worker owns its recipe's allowWrites (touches `templates/workers/`, `src/workers/__tests__/`) — durability session
 
 
 

--- a/src/workers/__tests__/manifestCoversRecipeWrites.test.ts
+++ b/src/workers/__tests__/manifestCoversRecipeWrites.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { classifyActionClass } from "../actionClass.js";
+import { loadWorkersFromDir } from "../workerLoader.js";
+
+/**
+ * A worker's manifest must own every domain its recipe is allowed to write to.
+ *
+ * These are two declarations of the same authority, written in different files,
+ * with nothing keeping them honest. Butler drifted: its recipe declares
+ * `allowWrites: [todoist.create_task, file.append]`, its manifest owns
+ * `[tasks-read, tasks]`, and the manifest comment claims it "matches the
+ * recipe's actual steps". The receipt step was added later and the manifest was
+ * not updated.
+ *
+ * The failure is quiet in the worst way. An unowned class does not error — the
+ * gate floors it to L0 and, because `fs-write` is reversible, the action flows
+ * anyway. So the write happens, evidence accrues against a class the worker
+ * does not own, and `workers shadow` prints "⚠ NOT OWNED" that nothing acts on.
+ * The worker looks busier than it is and none of that work can ever become
+ * trust.
+ *
+ * The check runs the other way round from `owns`-side guards: it starts at what
+ * the recipe may actually DO. An `owns` entry with no step behind it is merely
+ * useless; a step with no `owns` entry behind it is evidence being thrown away.
+ */
+describe("guard: a worker manifest covers its recipe's declared writes", () => {
+  const workersDir = path.join(process.cwd(), "templates", "workers");
+  const recipesDir = path.join(process.cwd(), "templates", "recipes");
+
+  /** `allowWrites:` entries — a flat YAML list of tool ids. */
+  function allowWrites(recipeText: string): string[] {
+    const lines = recipeText.split("\n");
+    const start = lines.findIndex((l) => /^allowWrites:\s*(#.*)?$/.test(l));
+    if (start === -1) return [];
+    const out: string[] = [];
+    for (const line of lines.slice(start + 1)) {
+      const m = /^\s+-\s*([A-Za-z0-9_.-]+)\s*(#.*)?$/.exec(line);
+      if (!m) break; // first non-list line ends the block
+      if (m[1]) out.push(m[1]);
+    }
+    return out;
+  }
+
+  it("every allowWrites tool classifies into a domain the manifest owns", () => {
+    const workers = loadWorkersFromDir(workersDir);
+    expect(workers.length).toBeGreaterThan(0); // anchor: dir must not be empty
+
+    const gaps: string[] = [];
+    let checked = 0;
+
+    for (const w of workers) {
+      const recipePath = path.join(recipesDir, `${w.recipe}.yaml`);
+      if (!existsSync(recipePath)) continue; // worker ships without its recipe
+      const tools = allowWrites(readFileSync(recipePath, "utf-8"));
+      if (tools.length === 0) continue;
+      checked++;
+
+      const owned = new Set(w.owns.map((o) => String(o).split(":")[0]));
+      for (const tool of tools) {
+        const { domain } = classifyActionClass(tool);
+        if (!owned.has(domain)) {
+          gaps.push(`${w.id}: recipe writes ${tool} (${domain}) — not in owns`);
+        }
+      }
+    }
+
+    // Anchor: if no worker/recipe pair was examined, the assertion below is
+    // vacuous and would pass however broken the manifests are.
+    expect(checked).toBeGreaterThan(0);
+    expect(gaps).toEqual([]);
+  });
+
+  it("the recipes this guard reads actually declare allowWrites", () => {
+    // Premise check. If `allowWrites` were renamed or the parser broke, the
+    // guard above would silently examine zero tools per recipe and pass.
+    const files = readdirSync(recipesDir).filter((f) => f.endsWith(".yaml"));
+    const withWrites = files.filter(
+      (f) =>
+        allowWrites(readFileSync(path.join(recipesDir, f), "utf-8")).length > 0,
+    );
+    expect(withWrites.length).toBeGreaterThan(0);
+  });
+});

--- a/templates/workers/butler-errands.worker.yaml
+++ b/templates/workers/butler-errands.worker.yaml
@@ -23,13 +23,25 @@ responsibilities:
   - Turn a stated request into a task on the user's personal list
   - Never act on a request it merely READ somewhere; only one the user made
 
-# Matches the recipe's actual steps. `tasks` covers todoist.create_task;
-# `tasks-read` covers the list read. Nothing aspirational — an `owns` entry
-# with no step to attach an observation to can never earn anything, it just
-# looks like coverage.
+# Matches the recipe's actual steps AND its `allowWrites`. `tasks` covers
+# todoist.create_task; `tasks-read` covers the list read; `fs-write` covers the
+# file.append receipt step. Nothing aspirational — an `owns` entry with no step
+# to attach an observation to can never earn anything, it just looks like
+# coverage.
+#
+# `fs-write` was missing while the recipe already declared file.append, and the
+# failure was silent in the worst direction: an unowned class does not error,
+# the gate floors it to L0, and because fs-write is reversible the write
+# happened anyway. So the receipt was written, the observation accrued against
+# a class the worker did not own, and `workers shadow` printed a NOT OWNED
+# warning nothing acted on. Adding it cannot widen anything — trust is per
+# (worker × class), so evidence earned on a reversible file write can never
+# unlock the compensable todoist write. Guarded by
+# src/workers/__tests__/manifestCoversRecipeWrites.test.ts.
 owns:
   - tasks-read
   - tasks
+  - fs-write
 
 # Capped at 1, BELOW the compensable auto-allow rung (L2), so every write stays
 # human-approved no matter how much trust accrues. That is the point of the


### PR DESCRIPTION
## The drift

```
recipe  allowWrites:  todoist.create_task, file.append
manifest owns:        tasks-read, tasks
manifest comment:     "Matches the recipe's actual steps"
```

The receipt step was added later. The manifest was not. Two declarations of the same authority, in different files, with nothing keeping them honest.

## Why it was invisible

An unowned class does **not** error. The gate floors it to L0, and because `fs-write` is reversible the write happens anyway. So the receipt was written, the observation accrued against a class the worker doesn't own, and `workers shadow` printed a warning nothing acted on:

```
fs-write:reversible:medium   earned L0 · 1 obs · 80% mean  ⚠ NOT OWNED — gate floors to L0
```

A quarter of what the reference worker does could never become trust — on the one worker the entire governance demo rests on.

## Why adding it can't widen anything

Trust is per `(worker × class)`. Evidence earned on a reversible file write can never unlock the compensable todoist write; that stays gated by the L1 autonomy ceiling, which is the point of the demo.

## The guard

Runs from the **recipe toward the manifest**, which is the direction that matters: an `owns` entry with no step behind it is merely useless, while a step with no `owns` entry behind it is evidence being thrown away.

Both assertions carry anchors, because this test's natural failure mode is passing while examining nothing:

- it counts the worker/recipe pairs actually examined and asserts that count is non-zero
- a second test asserts the shipped recipes still declare `allowWrites` at all, so a rename can't make the guard vacuous

Mutation-tested: adding `githubCreateIssue` to the recipe's allowWrites reports `githubCreateIssue (issue) — not in owns` and fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)