### PR TITLE
fix(auth): make Connect Claude work — send state, and use the UUID client_id

### DIFF
--- a/src/__tests__/claudeAuthHttp.test.ts
+++ b/src/__tests__/claudeAuthHttp.test.ts
@@ -121,6 +121,25 @@ describe("handleClaudeAuthComplete", () => {
   });
 });
 
+describe("authorize URL client_id", () => {
+  // claude.ai's /oauth/authorize rejects a non-UUID client_id with
+  // "Input should be a valid UUID" and renders "OAuth Request Failed", so the
+  // flow dies before the user can approve. The client-metadata URL previously
+  // used here is exactly that shape, and the failure is invisible from the
+  // bridge side: /start happily returns a URL that cannot work.
+  it("sends a UUID client_id, not a client-metadata URL", async () => {
+    const { res, result } = captureResponse();
+    await handleClaudeAuthStart(fakeReq("{}"), res);
+    const { url } = JSON.parse(result.body) as { url: string };
+    const clientId = new URL(url).searchParams.get("client_id") ?? "";
+
+    expect(clientId).not.toMatch(/^https?:\/\//);
+    expect(clientId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+});
+
 describe("token exchange sends state (Invalid request format bug)", () => {
   // Anthropic's /v1/oauth/token rejects the request with
   //   {"error":{"type":"invalid_request_error","message":"Invalid request format"}}

--- a/src/__tests__/claudeAuthHttp.test.ts
+++ b/src/__tests__/claudeAuthHttp.test.ts
@@ -121,6 +121,91 @@ describe("handleClaudeAuthComplete", () => {
   });
 });
 
+describe("token exchange sends state (Invalid request format bug)", () => {
+  // Anthropic's /v1/oauth/token rejects the request with
+  //   {"error":{"type":"invalid_request_error","message":"Invalid request format"}}
+  // when `state` is absent — verified against the live endpoint 2026-08-12 with
+  // a junk code: form-encoded WITHOUT state → "Invalid request format";
+  // form-encoded WITH state → "invalid_grant" (i.e. it got past the shape
+  // check). Body encoding is NOT the trigger; the missing field is. This made
+  // "Connect Claude" fail for every user regardless of what they pasted.
+  it("includes state in the token-exchange body", async () => {
+    const sessionId = await startSession();
+    let sentBody = "";
+    vi.stubGlobal("fetch", (_url: string, init: { body: string }) => {
+      sentBody = init.body;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ access_token: "sk-ant-oat01-x" }),
+      });
+    });
+
+    const { res } = captureResponse();
+    await handleClaudeAuthComplete(
+      fakeReq(JSON.stringify({ sessionId, code: "the-code" })),
+      res,
+    );
+
+    const sent = new URLSearchParams(sentBody);
+    expect(sent.get("state")).toBeTruthy();
+  });
+
+  // Anthropic's callback page shows the value as `<code>#<state>`. Users paste
+  // it verbatim (or paste the whole URL). Both must resolve to a bare code plus
+  // the state, never a code with a "#..." suffix glued on.
+  it("splits a pasted <code>#<state> value into code and state", async () => {
+    const sessionId = await startSession();
+    let sentBody = "";
+    vi.stubGlobal("fetch", (_url: string, init: { body: string }) => {
+      sentBody = init.body;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ access_token: "sk-ant-oat01-x" }),
+      });
+    });
+
+    const { res } = captureResponse();
+    await handleClaudeAuthComplete(
+      fakeReq(JSON.stringify({ sessionId, code: "abc123#st4te" })),
+      res,
+    );
+
+    const sent = new URLSearchParams(sentBody);
+    expect(sent.get("code")).toBe("abc123");
+    expect(sent.get("state")).toBe("st4te");
+  });
+
+  it("accepts a full pasted callback URL", async () => {
+    const sessionId = await startSession();
+    let sentBody = "";
+    vi.stubGlobal("fetch", (_url: string, init: { body: string }) => {
+      sentBody = init.body;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ access_token: "sk-ant-oat01-x" }),
+      });
+    });
+
+    const { res } = captureResponse();
+    await handleClaudeAuthComplete(
+      fakeReq(
+        JSON.stringify({
+          sessionId,
+          code: "https://platform.claude.com/oauth/code/callback?code=abc123&state=st4te",
+        }),
+      ),
+      res,
+    );
+
+    const sent = new URLSearchParams(sentBody);
+    expect(sent.get("code")).toBe("abc123");
+    expect(sent.get("state")).toBe("st4te");
+  });
+});
+
 describe("handleClaudeAuthStart session-map cap (http-routes-4)", () => {
   it("rejects new sessions with 503 once the map is at capacity", async () => {
     // The session map is module-scoped and shared across tests in this file,

--- a/src/claudeAuthHttp.ts
+++ b/src/claudeAuthHttp.ts
@@ -80,6 +80,51 @@ function deriveCodeChallenge(verifier: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Pasted-value normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Turn whatever the user pasted into `{ code, state }`.
+ *
+ * Anthropic's callback page renders the value as `<code>#<state>`, and users
+ * variously paste that verbatim, paste just the code, or paste the entire
+ * callback URL out of the address bar. All three must work.
+ *
+ * `state` matters: /v1/oauth/token rejects a body without it as
+ * `invalid_request_error / "Invalid request format"` — verified against the
+ * live endpoint 2026-08-12. Sending only `code` failed for every user, which
+ * is why the flow never worked regardless of what was pasted.
+ */
+export function parsePastedAuthCode(raw: string): {
+  code: string;
+  state?: string;
+} {
+  const trimmed = raw.trim();
+
+  // Full callback URL — pull code/state out of the query string.
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      const code = url.searchParams.get("code")?.trim();
+      const state = url.searchParams.get("state")?.trim();
+      if (code) return { code, state: state || undefined };
+    } catch {
+      // Not a parseable URL — fall through to the `#` handling below.
+    }
+  }
+
+  // `<code>#<state>` — the shape the callback page displays.
+  const hash = trimmed.indexOf("#");
+  if (hash !== -1) {
+    const code = trimmed.slice(0, hash).trim();
+    const state = trimmed.slice(hash + 1).trim();
+    return { code, state: state || undefined };
+  }
+
+  return { code: trimmed };
+}
+
+// ---------------------------------------------------------------------------
 // Body reader (reuse the same pattern as the bridge's other POST handlers)
 // ---------------------------------------------------------------------------
 
@@ -206,6 +251,20 @@ export async function handleClaudeAuthComplete(
   // Audit 2026-06-08 HIGH (auth-1): bound the fetch with an AbortController so a
   // slow/hung Anthropic endpoint can't keep the HTTP connection + session open
   // indefinitely. Map an abort to a 504 (distinct from a 502 network error).
+  // The pasted value may be `<code>#<state>`, a bare code, or the whole
+  // callback URL. Fall back to the session id for `state` — that is what we
+  // put in the authorize URL, so it round-trips correctly when the user pasted
+  // only the code half.
+  const { code: authCode, state: pastedState } = parsePastedAuthCode(code);
+  if (!authCode) {
+    jsonReply(res, 400, {
+      error: "missing_fields",
+      detail: "sessionId and code required",
+    });
+    return;
+  }
+  const authState = pastedState ?? session.sessionId;
+
   let tokenRes: Response;
   const controller = new AbortController();
   const timeout = setTimeout(
@@ -219,7 +278,8 @@ export async function handleClaudeAuthComplete(
       body: new URLSearchParams({
         grant_type: "authorization_code",
         client_id: CLAUDE_OAUTH_CLIENT_ID,
-        code: code.trim(),
+        code: authCode,
+        state: authState,
         redirect_uri: CLAUDE_OAUTH_REDIRECT_URI,
         code_verifier: session.codeVerifier,
       }).toString(),

--- a/src/claudeAuthHttp.ts
+++ b/src/claudeAuthHttp.ts
@@ -27,8 +27,13 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 // Constants (extracted from the claude binary via strings analysis)
 // ---------------------------------------------------------------------------
 
-const CLAUDE_OAUTH_CLIENT_ID =
-  "https://claude.ai/oauth/claude-code-client-metadata";
+// Claude Code's public OAuth client id. It must be a UUID: claude.ai's
+// /oauth/authorize rejects a non-UUID client_id ("Input should be a valid
+// UUID") and renders an "OAuth Request Failed" page, so the client-metadata
+// URL that used to live here made the flow unreachable before the user could
+// even approve. Public by design — an OAuth public client id is an
+// identifier, not a secret; PKCE is what protects the exchange.
+const CLAUDE_OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const CLAUDE_OAUTH_AUTH_URL = "https://claude.com/cai/oauth/authorize";
 const CLAUDE_OAUTH_TOKEN_URL = "https://api.anthropic.com/v1/oauth/token";
 const CLAUDE_OAUTH_REDIRECT_URI =


### PR DESCRIPTION
Connect Claude was broken in this repo for **two independent reasons**. Both are fixed here, because shipping either alone leaves the flow dead.

## 1. The token exchange omitted `state`

Anthropic's `/v1/oauth/token` rejects any request without `state` as `invalid_request_error / "Invalid request format"`. Verified against the live endpoint with a junk code:

| request | reply |
|---|---|
| form-encoded, no `state` — what we sent | `Invalid request format` |
| JSON, no `state` | `Invalid request format` |
| form-encoded **with** `state` | `invalid_grant` (past the shape check) |

Body encoding is not the trigger; the absent field is. The pasted value was never the problem.

## 2. The `client_id` was a URL, not a UUID

claude.ai's `/oauth/authorize` rejects a non-UUID `client_id` ("Input should be a valid UUID") and renders "OAuth Request Failed". This repo sent the client-metadata URL, so the flow died *before* the user could approve — and it's invisible from the bridge side, because `/start` happily returns a URL that cannot work.

**Evidence, stated plainly:** this is the value the multi-tenant deployment runs, where the flow is confirmed working end-to-end today. A direct probe isn't possible from a shell — bot protection answers 403 to curl for valid and invalid client ids alike — so this rests on the working deployment plus the documented rejection, not on a reproduction here.

The id is public by design: an OAuth public client id is an identifier, not a secret; PKCE protects the exchange.

## Also fixed

`parsePastedAuthCode` normalises what users actually paste — a bare code, the `<code>#<state>` form the callback page displays, or the whole callback URL. All three resolve to a clean code + state. `state` falls back to the session id, so it round-trips when only the code half was pasted.

## Tests

4 tests added, each confirmed failing before its fix — including a mutation check that restoring the URL `client_id` turns the guard red. 8/8 green. Repo typecheck reports pre-existing errors unrelated to this file, identical with and without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)