### PR TITLE
fix(outcomes): a failed write is a 500, not a 400 with the path in it

### DIFF
--- a/src/__tests__/outcomesRoutesErrorClassification.test.ts
+++ b/src/__tests__/outcomesRoutesErrorClassification.test.ts
@@ -1,0 +1,135 @@
+/**
+ * POST /outcomes — a store failure is not a bad request.
+ *
+ * The route wrapped `store.upsert()` in a catch that answered EVERY error with
+ * `400` and the error's raw `message`. `upsert` throws a TYPED
+ * `AmbiguousActionRefError` for the validation case it means to report; every
+ * other error escaping it comes from `appendFileSync` on
+ * `outcome-log.jsonl`. So a disk fault (EACCES / ENOSPC / a read-only volume)
+ * was reported to the operator as "your request is malformed", carrying the
+ * filesystem path in the body.
+ *
+ * Two defects in one catch:
+ *
+ *  1. CORRECTNESS, and the reason this matters more than its severity label.
+ *     The operator's confirmation is the ONLY thing that moves a worker's
+ *     dial on a non-reversible action — an unconfirmed filing is withheld
+ *     forever. Telling that operator their input was invalid, when the write
+ *     actually failed, sends them to fix a request that was already correct
+ *     while the disposition is silently lost. A 500 says "retry"; a 400 says
+ *     "stop, you are wrong".
+ *
+ *  2. DISCLOSURE (CodeQL js/stack-trace-exposure, alert #141). An arbitrary
+ *     Error message from inside the store is echoed to an HTTP caller.
+ *
+ * The fix classifies at the SOURCE's own signal — `instanceof
+ * AmbiguousActionRefError` — rather than sniffing message text. This codebase
+ * has corrected the string-matching version of this mistake twice (#1349,
+ * #1356); enumerating error spellings is how a new spelling gets missed.
+ */
+
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import type { RecipeRouteDeps } from "../recipeRoutes.js";
+import { tryHandleRecipeRoute } from "../recipeRoutes.js";
+import { AmbiguousActionRefError } from "../workers/actionRef.js";
+import type { OutcomeStore } from "../workers/outcomeStore.js";
+
+function makeReq(): IncomingMessage {
+  const req = new EventEmitter() as unknown as IncomingMessage;
+  (req as { method?: string }).method = "POST";
+  return req;
+}
+
+function makeRes(): {
+  res: ServerResponse;
+  read: () => { status: number; body: string };
+} {
+  let status = 0;
+  let body = "";
+  const res = {
+    writeHead(code: number) {
+      status = code;
+      return this;
+    },
+    end(b?: string) {
+      body = b ?? "";
+      return this;
+    },
+  } as unknown as ServerResponse;
+  return { res, read: () => ({ status, body }) };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+/** A store whose `upsert` fails the way the caller under test chooses. */
+function depsWithFailingUpsert(err: Error): RecipeRouteDeps {
+  return {
+    outcomeStoreFn: () =>
+      ({
+        upsert() {
+          throw err;
+        },
+        readAll: () => [],
+        getDisposition: () => null,
+      }) as unknown as OutcomeStore,
+  } as unknown as RecipeRouteDeps;
+}
+
+async function post(
+  deps: RecipeRouteDeps,
+): Promise<{ status: number; body: string }> {
+  const req = makeReq();
+  const { res, read } = makeRes();
+  tryHandleRecipeRoute(req, res, new URL("http://x/outcomes"), deps);
+  req.emit(
+    "data",
+    Buffer.from(
+      JSON.stringify({
+        issueUrl: "https://github.com/o/r/issues/1",
+        disposition: "confirmed",
+      }),
+    ),
+  );
+  req.emit("end");
+  await flush();
+  await flush();
+  return read();
+}
+
+describe("POST /outcomes — store failures are classified by type, not echoed", () => {
+  it("a disk failure is a 500 and does not leak the error message", async () => {
+    // The shape appendFileSync actually throws: message carries the path.
+    const diskErr = Object.assign(
+      new Error(
+        "EACCES: permission denied, open '/Users/someone/.patchwork/outcome-log.jsonl'",
+      ),
+      { code: "EACCES" },
+    );
+
+    const { status, body } = await post(depsWithFailingUpsert(diskErr));
+
+    expect(status, "a failed write is a server fault, not a bad request").toBe(
+      500,
+    );
+    expect(body).not.toContain("EACCES");
+    expect(body).not.toContain("outcome-log.jsonl");
+    expect(body).not.toContain(".patchwork");
+  });
+
+  it("a validation refusal is still a 400 with its authored message", async () => {
+    // The one error the route MEANS to surface. Its text is written by us for
+    // an operator to read, so it must survive the fix intact — a change that
+    // hid this too would be a regression wearing a security fix's clothes.
+    const authored =
+      "An outcome record needs a usable key — either `issueUrl` or a `ref` with a tool and an id.";
+
+    const { status, body } = await post(
+      depsWithFailingUpsert(new AmbiguousActionRefError(authored)),
+    );
+
+    expect(status).toBe(400);
+    expect(body).toContain("usable key");
+  });
+});

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -53,6 +53,7 @@ import type { LintIssue } from "./recipes/validation.js";
 import type { RecipeDraft } from "./recipesHttp.js";
 import { invalidateRecipesCache } from "./recipesHttp.js";
 import { validateSafeUrl } from "./ssrfGuard.js";
+import { AmbiguousActionRefError } from "./workers/actionRef.js";
 import type { OutcomeStore } from "./workers/outcomeStore.js";
 
 /**
@@ -1330,9 +1331,24 @@ export function tryHandleRecipeRoute(
           });
         } catch (err) {
           // The store refuses a record nothing could look up (e.g. a tool name
-          // that would produce a URL-shaped key). Surface it as a 400 — it is
+          // that would produce a URL-shaped key). Surface THAT as a 400 — it is
           // a bad request, not a server fault.
-          respond400(err instanceof Error ? err.message : String(err));
+          //
+          // Classified on the source's own typed signal, never on message
+          // text. Everything else escaping `upsert` comes from the
+          // `appendFileSync` to outcome-log.jsonl, and answering a disk fault
+          // with 400 + the raw message was wrong twice over: it told the
+          // operator their input was malformed when the WRITE failed (a 500
+          // says "retry", a 400 says "stop, you are wrong"), and it echoed a
+          // filesystem path back to the caller (CodeQL js/stack-trace-exposure
+          // #141). The operator's confirmation is the only thing that moves a
+          // worker's dial on a non-reversible action, so a lost disposition
+          // misreported as user error is evidence quietly going missing.
+          if (err instanceof AmbiguousActionRefError) {
+            respond400(err.message);
+          } else {
+            respond500(res, err, "POST /outcomes upsert");
+          }
           return;
         }
         res.writeHead(200, { "Content-Type": "application/json" });


### PR DESCRIPTION
Closes CodeQL alert **#141** (`js/stack-trace-exposure`, medium) — but the security label is the smaller half of this.

## What was wrong

`POST /outcomes` wrapped `store.upsert()` in a catch that answered **every** error with `400` and the raw `err.message`:

```ts
} catch (err) {
  respond400(err instanceof Error ? err.message : String(err));
```

`upsert` throws a **typed** `AmbiguousActionRefError` for the validation case it means to report. Everything else escaping it comes from `appendFileSync` on `outcome-log.jsonl`.

So a disk fault — `EACCES`, `ENOSPC`, a read-only volume — was reported to the operator as *"your request is malformed"*, with the filesystem path in the response body.

## Two defects, and the correctness one matters more

1. **Correctness.** An operator's confirmation is the only thing that moves a worker's dial on a non-reversible action — an unconfirmed filing is withheld forever. Telling that operator their input was invalid, when the *write* failed, sends them off to fix a request that was already correct while the disposition is silently lost. **A 500 says "retry". A 400 says "stop, you are wrong."** On the trust ledger, that difference is evidence going missing.

2. **Disclosure.** An arbitrary internal `Error` message echoed to an HTTP caller.

## The fix

Classify on the source's **own typed signal**, never on message text:

```ts
if (err instanceof AmbiguousActionRefError) respond400(err.message);
else respond500(res, err, "POST /outcomes upsert");
```

This codebase has corrected the string-matching version of this mistake twice already (#1349, #1356) — enumerating error spellings is precisely how the next spelling gets missed. `respond500` already logs the stack server-side and returns a generic body, so no new redaction was needed; the error just had to reach it.

## Verification — test-first

| Case | Before | After |
|---|---|---|
| Disk fault (`EACCES` + path) | ❌ 400, leaks path | ✅ 500, generic body |
| Validation refusal | ✅ 400 + authored message | ✅ 400 + authored message |

The second row is the one that stops this being a security fix that quietly breaks a feature: the message we *do* mean an operator to read must survive, and it's asserted both before and after.

Full suite: **9600/9600**.

## Deliberately not changed

The `patchwork outcomes confirm|reject` CLI path prints the same raw message to the operator's own terminal. No disclosure applies locally, and there's no 400/500 distinction to get wrong — the filesystem path is the *useful* part of that diagnostic. Changing it would remove a real signal to satisfy a pattern that doesn't apply there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)