### PR TITLE
docs(adr): close the ADR-0020 double-check — decision stands

### DIFF
--- a/docs/adr/0020-per-member-authentication.md
+++ b/docs/adr/0020-per-member-authentication.md
@@ -200,5 +200,49 @@ implementations behind the same seam, delegating to GitHub/Google can be added
 later as a *third* provider without disturbing any consumer — mapped on the
 provider's `sub`, exactly as Phase B is.
 
+## Amendment — 2026-08-12: double-check completed, decision stands
+
+An earlier internal recommendation, made two days before this ADR, pointed the
+other way: delegate to GitHub/Google OAuth and own the roles rather than the
+passwords. The contradiction was flagged at the time, with a note that reversing
+would cost nothing because no code had been written against either answer.
+
+Re-verified 2026-08-12 against `main`: still true. `canApproveAction` has zero
+production references outside its own module and tests, and the dashboard
+session payload is still `` `v1.${expiresAt}` ``. Nothing has been built either
+way.
+
+**The decision stands.** The earlier recommendation was made without the two
+arguments that decide it — an authentication path that requires reaching a third
+party contradicts the free product's central property, and puts that third party
+in the evidence path for records whose purpose is to be defensible later. Its
+cost objection is real but bounded: password reset for a single-digit roster is
+a CLI command, and consumer OAuth remains addable behind the same seam.
+
+### Clarification: the licence line is whose directory, not which protocol
+
+The table above lists exactly one OIDC row, and it is control-plane. Read alone
+it implies that *any* OIDC implementation is reserved. ADR-0019 reserves
+**organisation** identity — SSO/SCIM, directory sync, provisioning — not the
+protocol.
+
+So, explicitly: a self-hoster signing in with their own GitHub or Google account
+is not organisation identity, and such a provider may be implemented **here,
+under MIT**, behind the same seam. What is reserved is federation against an
+organisation's identity provider and the directory machinery around it.
+
+This changes no decision and adds no work. It removes a reading under which a
+free-tier convenience would have been mistakenly treated as commercial.
+
+### What this cost
+
+Eight days labelled provisional while the answer was already written down. The
+review asked for a double-check on the reasoning; the reasoning had already
+been recorded in "Alternatives rejected" and needed only to be read. A decision
+left open is not free — it blocks the one subsystem that is built and unwired,
+and every day it stays open invites re-litigation rather than progress.
+
+## Alternatives rejected (continued)
+
 **Defaulting the actor to the implicit owner.** Rejected outright, and recorded
 here so it is not re-proposed as a shortcut. It fabricates evidence.

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-12 `fix/redact-separator-variants` — a resolved `api_key` was never redacted (patterns enumerated spellings and missed the snake_case one); normalise separators once (touches `src/recipes/stepObservation.ts`) — durability session
+_Nothing in flight._
 
 
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-12 `docs/adr-0020-double-check` — close the eight-day-old ADR-0020 double-check: decision stands, plus a clarification that the open-core line is whose directory not which protocol (touches `docs/adr/`) — durability session
 
 
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -30,7 +30,6 @@ verified (which is how this line came to be written).
 ## Active
 
 - 2026-08-12 `docs/adr-0020-double-check` — close the eight-day-old ADR-0020 double-check: decision stands, plus a clarification that the open-core line is whose directory not which protocol (touches `docs/adr/`) — durability session
-_Nothing in flight._
 
 
 


### PR DESCRIPTION
An earlier internal recommendation pointed the other way on pre-SSO identity — delegate to GitHub/Google OAuth rather than own credentials. The contradiction was flagged eight days ago with a note that reversing would cost nothing, and then nothing happened.

**Re-verified against `main` today: still costs nothing.** `canApproveAction` has zero production references outside its own module and tests; the dashboard session payload is still `` `v1.${expiresAt}` ``. No code has been written against either answer.

## The decision stands

The earlier recommendation was made without the two arguments that decide it: an authentication path requiring a third-party round-trip contradicts the free product's central property (local, offline), and it puts that third party in the evidence path for records whose entire purpose is to be defensible later. Its cost objection is real but bounded — password reset for a single-digit roster is a CLI command, and consumer OAuth stays addable behind the same seam.

Worth saying plainly: **the ADR had already answered this.** "Alternatives rejected" engages consumer OAuth directly, with the offline argument and the cost acknowledged rather than dismissed. The double-check needed reading, not re-deciding.

## One clarification worth making

The Phase A/B table lists exactly one OIDC row and it is control-plane, so read alone it implies *any* OIDC implementation is reserved. ADR-0019 reserves **organisation** identity — SSO/SCIM, directory sync, provisioning — not the protocol.

A self-hoster signing in with their own GitHub account is not organisation identity, and such a provider may be built **here, under MIT**, behind the same seam. What's reserved is federation against an organisation's IdP.

Changes no decision, adds no work, removes a reading under which a free-tier convenience would have been mistakenly treated as commercial.

## Note

The amendment deliberately does not cite the internal document that raised the objection — the substance crosses, the pointer does not. `audit-business-content` passes, but it scans for commercial *content*, not references to where commercial documents live, so that one was on me rather than the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)