### PR TITLE
feat(runstore): the ADR-0022 storage seam + a conformance contract

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,18 +29,19 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-13 `feat/durable-evidence-store` — implements
-  [ADR-0022](adr/0022-durable-evidence-store.md) (decision landed in #1362):
-  move `runs` + `run_steps` off JSONL to embedded SQLite (`node:sqlite`,
-  engines →22.5, Node 24 added to the CI matrix) behind a repository
-  interface, via dual-write + shadow-read through the first rotation rather
-  than a cutover; JSONL demoted to the append-only export path. Branch
-  reserved, not yet cut. Will touch `src/runLog.ts`, `src/runStepLedger.ts`
-  and all 8 `RecipeRunLog` construction sites (bridge.ts, index.ts ×3,
-  yamlRunner, chainedRunner ×2, runWorkerShadow) — anyone working in the
-  recipe runner or the worker-trust replay path should coordinate first.
-  Folds in #1360 (`getBySeq` collisions): a real primary key is that fix. —
-  build session
+- 2026-08-13 `feat/sqlite-run-store` — next slice of
+  [ADR-0022](adr/0022-durable-evidence-store.md). The seam landed in #1366
+  (`src/runStore/`: `RunRepository`, the JSONL adapter, and the conformance
+  contract both stores must pass). This slice adds the `node:sqlite`
+  implementation against that same contract, then dual-write + shadow-read.
+  Branch reserved, not yet cut. Will touch `src/runLog.ts`,
+  `src/runStepLedger.ts` and all 8 `RecipeRunLog` construction sites
+  (bridge.ts, index.ts ×3, yamlRunner, chainedRunner ×2, runWorkerShadow) —
+  anyone working in the recipe runner or the worker-trust replay path should
+  coordinate first. Folds in #1360 (`getBySeq` collisions): a real primary
+  key is that fix. Blocked-ish on #1365 — windows/24 is advisory, and it must
+  be blocking again before `node:sqlite` code relies on that cell for
+  coverage. — build session
 
 
 

--- a/src/runStore/__tests__/jsonlRunRepository.test.ts
+++ b/src/runStore/__tests__/jsonlRunRepository.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Pins the ADR-0022 contract against the INCUMBENT store.
+ *
+ * This runs first and must stay green on its own merits: it is the baseline
+ * that gives the suite authority. A contract only validated against the new
+ * implementation would be a description of that implementation, and would
+ * accept whatever it happened to do.
+ */
+
+import { RecipeRunLog } from "../../runLog.js";
+import { JsonlRunRepository } from "../jsonlRunRepository.js";
+import { describeRunRepositoryContract } from "./runRepositoryConformance.js";
+
+describeRunRepositoryContract("JSONL (incumbent)", (dir) => ({
+  repo: JsonlRunRepository.open({ dir }),
+  // A second RecipeRunLog over the same directory — the in-process stand-in
+  // for a second bridge instance, which is the configuration all three known
+  // defects (#1324 / #1340 / #1341) actually occurred in.
+  reopen: () => new JsonlRunRepository(new RecipeRunLog({ dir })),
+}));

--- a/src/runStore/__tests__/runRepositoryConformance.ts
+++ b/src/runStore/__tests__/runRepositoryConformance.ts
@@ -1,0 +1,237 @@
+/**
+ * The shared contract every `RunRepository` implementation must satisfy —
+ * ADR-0022.
+ *
+ * WHY A SHARED SUITE. The migration's entire safety argument is "the new store
+ * behaves like the one we already trust". That claim is only checkable if both
+ * stores are held to one set of assertions written down in one place. Two
+ * separately-written test files drift, and they drift silently in the
+ * permissive direction: the new store's suite quietly omits the case it fails.
+ *
+ * HOW TO USE. Call `describeRunRepositoryContract` with a factory. The factory
+ * receives a fresh directory per test and must return a repository over it,
+ * plus a `reopen()` that constructs a SECOND independent instance over the SAME
+ * storage — that is how cross-process durability is exercised, and it is where
+ * every one of #1324 / #1340 / #1341 actually lived.
+ *
+ * WHAT THIS SUITE IS NOT. It is not the bug-replay comparison. Everything here
+ * passes against JSONL today, by design — a contract the incumbent fails is a
+ * wish, not a contract. The three known defects are asserted separately, where
+ * JSONL is EXPECTED to lose (ADR-0022 §4).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RunStepResult } from "../../runLog.js";
+import type { RunRepository } from "../runRepository.js";
+
+export interface RepositoryHarness {
+  repo: RunRepository;
+  /** A second, independent instance over the same storage. */
+  reopen: () => RunRepository;
+}
+
+export type RepositoryFactory = (dir: string) => RepositoryHarness;
+
+/**
+ * A step fixture.
+ *
+ * `tool` defaults to `http.post` — classified `irreversible` — because the
+ * in-flight durability guarantee is SCOPED to evidence-bearing steps
+ * (`isEvidenceBearing`: non-reversible, or any error). A reversible step such
+ * as `file.write` is deliberately never written mid-flight, so using one as
+ * the default fixture makes the durability assertion silently untestable. The
+ * first draft of this suite did exactly that and read as a store defect.
+ */
+const step = (
+  id: string,
+  status: "ok" | "error" = "ok",
+  tool = "http.post",
+): RunStepResult => ({ id, tool, status }) as unknown as RunStepResult;
+
+export function describeRunRepositoryContract(
+  name: string,
+  factory: RepositoryFactory,
+): void {
+  describe(`RunRepository contract — ${name}`, () => {
+    let dir: string;
+    let h: RepositoryHarness;
+
+    beforeEach(() => {
+      dir = mkdtempSync(path.join(tmpdir(), "run-repo-contract-"));
+      h = factory(dir);
+    });
+    afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+    const start = (
+      over: Partial<Parameters<RunRepository["startRun"]>[0]> = {},
+    ) =>
+      h.repo.startRun({
+        taskId: `task-${Math.random().toString(36).slice(2)}`,
+        recipeName: "demo",
+        // "cron" not "manual": RunTrigger is cron | webhook | recipe. A manual
+        // run is not a distinct trigger kind in this model.
+        trigger: "cron",
+        createdAt: 1_000,
+        ...over,
+      });
+
+    const finish = (seq: number, over: Record<string, unknown> = {}) =>
+      h.repo.completeRun(seq, {
+        status: "done",
+        doneAt: 2_000,
+        durationMs: 1_000,
+        stepResults: [step("s1")],
+        ...over,
+      });
+
+    it("a started run is visible as running before it completes", () => {
+      const seq = start({ taskId: "t-running" });
+      const run = h.repo.getBySeq(seq);
+      expect(run?.status).toBe("running");
+      expect(run?.taskId).toBe("t-running");
+    });
+
+    it("completeRun makes the run terminal and keeps its steps", () => {
+      const seq = start();
+      finish(seq, { stepResults: [step("a"), step("b")] });
+      const run = h.repo.getBySeq(seq);
+      expect(run?.status).toBe("done");
+      expect(run?.stepResults?.map((s) => s.id)).toEqual(["a", "b"]);
+    });
+
+    /**
+     * #1340. Steps must be durable AS THEY HAPPEN, not at completion — a run
+     * whose process dies mid-flight previously recorded none of the work it had
+     * already done.
+     *
+     * `ownerPid: -1` marks the run as owned by a process that is provably gone,
+     * which is the condition recovery is gated on (`isProcessAlive`). Without
+     * it the run's owner is THIS live process, recovery correctly declines to
+     * touch it, and the assertion below fails for a reason that has nothing to
+     * do with durability. The first draft of this test made exactly that
+     * mistake and read as a JSONL defect.
+     *
+     * Asserted through `reopen()`: an in-memory list would satisfy a
+     * same-instance read while still losing everything on a crash.
+     */
+    it("in-flight steps survive a dead owner without completeRun (#1340)", () => {
+      const seq = start({ taskId: "t-inflight", ownerPid: -1 });
+      h.repo.updateRunSteps(seq, [step("early-1"), step("early-2")]);
+
+      const seen = h
+        .reopen()
+        .query({ limit: 50 })
+        .find((r) => r.taskId === "t-inflight");
+      expect(seen, "the run itself must be durable").toBeTruthy();
+      expect(
+        seen?.stepResults?.map((s) => s.id),
+        "work that already happened must not be erased by the interruption",
+      ).toEqual(["early-1", "early-2"]);
+    });
+
+    /**
+     * The scope boundary of the guarantee above, asserted so it cannot be
+     * widened by accident. Reversible steps are NOT persisted mid-flight —
+     * `runs.jsonl`'s byte cap is what starved the trust ledger, and paying it
+     * for steps that carry no trust evidence would buy durability with
+     * retention. A future store that "helpfully" persisted everything would
+     * reintroduce that trade silently.
+     */
+    it("reversible in-flight steps are deliberately NOT persisted", () => {
+      const seq = start({ taskId: "t-reversible", ownerPid: -1 });
+      h.repo.updateRunSteps(seq, [step("rev-1", "ok", "file.write")]);
+
+      const seen = h
+        .reopen()
+        .query({ limit: 50 })
+        .find((r) => r.taskId === "t-reversible");
+      expect(seen?.stepResults ?? []).toHaveLength(0);
+    });
+
+    /**
+     * The other half of the same rule, and the one #1341 got wrong: a run whose
+     * owner is ALIVE must be left alone. A reader that "recovers" a live run
+     * rewrites its history, which is how a successful run came to be recorded
+     * as `interrupted, steps: 0`.
+     */
+    it("a live owner's in-flight run is not swept by another instance (#1341)", () => {
+      const seq = start({ taskId: "t-live" }); // ownerPid defaults to this process
+      h.repo.updateRunSteps(seq, [step("in-progress")]);
+
+      const seen = h
+        .reopen()
+        .query({ limit: 50 })
+        .find((r) => r.taskId === "t-live");
+      expect(seen?.status, "a live run must stay running").toBe("running");
+    });
+
+    it("a completed run is visible to a second instance (durability)", () => {
+      const seq = start({ taskId: "t-durable" });
+      finish(seq);
+      const seen = h
+        .reopen()
+        .query({ limit: 50 })
+        .find((r) => r.taskId === "t-durable");
+      expect(seen?.status).toBe("done");
+    });
+
+    it("query filters by recipe", () => {
+      finish(start({ recipeName: "alpha" }));
+      finish(start({ recipeName: "beta" }));
+      const names = h.repo.query({ recipe: "alpha" }).map((r) => r.recipeName);
+      expect(names).toEqual(["alpha"]);
+    });
+
+    it("query filters by status", () => {
+      finish(start(), { status: "error", errorMessage: "boom" });
+      finish(start());
+      expect(h.repo.query({ status: "error" })).toHaveLength(1);
+      expect(h.repo.query({ status: "done" })).toHaveLength(1);
+    });
+
+    it("query respects limit and returns newest first", () => {
+      finish(start({ recipeName: "r1", createdAt: 1 }));
+      finish(start({ recipeName: "r2", createdAt: 2 }));
+      finish(start({ recipeName: "r3", createdAt: 3 }));
+      const got = h.repo.query({ limit: 2 });
+      expect(got).toHaveLength(2);
+      expect(got[0]?.recipeName).toBe("r3");
+    });
+
+    it("query filters by since (createdAt lower bound)", () => {
+      finish(start({ createdAt: 100, recipeName: "old" }));
+      finish(start({ createdAt: 900, recipeName: "new" }));
+      const names = h.repo.query({ since: 500 }).map((r) => r.recipeName);
+      expect(names).toEqual(["new"]);
+    });
+
+    it("query filters by manualRunId, yielding every retry of one attempt", () => {
+      finish(start({ manualRunId: "attempt-A" }));
+      finish(start({ manualRunId: "attempt-A" }));
+      finish(start({ manualRunId: "attempt-B" }));
+      expect(h.repo.query({ manualRunId: "attempt-A" })).toHaveLength(2);
+    });
+
+    it("getChildSeqs finds runs by parentSeq", () => {
+      const parent = start({ recipeName: "parent" });
+      finish(parent);
+      const child = start({ recipeName: "child", parentSeq: parent });
+      finish(child);
+      expect(h.repo.getChildSeqs(parent)).toContain(child);
+    });
+
+    it("getBySeq returns null for an unknown seq", () => {
+      expect(h.repo.getBySeq(999_999)).toBeNull();
+    });
+
+    it("size reflects retained runs", () => {
+      expect(h.repo.size()).toBe(0);
+      finish(start());
+      finish(start());
+      expect(h.repo.size()).toBe(2);
+    });
+  });
+}

--- a/src/runStore/jsonlRunRepository.ts
+++ b/src/runStore/jsonlRunRepository.ts
@@ -1,0 +1,69 @@
+/**
+ * The incumbent JSONL store, behind the ADR-0022 repository seam.
+ *
+ * This adapter holds NO logic of its own — every method forwards to
+ * `RecipeRunLog`. That is the point. It exists so the interface can be
+ * introduced with provably zero behaviour change, which is what makes the
+ * conformance suite meaningful: the suite is first pinned against the store
+ * we already trust, and only then pointed at a new one.
+ *
+ * If this file ever grows a behavioural decision, the comparison it enables
+ * stops being a comparison.
+ */
+
+import type { RecipeRun, RunQuery, RunStepResult } from "../runLog.js";
+import { RecipeRunLog, type RunLogOptions } from "../runLog.js";
+import type {
+  CompleteRunInput,
+  RunRepository,
+  StartRunInput,
+} from "./runRepository.js";
+
+export class JsonlRunRepository implements RunRepository {
+  constructor(private readonly log: RecipeRunLog) {}
+
+  /** Convenience: build the adapter and the underlying log together. */
+  static open(opts: RunLogOptions): JsonlRunRepository {
+    return new JsonlRunRepository(new RecipeRunLog(opts));
+  }
+
+  /**
+   * Escape hatch for callers still reaching for `RecipeRunLog`-only methods
+   * (`record`, `appendDirect`, `readArchive`). Those are deliberately absent
+   * from `RunRepository` — `readArchive` in particular is a JSONL rotation
+   * detail with no meaning in a store that does not rotate by bytes.
+   *
+   * Every use of this is a migration debt marker, not an approved pattern.
+   */
+  get underlying(): RecipeRunLog {
+    return this.log;
+  }
+
+  startRun(input: StartRunInput): number {
+    return this.log.startRun(input);
+  }
+
+  updateRunSteps(seq: number, stepResults: RunStepResult[]): void {
+    this.log.updateRunSteps(seq, stepResults);
+  }
+
+  completeRun(seq: number, input: CompleteRunInput): void {
+    this.log.completeRun(seq, input);
+  }
+
+  query(q: RunQuery = {}): RecipeRun[] {
+    return this.log.query(q);
+  }
+
+  getBySeq(seq: number): RecipeRun | null {
+    return this.log.getBySeq(seq);
+  }
+
+  getChildSeqs(parentSeq: number): number[] {
+    return this.log.getChildSeqs(parentSeq);
+  }
+
+  size(): number {
+    return this.log.size();
+  }
+}

--- a/src/runStore/runRepository.ts
+++ b/src/runStore/runRepository.ts
@@ -1,0 +1,110 @@
+/**
+ * The storage seam for run evidence — ADR-0022.
+ *
+ * WHY THIS EXISTS. `runs.jsonl` is the autonomy gate's trust evidence and also
+ * an append-only text file with no integrity properties. It failed three ways
+ * in eight weeks, each silently: #1324 (`seq` collides across instances — 142
+ * of 145 in the live log), #1340 (in-flight steps never reached disk), #1341
+ * (a concurrent reader made `completeRun` a no-op, recording a successful run
+ * as `interrupted, steps: 0`). Each was fixed; the pattern was not.
+ *
+ * This interface is the line those fixes kept crossing. It names what a run
+ * store must DO, so an implementation can be swapped without every caller
+ * learning how the bytes are laid out. `RecipeRunLog` is the incumbent
+ * implementation; a SQLite one follows, and dual-write compares them before
+ * anything flips.
+ *
+ * ## What this interface deliberately does NOT do
+ *
+ * It does not redesign what a run means. Every method mirrors a `RecipeRunLog`
+ * method with the same name and semantics, including ones that are arguably
+ * wrong (see `getBySeq`). A storage migration that also changes the domain
+ * model cannot be verified by comparing old against new, because there is no
+ * longer a fixed thing to compare — and comparison against the incumbent is
+ * the entire safety argument for the migration.
+ *
+ * Fixing those wrong-but-preserved parts happens AFTER the stores agree, not
+ * during.
+ */
+
+import type {
+  RecipeRun,
+  RunQuery,
+  RunStepResult,
+  RunTrigger,
+  TerminalRunStatus,
+} from "../runLog.js";
+
+/** Arguments to {@link RunRepository.startRun}. Mirrors `RecipeRunLog.startRun`. */
+export interface StartRunInput {
+  taskId: string;
+  recipeName: string;
+  trigger: RunTrigger;
+  createdAt: number;
+  startedAt?: number;
+  model?: string;
+  parentSeq?: number;
+  manualRunId?: string;
+  /** Test seam — defaults to this process. See `RecipeRun.ownerPid`. */
+  ownerPid?: number;
+}
+
+/** Arguments to {@link RunRepository.completeRun}. Mirrors `RecipeRunLog.completeRun`. */
+export interface CompleteRunInput {
+  status: TerminalRunStatus;
+  doneAt: number;
+  durationMs: number;
+  stepResults: RunStepResult[];
+  outputTail?: string;
+  errorMessage?: string;
+  assertionFailures?: RecipeRun["assertionFailures"];
+  inboxOutputs?: RecipeRun["inboxOutputs"];
+  budgetWarnings?: RecipeRun["budgetWarnings"];
+  tokenTotals?: RecipeRun["tokenTotals"];
+  budgetTotals?: RecipeRun["budgetTotals"];
+}
+
+/**
+ * A store of recipe runs and their steps.
+ *
+ * Implementations must be safe against a SECOND PROCESS writing the same
+ * store concurrently. That is not a theoretical requirement: `runs.jsonl` has
+ * eight construction sites, several of which write, and every one of the three
+ * bugs above involved two writers or a writer and a reader disagreeing.
+ */
+export interface RunRepository {
+  /**
+   * Begin a run and return its `seq`.
+   *
+   * NOTE the returned `seq` is per-instance and therefore NOT unique across
+   * processes (#1324). It is preserved because callers pass it back to
+   * `updateRunSteps` / `completeRun` within one process, where it is
+   * well-defined. Cross-process identity is `taskId`.
+   */
+  startRun(input: StartRunInput): number;
+
+  /** Replace the step list of an in-flight run, persisting evidence as it arrives (#1340). */
+  updateRunSteps(seq: number, stepResults: RunStepResult[]): void;
+
+  /** Finish a run. Must be durable before returning. */
+  completeRun(seq: number, input: CompleteRunInput): void;
+
+  /** Query runs, newest first. */
+  query(q?: RunQuery): RecipeRun[];
+
+  /**
+   * Look up one run by `seq`.
+   *
+   * PRESERVED AS-IS AND KNOWN TO BE WRONG (#1360): `seq` is not unique across
+   * processes, so this can resolve to an arbitrary colliding run. It backs the
+   * `/runs/[seq]` URL contract, so correcting it is a separate, visible change
+   * — not something to slip in behind a storage swap.
+   */
+  getBySeq(seq: number): RecipeRun | null;
+
+  /** `seq`s of runs whose `parentSeq` is the given run. */
+  getChildSeqs(parentSeq: number): number[];
+
+  /** Number of runs currently retained and readable. */
+  size(): number;
+}


### PR DESCRIPTION
First slice of [ADR-0022](../blob/main/docs/adr/0022-durable-evidence-store.md). **No production wiring, no behaviour change** — nothing constructs these yet. Four new files, nothing else touched.

## What's here

| File | Role |
|---|---|
| `runRepository.ts` | The interface — what a run store must *do* |
| `jsonlRunRepository.ts` | The incumbent behind the seam, pure delegation |
| `__tests__/runRepositoryConformance.ts` | **The contract both stores must satisfy** |
| `__tests__/jsonlRunRepository.test.ts` | Pins the contract against JSONL |

The conformance suite is the point of the PR. The migration's entire safety argument is *"the new store behaves like the one we already trust"* — checkable only if both are held to one set of assertions in one place. Two separately-written suites drift, and they drift in the permissive direction: the new store's suite quietly omits the case it fails.

It's pinned against the **incumbent first**, deliberately. A contract validated only against the new implementation is a description of that implementation, and will accept whatever it happens to do.

## The interface preserves things that are wrong

`getBySeq` resolves an ambiguous key (#1360) and is carried over as-is. A storage migration that also fixes the domain model can't be verified by comparing old against new — there's no longer a fixed thing to compare, and that comparison is the whole safety argument. Fixes land *after* the stores agree.

## Writing the contract found two things I had wrong

Both initially read as store defects. Both are now recorded in comments, because the next person will make the same inference:

1. **In-flight recovery is gated on the owning process being dead.** With a live owner the store correctly declines to touch the run. Using the default `ownerPid` made the durability assertion fail for a reason unrelated to durability. Fixed with `ownerPid: -1` — the idiom `runLogSweepOwnership.test.ts` already uses.

2. **The guarantee is scoped to evidence-bearing steps** (`isEvidenceBearing`: non-reversible, or any error). `file.write` is *reversible*, so my original fixture picked the one kind of step deliberately never persisted mid-flight. Now defaults to `http.post` — and the exclusion has its own test, so a future store can't "helpfully" persist everything and silently trade retention for durability. That trade is what starved the trust ledger in the first place.

## Verification — by mutation, not by green

| Mutant | Result |
|---|---|
| `updateRunSteps` drops steps (#1340 regression) | ✅ fails exactly the #1340 test |
| `query` ignores all filters | ✅ fails exactly the 4 filter tests |
| restored | ✅ 14/14 |

A contract that cannot fail proves nothing. Full suite: **9612/9612**.

## Next

SQLite implementation against this same contract, then dual-write + shadow-read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)