### PR TITLE
fix(test-wrapper): report the signal that killed vitest instead of a bare exit 1

### DIFF
--- a/scripts/test-via-bridge.mjs
+++ b/scripts/test-via-bridge.mjs
@@ -98,6 +98,35 @@ function fallbackToVitest() {
     stdio: "inherit",
     shell: process.platform === "win32",
   });
+
+  // Say WHY the child failed. `result.status` is null when the process was
+  // killed by a signal or never spawned, so `status ?? 1` turned "killed by
+  // SIGSEGV" and "npx not found" into an indistinguishable bare exit 1 — no
+  // signal, no error, no message. CI is the only place this path runs (it is
+  // taken whenever no bridge lock exists), which is exactly where nobody can
+  // attach a debugger.
+  //
+  // This is not hypothetical tidying: #1365 (windows-latest + node 24) fails
+  // through this branch with no vitest summary and no failing test, and the
+  // reason it has stayed unexplained is that the one process that knew —
+  // this one — discarded the evidence on its way out.
+  if (result.error) {
+    console.error(
+      `[test-via-bridge] could not run vitest: ${result.error.message}`,
+    );
+    process.exit(1);
+  }
+  if (result.signal) {
+    console.error(
+      `[test-via-bridge] vitest was KILLED by ${result.signal} — the suite did ` +
+        `not finish, so a missing summary above is the cause, not a symptom. ` +
+        `Usual suspects: OOM (heap or runner memory) and a watchdog kill.`,
+    );
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    console.error(`[test-via-bridge] vitest exited ${result.status}`);
+  }
   process.exit(result.status ?? 1);
 }
 


### PR DESCRIPTION
Diagnostic step for #1365 — and a real defect on its own. **Does not fix #1365**; it makes the next windows/24 run say what actually happened.

## The gap

`fallbackToVitest` ended with:

```js
process.exit(result.status ?? 1);
```

`spawnSync` sets `status` to `null` when the child is **killed by a signal** or **never spawned**. So three very different outcomes collapsed into an indistinguishable bare exit 1:

| Reality | What CI showed |
|---|---|
| killed by SIGSEGV / OOM | exit 1, no message |
| `npx` not found | exit 1, no message |
| genuine test failure | exit 1, no message |

`result.signal` and `result.error` were both discarded.

## Why this is the blocker on #1365

This branch is taken **whenever no bridge lock exists** — that is CI, and essentially only CI, which is exactly where nobody can attach a debugger.

#1365's whole signature is *"vitest dies with no summary, no failing test, no reason"*. I spent a day treating that as a mystery. It isn't: the one process that knew why vitest died was throwing the evidence away on its way out. What we've been reading as "silent crash" is partly just our own wrapper refusing to say.

Same failure shape this repo keeps correcting — mark the failure at the **source** rather than asking a downstream reader to infer it (#1349, #1356).

## What changed

Distinguishes and reports all three cases. No behaviour change on the success path; a non-zero exit is still a non-zero exit.

## Verification — each branch forced, not read

| Branch | How | Output |
|---|---|---|
| signal | stub `npx` that SIGSEGVs itself | `KILLED by SIGSEGV` |
| spawn error | `PATH` with `node` but no `npx` | `spawnSync npx ENOENT` |
| non-zero exit | unmatched test filter | `vitest exited 1` |

My first attempt at the spawn-error test was invalid — it removed `node` from `PATH` as well, so it proved nothing. Redone with only `node` present.

Full suite: **9614/9614**.

## Expected next

The following windows/24 run should print one of those three lines. If it's `KILLED by <signal>`, #1365 is a resource/watchdog problem and the fix is memory or pooling, not a test. If it's `exited N` with no summary, the problem is inside vitest's own reporting and needs a different attack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)