### PR TITLE
fix(recipes): a failed orchestrator task must not read as the agent's answer

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-13 `fix/orchestrator-failure-not-agent-answer` — a failed orchestrator task was returned as the agent step's answer, so a driver error became a proposed gated write (touches `src/recipeOrchestration.ts`) — durability session
 
 
 

--- a/src/__tests__/agentTextFromTask.test.ts
+++ b/src/__tests__/agentTextFromTask.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { agentTextFromTask } from "../recipeOrchestration.js";
+import { detectSilentFail } from "../recipes/stepObservation.js";
+
+/**
+ * A failed orchestrator task must not read as the agent's answer.
+ *
+ * Both orchestrator-backed agent paths did `task.output ?? task.errorMessage ??
+ * ""`. When the task failed, `output` was undefined and the driver's thrown
+ * message came back as the agent step's SUCCESSFUL result, unmarked. The runner
+ * cannot tell that from a real answer, so it flowed into the step's `into`
+ * variable and onward.
+ *
+ * Observed live on 2026-08-13: an orchestrator task failed with "OpenAIApiDriver
+ * requires openai — install it with: npm install openai", that string became the
+ * proposed task title, the recipe's `{{title}} != DUPLICATE` guard passed (an
+ * error string is not "DUPLICATE"), and a worker asked a human to approve
+ * creating a Todoist task with that title. The gate asking is the only reason it
+ * did not land — approve on autopilot and it writes nonsense to a real external
+ * service.
+ *
+ * `makeProviderDriverFn` already marked its failures this way. Only this path
+ * did not, and the two sites here were byte-identical duplicates that still
+ * drifted from that third one — hence one exported helper rather than two
+ * corrected copies.
+ */
+describe("agentTextFromTask", () => {
+  it("marks a failed task so the runner can see it failed", () => {
+    const text = agentTextFromTask({
+      errorMessage:
+        "OpenAIApiDriver requires openai — install it with: npm install openai",
+    });
+    expect(text).toContain("[agent step failed:");
+    expect(text).toContain("OpenAIApiDriver requires openai");
+  });
+
+  it("the marked text is recognised as a silent failure", () => {
+    // The point of marking: detectSilentFail must catch it. Without this the
+    // string is indistinguishable from a legitimate answer.
+    const text = agentTextFromTask({ errorMessage: "boom" });
+    expect(detectSilentFail(text)).not.toBeNull();
+  });
+
+  it("a raw driver error would NOT be caught — why marking happens at the source", () => {
+    // Anchor for the design decision. This is the string the old code returned.
+    // It is not recognisable downstream, and no reasonable pattern list would
+    // catch every shape a driver error can take.
+    expect(
+      detectSilentFail(
+        "OpenAIApiDriver requires openai — install it with: npm install openai",
+      ),
+    ).toBeNull();
+  });
+
+  it("passes a successful task's output through unchanged", () => {
+    // Anchor against over-marking: a real answer must survive intact, including
+    // one that merely mentions failure.
+    expect(agentTextFromTask({ output: "Descale the coffee machine" })).toBe(
+      "Descale the coffee machine",
+    );
+    expect(
+      agentTextFromTask({ output: "The build failed; investigate the linker" }),
+    ).toBe("The build failed; investigate the linker");
+  });
+
+  it("prefers output when a task carries both", () => {
+    expect(
+      agentTextFromTask({ output: "real answer", errorMessage: "ignored" }),
+    ).toBe("real answer");
+  });
+
+  it("returns empty string when a task carries neither", () => {
+    expect(agentTextFromTask({})).toBe("");
+  });
+
+  it("caps a long error so one failure cannot flood a prompt or a record", () => {
+    const text = agentTextFromTask({ errorMessage: "x".repeat(5000) });
+    expect(text.length).toBeLessThan(300);
+  });
+});

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -67,6 +67,38 @@ import {
 export const RECIPE_TASK_TIMEOUT_MS = 1_800_000;
 
 /**
+ * The text an agent step receives from a finished orchestrator task.
+ *
+ * A FAILED task must not read as an answer. Both call sites previously did
+ * `task.output ?? task.errorMessage ?? ""`, so when a task failed the driver's
+ * error text was returned as the agent's successful result — unmarked. The
+ * runner saw a normal answer, it flowed into the step's `into` variable, and on
+ * the observed occasion a worker proposed a gated external write whose title
+ * was "OpenAIApiDriver requires openai — install it with: npm install openai".
+ * A human was asked to approve that. The gate asking is what caught it.
+ *
+ * `makeProviderDriverFn` in `yamlRunner.ts` already marks every failure this
+ * way; only the orchestrator-backed path did not, which is precisely the kind
+ * of divergence that hides. Marking happens HERE, at the source, rather than by
+ * teaching `detectSilentFail` to recognise driver error text — enumerating the
+ * shapes an error can take is the mistake #1349 corrected in the redaction
+ * patterns, and it fails silently on every shape nobody thought of.
+ *
+ * Exported so both sites share one implementation and a test can pin it; they
+ * were byte-identical duplicates and still drifted from the third site.
+ */
+export function agentTextFromTask(task: {
+  output?: string;
+  errorMessage?: string;
+}): string {
+  if (task.output) return task.output;
+  if (task.errorMessage) {
+    return `[agent step failed: ${task.errorMessage.slice(0, 200)}]`;
+  }
+  return "";
+}
+
+/**
  * M3 — build the flat-runner approval fn backed by the bridge ApprovalQueue.
  * Returns true (allow) for steps below the gate threshold; otherwise queues a
  * human approval and resolves true only on an explicit "approved" decision
@@ -802,7 +834,7 @@ export class RecipeOrchestration {
               disallowedTools: callOpts.disallowedTools,
             }),
           });
-          return task.output ?? task.errorMessage ?? "";
+          return agentTextFromTask(task);
         };
         // Resolve the owning worker (if any) so replayed steps that fall
         // through to real execution still get the per-worker allowedTools
@@ -1498,7 +1530,7 @@ export class RecipeOrchestration {
           disallowedTools: callOpts.disallowedTools,
         }),
       });
-      return task.output ?? task.errorMessage ?? "";
+      return agentTextFromTask(task);
     };
     // M3 — flat-runner approval gate. Inject a queue-backed approval fn
     // whenever the bridge's approvalGate is engaged. The flat runner only


### PR DESCRIPTION
## The bug

Both orchestrator-backed agent paths did:

```ts
return task.output ?? task.errorMessage ?? "";
```

When the task **failed**, `output` was undefined and the driver's thrown message came back as the agent step's **successful result**, unmarked. The runner cannot distinguish that from a real answer, so it flowed into the step's `into` variable and onward.

## Observed live, 2026-08-13

An orchestrator task failed with `OpenAIApiDriver requires openai — install it with: npm install openai`. That string became `{{title}}`. The recipe's `{{title}} != DUPLICATE` guard passed — an error string is not `"DUPLICATE"` — and a worker asked a human to approve **creating a Todoist task with that title**.

The gate asking is the only reason it did not land. Approve on autopilot and a governed worker writes nonsense to a real external service under a human's name.

## Why one helper, not two fixes

`makeProviderDriverFn` in `yamlRunner.ts` already marks every failure as `[agent step failed: …]`, which `detectSilentFail` recognises. Only this path did not — and the two sites here were **byte-identical duplicates that had still drifted from that third one**. Two corrected copies would be the same setup again, so both now call one exported `agentTextFromTask`.

## Why marking at the source, not pattern-matching downstream

The tempting fix is to teach `detectSilentFail` about driver error text. That is enumerating the shapes an error can take — the exact mistake #1349 corrected in the redaction patterns, where hand-maintained spellings missed the snake_case `api_key` that recipe YAML actually uses. It fails silently on every shape nobody thought of.

A test pins the reasoning by asserting the raw string is **not** detectable downstream, so a future reader can see why the marking happens where it does.

## Verification

The fix landed before the test here, inverting the usual protocol — so the equivalent proof is mutation. Restoring the original expression reddens **3 of 7** tests; the 4 anchors stay green:

- successful output passes through unchanged (including an answer that mentions failure)
- `output` preferred when a task carries both
- empty string when it carries neither

Also confirmed no survivor of the old expression anywhere in `src/`.

## Behaviour change

Failures that previously read as answers now read as failures, so a recipe silently producing garbage will now halt visibly. That is the point — but someone may have work depending on the old behaviour.

Full suite green apart from the known local noise (3 `tokenEfficiency`, 4 pre-existing `ta/*`). All nine gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)