### PR TITLE
chore: stop naming private source files in the tracked .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,16 +143,6 @@ intellij-plugin/.gradle/
 /docs/*-rows.json
 /docs/*-cells.json
 /docs/*-backtest-*.md
-/src/ta/
-/src/recipes/tools/__tests__/market.test.ts
-/src/recipes/tools/__tests__/ta.test.ts
-/src/recipes/tools/__tests__/taLedger.test.ts
-/src/recipes/tools/__tests__/watchlist.test.ts
-/src/recipes/tools/altscan.ts
-/src/recipes/tools/market.ts
-/src/recipes/tools/ta.ts
-/src/recipes/tools/taLedger.ts
-/src/recipes/tools/watchlist.ts
 
 # Codex CLI scaffolding (different coding agent tool, not used for this repo)
 /.codex/


### PR DESCRIPTION
Ten deletions from `.gitignore`. No code.

## The finding

The block these lines sat in opens by explaining why they must not exist:

> This file is tracked and this repo is public, so the previous version of this block — which listed every research thread by name — **published a complete index of private work in the act of trying to protect it**. [...] Never by naming the topic here.

Ten per-file entries under `src/` were doing precisely that, directly beneath the paragraph forbidding it.

The `docs/` half of this was already migrated to `.git/info/exclude` on 2026-08-08 with that same reasoning written out. `src/` was missed — so the rule was half-applied while reading as fully applied, which is the more dangerous state of the two.

## What changed

Moved to `.git/info/exclude` (local, untracked), per the existing precedent. Per-clone exclusion is sufficient because the files exist only on one machine — a fresh clone has nothing to protect, which is exactly why the tracked file was the wrong place for them.

**Nothing replaces them.** A form-based pattern broad enough to cover them would re-publish the same index by shape.

## Why it's safe

Those files are no longer in the working tree at all. They were found orphaned while clearing typecheck noise — `src/ta/` held only a README and one cell, and every module they imported was already gone, so they could not compile or run and nothing registered them. Preserved outside the repo; the `.git/info/exclude` entries cover them if restored.

## Verification

By probe, not by reading:

1. Recreated the excluded paths → `git status` stays silent. ✅
2. Created a control file **not** on the list → `git status` shows it. ✅

Step 2 is the one that matters: without it, the silence in step 1 would be equally consistent with a probe that detects nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)