### PR TITLE
fix(recipes): redact every spelling of a secret key, not the ones somebody remembered

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-11 `fix/butler-manifest-covers-recipe-writes` — Butler accrued evidence on fs-write its manifest did not own, so it could never become trust; guard test asserts every shipped worker owns its recipe's allowWrites (touches `templates/workers/`, `src/workers/__tests__/`) — durability session
+- 2026-08-12 `fix/redact-separator-variants` — a resolved `api_key` was never redacted (patterns enumerated spellings and missed the snake_case one); normalise separators once (touches `src/recipes/stepObservation.ts`) — durability session
 
 
 

--- a/src/recipes/__tests__/stepObservation.test.ts
+++ b/src/recipes/__tests__/stepObservation.test.ts
@@ -337,3 +337,50 @@ describe("agent driver enum matches the runtime (#1311 sibling drift)", () => {
     }
   });
 });
+
+/**
+ * Separator variants of the same secret name must all redact.
+ *
+ * `SENSITIVE_KEY_PATTERNS` was hand-maintained and carried BOTH separator
+ * spellings for some names (`client_secret` / `client-secret`,
+ * `refresh_token` / `refresh-token`) — but only `api-key` and `apikey`, never
+ * the snake_case `api_key` that recipe YAML naturally uses. So a resolved
+ * `api_key` reached the run log, the dashboard, and the approval payload in
+ * clear text.
+ *
+ * Found while making approval prompts show resolved values (#1343): rendering
+ * templates before showing them to a human is what turns an inert
+ * `{{api_key}}` into an actual credential in a persisted record.
+ *
+ * The fix normalises separators once rather than enumerating spellings, which
+ * is why this test asserts all three forms together — enumerating is the thing
+ * that failed.
+ */
+describe("captureForRunlog — separator variants of a secret key", () => {
+  const SECRET = "NOT-A-REAL-CREDENTIAL-abcdef123456";
+
+  for (const key of ["api_key", "api-key", "apikey", "API_KEY"]) {
+    it(`redacts ${key}`, () => {
+      const out = JSON.stringify(
+        captureForRunlog({ [key]: SECRET, keep: "ok" }),
+      );
+      expect(out).not.toContain(SECRET);
+      expect(out).toContain("ok"); // anchor: non-secret fields survive
+    });
+  }
+
+  for (const key of ["client_secret", "refresh_token", "access_token"]) {
+    it(`still redacts ${key}`, () => {
+      const out = JSON.stringify(captureForRunlog({ [key]: SECRET }));
+      expect(out).not.toContain(SECRET);
+    });
+  }
+
+  it("does not redact an innocuous key that merely resembles one", () => {
+    // Anchor against over-widening: "monkey" ends in "key", "tokenizer"
+    // contains "token". The second SHOULD redact (substring match is the
+    // existing, deliberate behaviour); the first must not.
+    const out = JSON.stringify(captureForRunlog({ monkey: "banana" }));
+    expect(out).toContain("banana");
+  });
+});

--- a/src/recipes/stepObservation.ts
+++ b/src/recipes/stepObservation.ts
@@ -172,10 +172,23 @@ const MAX_BYTES = 8 * 1024;
 // Case-insensitive substring match. Order: most specific first to avoid
 // accidentally matching narrower strings (none currently overlap, but
 // this is the convention).
+/**
+ * Substrings that mark a key as secret-bearing.
+ *
+ * Compared against a SEPARATOR-STRIPPED, lower-cased key (see
+ * `isSensitiveKey`), so each name is written once here and matches every
+ * spelling: `api_key`, `api-key`, `apiKey`, `API_KEY`.
+ *
+ * This list previously carried the spellings by hand and drifted: it had both
+ * `client_secret` and `client-secret`, both `refresh_token` and
+ * `refresh-token` — but only `api-key` and `apikey`, never the snake_case
+ * `api_key` that recipe YAML naturally uses. A resolved `api_key` therefore
+ * reached the run log, the dashboard and the approval payload in clear text.
+ * Enumerating spellings is what failed; normalising once is the fix.
+ */
 const SENSITIVE_KEY_PATTERNS = [
   "authorization",
-  "x-api-key",
-  "api-key",
+  "xapikey",
   "apikey",
   "password",
   "passwd",
@@ -183,14 +196,10 @@ const SENSITIVE_KEY_PATTERNS = [
   "token",
   "cookie",
   "session",
-  "private-key",
   "privatekey",
-  "client-secret",
-  "client_secret",
-  "refresh-token",
-  "refresh_token",
-  "access-token",
-  "access_token",
+  "clientsecret",
+  "refreshtoken",
+  "accesstoken",
 ];
 
 export const REDACTED = "[REDACTED]";
@@ -219,9 +228,11 @@ export function redactSecretsForPrompt<T extends Record<string, string>>(
 }
 
 function isSensitiveKey(key: string): boolean {
-  const lower = key.toLowerCase();
+  // Strip separators so one pattern covers every spelling a caller might use.
+  // `api_key`, `api-key`, `apiKey` and `API_KEY` all normalise to `apikey`.
+  const normalised = key.toLowerCase().replace(/[-_\s.]/g, "");
   for (const pattern of SENSITIVE_KEY_PATTERNS) {
-    if (lower.includes(pattern)) return true;
+    if (normalised.includes(pattern)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## The gap

`SENSITIVE_KEY_PATTERNS` was hand-maintained and had drifted. It carried BOTH separator spellings for some names — `client_secret` *and* `client-secret`, `refresh_token` *and* `refresh-token` — but only `api-key` and `apikey`, never the snake_case **`api_key` that recipe YAML naturally uses**.

So a resolved `api_key` reached the run log, the dashboard and the approval payload in clear text.

Found while making approval prompts show resolved values (#1343), and the two are connected: rendering a template before showing it to a human is exactly what turns an inert `{{api_key}}` into a real credential sitting in a persisted record. I flagged it there rather than fixing it inline, because changing redaction matching touches every capture site in the tree.

## The fix

Normalise separators once instead of enumerating spellings. Keys are lower-cased and stripped of `-`, `_`, whitespace and `.` before matching, so one pattern covers `api_key`, `api-key`, `apiKey`, `API_KEY`.

That also removes the hand-maintained duplicates — and several were always dead weight anyway, since `secret` and `token` are substrings that already matched `client_secret` and `access_token`. Enumerating spellings is the thing that failed; the list is now one entry per name.

Widening redaction is the safe direction, and the full suite confirms nothing depended on the old gaps.

## Verification that could have failed

Tests written first, red before the fix (`api_key` and `API_KEY`). Then mutation-probed: dropping the normalisation reddens four tests, including a pre-existing one.

Anchors included so the tests can't pass vacuously — each asserts a non-secret field *survives* redaction, and one asserts an innocuous key (`monkey`) is not redacted, guarding the over-widening direction.

Full suite green apart from the known local noise (3 `tokenEfficiency`, 4 pre-existing `ta/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)