### PR TITLE
feat(workers): operator-asserted action-domain resolver for unknown tools

### DIFF
--- a/src/workers/__tests__/actionDomainResolver.test.ts
+++ b/src/workers/__tests__/actionDomainResolver.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the action-domain resolver seam.
+ *
+ * Why the seam exists: `DOMAIN_BY_TOOL` is a static allowlist keyed on exact
+ * tool names, so any tool the bridge does not ship — a plugin tool, most
+ * obviously — falls to `other` → `irreversible`. That is conservative, but it
+ * collapses an entire integration into ONE trust cell: a read and a destructive
+ * write become indistinguishable to the gate, which is precisely the
+ * trust-transfer the action-class design exists to prevent.
+ *
+ * Why it is OPERATOR-asserted and not plugin-declared: reversible actions
+ * bypass the gate unconditionally. A tool that could declare its own
+ * reversibility could therefore declare itself out of governance entirely.
+ * Classification must never be controlled by the thing being classified.
+ *
+ * The safety property under test is narrow and load-bearing: the resolver may
+ * only classify tools the bridge does NOT already know. It can never re-map,
+ * soften, or shadow a built-in mapping.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  classifyActionClass,
+  registerActionDomainResolver,
+} from "../actionClass.js";
+
+afterEach(() => {
+  registerActionDomainResolver(null);
+});
+
+describe("action-domain resolver seam", () => {
+  it("leaves unknown tools at other:irreversible when no resolver is set", () => {
+    const ac = classifyActionClass("acmeCrm_list_records");
+    expect(ac.domain).toBe("other");
+    expect(ac.reversibility).toBe("irreversible");
+  });
+
+  it("lets an operator classify an unknown tool as a reversible read", () => {
+    registerActionDomainResolver((tool) =>
+      tool === "acmeCrm_list_records" ? { domain: "fs-read" } : undefined,
+    );
+    const ac = classifyActionClass("acmeCrm_list_records");
+    expect(ac.domain).toBe("fs-read");
+    expect(ac.reversibility).toBe("reversible");
+  });
+
+  it("keeps distinct classes for distinct tools instead of one shared cell", () => {
+    registerActionDomainResolver((tool) =>
+      tool.endsWith("_list_records") ? { domain: "fs-read" } : undefined,
+    );
+    const read = classifyActionClass("acmeCrm_list_records");
+    const other = classifyActionClass("acmeBooks_create_invoice");
+    expect(read.key).not.toBe(other.key);
+    expect(other.reversibility).toBe("irreversible");
+  });
+
+  // The security property. A resolver that could re-map a built-in tool could
+  // declare `gitPush` reversible and walk it straight past the gate.
+  it("cannot override a built-in mapping", () => {
+    registerActionDomainResolver(() => ({
+      domain: "fs-read",
+      reversibility: "reversible",
+    }));
+    const ac = classifyActionClass("gitPush");
+    expect(ac.domain).toBe("vcs-push");
+    expect(ac.reversibility).toBe("compensable");
+  });
+
+  it("cannot soften the agent step carve-out", () => {
+    registerActionDomainResolver(() => ({
+      domain: "fs-read",
+      reversibility: "reversible",
+    }));
+    const ac = classifyActionClass("agent");
+    expect(ac.reversibility).not.toBe("reversible");
+  });
+
+  it("falls back to irreversible for a domain it does not recognise", () => {
+    registerActionDomainResolver(() => ({ domain: "not-a-real-domain" }));
+    const ac = classifyActionClass("acmeBooks_create_invoice");
+    expect(ac.reversibility).toBe("irreversible");
+  });
+
+  // A resolver is operator-supplied config; a throw must degrade to the
+  // conservative default rather than take the gate down with it. A crashing
+  // gate is an outage, and an outage is the pressure that gets gates disabled.
+  it("fails closed when the resolver throws", () => {
+    registerActionDomainResolver(() => {
+      throw new Error("bad config");
+    });
+    const ac = classifyActionClass("acmeBooks_create_invoice");
+    expect(ac.domain).toBe("other");
+    expect(ac.reversibility).toBe("irreversible");
+  });
+
+  it("still applies magnitude banding when mapped to a banded domain", () => {
+    registerActionDomainResolver(() => ({ domain: "payments" }));
+    const small = classifyActionClass("acmeBooks_create_payment", {
+      amount: 5,
+    });
+    const large = classifyActionClass("acmeBooks_create_payment", {
+      amount: 50_000,
+    });
+    expect(small.key).not.toBe(large.key);
+  });
+
+  it("unregisters cleanly", () => {
+    registerActionDomainResolver(() => ({ domain: "fs-read" }));
+    expect(classifyActionClass("acmeCrm_list_records").domain).toBe("fs-read");
+    registerActionDomainResolver(null);
+    expect(classifyActionClass("acmeCrm_list_records").domain).toBe("other");
+  });
+});

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -447,12 +447,78 @@ export function knownActionDomains(): string[] {
   return Object.keys(REVERSIBILITY_BY_DOMAIN);
 }
 
+/**
+ * Operator-supplied classification for tools the bridge does not ship.
+ *
+ * Returns the domain (and optionally an explicit reversibility) for a tool
+ * name, or `undefined` to leave it alone. Mirrors `registerTierResolver` in
+ * riskTier.ts, which solves the same problem for blast tier.
+ */
+export type ActionDomainResolver = (
+  toolName: string,
+) => { domain: string; reversibility?: Reversibility } | undefined;
+
+let actionDomainResolver: ActionDomainResolver | null = null;
+
+/**
+ * Register (or clear, with `null`) the resolver for unknown tools.
+ *
+ * OPERATOR-asserted, deliberately — never declared by the tool itself. A
+ * reversible action bypasses the gate unconditionally, so anything that could
+ * declare its own reversibility could declare itself out of governance. The
+ * thing being classified must not control its classification.
+ */
+export function registerActionDomainResolver(
+  fn: ActionDomainResolver | null,
+): void {
+  actionDomainResolver = fn;
+}
+
+/**
+ * Resolve a domain for a tool the built-in map does not cover.
+ *
+ * Consulted ONLY on a miss, which is the safety property: the resolver can
+ * never re-map, soften, or shadow a shipped mapping (no declaring `gitPush`
+ * reversible). A throw degrades to the conservative default rather than
+ * propagating — a crashing gate is an outage, and outages are the pressure
+ * that gets gates switched off.
+ */
+function resolveUnknownDomain(
+  toolName: string,
+): { domain: string; reversibility?: Reversibility } | undefined {
+  if (!actionDomainResolver) return undefined;
+  // The agent step is carved out of gating and withheld from the outcome fold
+  // by name (AGENT_STEP_TOOL), and it is absent from DOMAIN_BY_TOOL — so
+  // without this it would be resolver-reachable and could be re-declared
+  // reversible, softening a carve-out two other subsystems depend on.
+  if (toolName === AGENT_STEP_TOOL) return undefined;
+  try {
+    const resolved = actionDomainResolver(toolName);
+    if (!resolved || typeof resolved.domain !== "string" || !resolved.domain) {
+      return undefined;
+    }
+    return resolved;
+  } catch {
+    return undefined;
+  }
+}
+
 export function classifyActionClass(
   toolName: string,
   params?: Record<string, unknown>,
 ): ActionClass {
-  const domain = DOMAIN_BY_TOOL[toolName] ?? "other";
-  const reversibility = REVERSIBILITY_BY_DOMAIN[domain] ?? "irreversible";
+  const builtIn = DOMAIN_BY_TOOL[toolName];
+  const resolved =
+    builtIn === undefined ? resolveUnknownDomain(toolName) : undefined;
+  const domain = builtIn ?? resolved?.domain ?? "other";
+  // A resolver-supplied reversibility applies only to a domain the bridge does
+  // not already define. An unrecognised domain stays "irreversible" — the same
+  // fail-closed default an unmapped tool gets, so a typo in operator config
+  // narrows autonomy rather than widening it.
+  const reversibility =
+    REVERSIBILITY_BY_DOMAIN[domain] ??
+    (builtIn === undefined ? resolved?.reversibility : undefined) ??
+    "irreversible";
   const blastTier = classifyTool(toolName);
   // Instance-derived facet. Without it the key is a pure function of the tool
   // NAME, so a trivial instance and a catastrophic one share a trust cell and


### PR DESCRIPTION
## Problem

`DOMAIN_BY_TOOL` is a static allowlist keyed on exact tool names, so any tool the bridge doesn't ship — a plugin tool most obviously — falls to `other` → `irreversible`. Conservative, but it collapses an entire integration into **one trust cell**: a read and a destructive write become indistinguishable to the gate. That's precisely the trust-transfer the action-class design exists to prevent.

It also leaves `brandExposed` false on genuinely brand-exposed actions, and makes such tools unownable — a worker can't own them without owning the `other` catch-all a guard test forbids.

## Change

`registerActionDomainResolver(fn)`, mirroring `registerTierResolver` in `riskTier.ts`, which solves the same problem for blast tier. `classifyActionClass` is the single choke point for all seven call sites (gate, preview, shadow observer, shadow gate, backtest, level store), so one hook keeps them consistent by construction.

**Operator-asserted, never tool-declared.** Reversible actions bypass the gate unconditionally, so anything able to declare its own reversibility could declare itself out of governance. The thing being classified must not control its classification.

## Safety properties (each tested)

1. **Consulted only on a miss** — it can never re-map, soften, or shadow a shipped mapping. No declaring `gitPush` reversible.
2. **`AGENT_STEP_TOOL` excluded explicitly** — `agent` is absent from `DOMAIN_BY_TOOL`, so it *was* resolver-reachable and could have been re-declared reversible, softening a carve-out both the gate and the outcome fold depend on. This was caught by a test, not by review.
3. **Fails closed** — a throwing or malformed resolver degrades to `other:irreversible` rather than propagating. A crashing gate is an outage, and outages are the pressure that gets gates switched off.

An unrecognised domain stays `irreversible`, so a typo in operator config *narrows* autonomy rather than widening it (ADR-0016 fail-closed).

## Verification

9 tests, confirmed failing before the change. **Verified they can fail on purpose:** allowing the resolver to override built-ins turns the `gitPush` test red. 332/332 green across `src/workers`.

## Blast radius

**Inert by default.** No caller is wired to this; with no resolver registered, behaviour is byte-identical. Trust maths, thresholds, `forbidPolicy`, and the `other` guard test are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)