### PR TITLE
feat(runstore): dual-write with shadow reads

### DIFF
--- a/src/runStore/__tests__/dualWriteRunRepository.test.ts
+++ b/src/runStore/__tests__/dualWriteRunRepository.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Dual-write: the two safety rules, and that the comparison actually detects
+ * things.
+ *
+ * The contract conformance run (below) proves dual-write is transparent — a
+ * caller cannot tell it is there. These tests prove the parts a contract
+ * cannot: that a broken mirror is harmless, and that a lying mirror is
+ * noticed. A comparison layer that reports nothing looks exactly like one
+ * where the stores agree, which is the failure this whole migration is
+ * guarding against.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RecipeRun, RunQuery, RunStepResult } from "../../runLog.js";
+import {
+  type Divergence,
+  DualWriteRunRepository,
+  type MirrorFailure,
+} from "../dualWriteRunRepository.js";
+import { JsonlRunRepository } from "../jsonlRunRepository.js";
+import type {
+  CompleteRunInput,
+  RunRepository,
+  StartRunInput,
+} from "../runRepository.js";
+import { SqliteRunRepository } from "../sqliteRunRepository.js";
+import { describeRunRepositoryContract } from "./runRepositoryConformance.js";
+
+/* ------------------------------------------------------------------ *
+ * 1. Transparency: the pair must satisfy the same contract as either
+ *    store alone. If wrapping changed observable behaviour, dual-write
+ *    would itself be the migration risk.
+ * ------------------------------------------------------------------ */
+describeRunRepositoryContract(
+  "dual-write (JSONL primary + SQLite mirror)",
+  (dir) => {
+    const opened: SqliteRunRepository[] = [];
+    const open = (): RunRepository => {
+      const mirror = new SqliteRunRepository({ dir: path.join(dir, "mirror") });
+      opened.push(mirror);
+      return new DualWriteRunRepository(
+        JsonlRunRepository.open({ dir }),
+        mirror,
+      );
+    };
+    return {
+      repo: open(),
+      reopen: open,
+      cleanup: () => {
+        for (const m of opened) m.close();
+        opened.length = 0;
+      },
+    };
+  },
+);
+
+/* ------------------------------------------------------------------ *
+ * 2. The rules that make it safe.
+ * ------------------------------------------------------------------ */
+
+/** A mirror that fails every call, the way a corrupt or locked db would. */
+const brokenMirror = (): RunRepository => ({
+  startRun: () => {
+    throw new Error("mirror down");
+  },
+  updateRunSteps: () => {
+    throw new Error("mirror down");
+  },
+  completeRun: () => {
+    throw new Error("mirror down");
+  },
+  query: () => {
+    throw new Error("mirror down");
+  },
+  getBySeq: () => {
+    throw new Error("mirror down");
+  },
+  getChildSeqs: () => {
+    throw new Error("mirror down");
+  },
+  size: () => {
+    throw new Error("mirror down");
+  },
+});
+
+/** A mirror that answers, but wrongly — the case comparison exists to catch. */
+class LyingMirror implements RunRepository {
+  constructor(private readonly inner: RunRepository) {}
+  startRun(i: StartRunInput): number {
+    return this.inner.startRun(i);
+  }
+  updateRunSteps(seq: number, s: RunStepResult[]): void {
+    this.inner.updateRunSteps(seq, s);
+  }
+  completeRun(seq: number, i: CompleteRunInput): void {
+    // Silently records the wrong outcome: the #1341 shape, where a run that
+    // succeeded is remembered as having been interrupted.
+    this.inner.completeRun(seq, { ...i, status: "interrupted" });
+  }
+  query(q: RunQuery = {}): RecipeRun[] {
+    return this.inner.query(q);
+  }
+  getBySeq(seq: number): RecipeRun | null {
+    return this.inner.getBySeq(seq);
+  }
+  getChildSeqs(p: number): number[] {
+    return this.inner.getChildSeqs(p);
+  }
+  size(): number {
+    return this.inner.size();
+  }
+}
+
+describe("dual-write safety rules", () => {
+  let dir: string;
+  let mirrors: SqliteRunRepository[];
+  let divergences: Divergence[];
+  let failures: MirrorFailure[];
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "dualwrite-"));
+    mirrors = [];
+    divergences = [];
+    failures = [];
+  });
+  afterEach(() => {
+    for (const m of mirrors) m.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const sqliteMirror = () => {
+    const m = new SqliteRunRepository({ dir: path.join(dir, "mirror") });
+    mirrors.push(m);
+    return m;
+  };
+
+  const build = (mirror: RunRepository) =>
+    new DualWriteRunRepository(JsonlRunRepository.open({ dir }), mirror, {
+      onDivergence: (d) => divergences.push(d),
+      onMirrorFailure: (f) => failures.push(f),
+    });
+
+  const runOnce = (repo: RunRepository, taskId: string) => {
+    const seq = repo.startRun({
+      taskId,
+      recipeName: "demo",
+      trigger: "cron",
+      createdAt: 1_000,
+    });
+    repo.completeRun(seq, {
+      status: "done",
+      doneAt: 2_000,
+      durationMs: 1_000,
+      stepResults: [],
+    });
+    return seq;
+  };
+
+  /** Rule 1. The whole point of a migration aid is that it cannot cause the
+   *  outage it is meant to de-risk. */
+  it("a totally broken mirror does not break anything", () => {
+    const repo = build(brokenMirror());
+
+    expect(() => runOnce(repo, "t-1")).not.toThrow();
+
+    // The primary is untouched and still authoritative.
+    expect(repo.query({ limit: 10 }).map((r) => r.taskId)).toEqual(["t-1"]);
+    expect(repo.size()).toBe(1);
+    // ...and the breakage was REPORTED, not swallowed into silence. A mirror
+    // that fails quietly would look identical to one that agrees.
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures[0]?.message).toBe("mirror down");
+  });
+
+  /** Rule 2. Reads come from the primary even when the mirror answers. */
+  it("reads always return the primary's answer", () => {
+    const repo = build(new LyingMirror(sqliteMirror()));
+    const seq = runOnce(repo, "t-2");
+
+    // The mirror recorded "interrupted"; the caller must still see the truth.
+    expect(repo.getBySeq(seq)?.status).toBe("done");
+    expect(repo.query({ limit: 10 })[0]?.status).toBe("done");
+  });
+
+  /** ...and the lie is not silently tolerated. */
+  it("a mirror that records the wrong outcome is reported (#1341 shape)", () => {
+    const repo = build(new LyingMirror(sqliteMirror()));
+    const seq = runOnce(repo, "t-3");
+    repo.getBySeq(seq);
+
+    const statuses = divergences.filter((d) => d.detail.startsWith("status:"));
+    expect(statuses.length).toBeGreaterThan(0);
+    expect(statuses[0]?.detail).toContain("primary=done");
+    expect(statuses[0]?.detail).toContain("mirror=interrupted");
+  });
+
+  it("a run missing from the mirror is reported", () => {
+    const mirror = sqliteMirror();
+    const repo = build(mirror);
+    runOnce(repo, "t-present");
+
+    // Write straight to the primary, bypassing the mirror — the shape of a
+    // dropped mirror write.
+    const primaryOnly = JsonlRunRepository.open({ dir });
+    runOnce(primaryOnly, "t-missing");
+
+    repo.query({ limit: 10 });
+    expect(divergences.some((d) => d.detail.includes("row count"))).toBe(true);
+  });
+
+  /** Agreement must be silent. A comparison that always fires tells you
+   *  nothing — the signal has to mean something when it appears. */
+  it("agreeing stores produce no divergences at all", () => {
+    const repo = build(sqliteMirror());
+    for (let i = 0; i < 5; i++) runOnce(repo, `t-agree-${i}`);
+
+    repo.query({ limit: 50 });
+    repo.query({ recipe: "demo" });
+    repo.getBySeq(1);
+    repo.size();
+    repo.getChildSeqs(1);
+
+    expect(divergences, JSON.stringify(divergences)).toEqual([]);
+    expect(failures, JSON.stringify(failures)).toEqual([]);
+  });
+
+  /** A reporting callback that throws must not become the outage the mirror
+   *  was forbidden from causing. */
+  it("a throwing callback cannot take the caller down", () => {
+    const repo = new DualWriteRunRepository(
+      JsonlRunRepository.open({ dir }),
+      new LyingMirror(sqliteMirror()),
+      {
+        onDivergence: () => {
+          throw new Error("callback exploded");
+        },
+        onMirrorFailure: () => {
+          throw new Error("callback exploded");
+        },
+      },
+    );
+    const seq = runOnce(repo, "t-cb");
+    expect(() => repo.getBySeq(seq)).not.toThrow();
+    expect(repo.getBySeq(seq)?.status).toBe("done");
+  });
+
+  it("compareReads:false keeps mirroring but stops comparing", () => {
+    const repo = new DualWriteRunRepository(
+      JsonlRunRepository.open({ dir }),
+      new LyingMirror(sqliteMirror()),
+      {
+        compareReads: false,
+        onDivergence: (d) => divergences.push(d),
+      },
+    );
+    const seq = runOnce(repo, "t-quiet");
+    repo.getBySeq(seq);
+    repo.query({ limit: 10 });
+
+    expect(divergences).toEqual([]);
+    // The mirror is still being populated — this is a volume control, not an
+    // off switch, so the data is present when the flip comes.
+    expect(mirrors[0]?.size()).toBe(1);
+  });
+});

--- a/src/runStore/dualWriteRunRepository.ts
+++ b/src/runStore/dualWriteRunRepository.ts
@@ -1,0 +1,275 @@
+/**
+ * Dual-write with shadow reads — ADR-0022 step 1 of the migration.
+ *
+ * The primary (JSONL) stays the source of truth and answers every read. The
+ * mirror (SQLite) receives every write and is read only to be COMPARED. When
+ * the two disagree, that is reported; it never changes the answer.
+ *
+ * ## Why not just cut over
+ *
+ * The migration's safety argument is "the new store behaves like the one we
+ * already trust". A test suite can only check that against cases someone
+ * thought to write. This checks it against YOUR ACTUAL TRAFFIC, in production,
+ * while the store being replaced is still authoritative — including through
+ * the first rotation, which on this installation has never once executed
+ * (`runs.jsonl.1` has never been written) and is the moment the old store is
+ * most likely to lose something.
+ *
+ * ## Two rules that make this safe
+ *
+ * 1. **The mirror can never break the primary.** Every mirror call is wrapped;
+ *    a failure is reported and swallowed. A migration aid that can take down
+ *    the system it is de-risking is worse than no migration aid.
+ *
+ * 2. **The mirror can never change an answer.** Reads return the primary's
+ *    result, always, even when the mirror looks more correct. The moment
+ *    divergence could alter behaviour, this stops being an observation and
+ *    becomes an untested cutover.
+ *
+ * The point at which those rules relax is the flip, and the flip has an
+ * explicit gate: #1324, #1340 and rotation loss replayed against both stores,
+ * with JSONL visibly LOSING all three (ADR-0022 §4).
+ */
+
+import type { RecipeRun, RunQuery, RunStepResult } from "../runLog.js";
+import type {
+  CompleteRunInput,
+  RunRepository,
+  StartRunInput,
+} from "./runRepository.js";
+
+/** One observed disagreement between the two stores. */
+export interface Divergence {
+  /** Which read surfaced it. */
+  operation: "query" | "getBySeq" | "getChildSeqs" | "size";
+  /** Machine-usable summary — what differed, in one short phrase. */
+  detail: string;
+  /** The run the disagreement concerns, when it concerns one. */
+  taskId?: string;
+}
+
+/** One mirror-side failure. Reported, never thrown. */
+export interface MirrorFailure {
+  operation: string;
+  message: string;
+}
+
+export interface DualWriteOptions {
+  /** Called for every observed disagreement. Must not throw. */
+  onDivergence?: (d: Divergence) => void;
+  /** Called when a mirror operation fails. Must not throw. */
+  onMirrorFailure?: (f: MirrorFailure) => void;
+  /**
+   * Compare reads. Default true. Turning it off keeps the mirror populated
+   * without paying the comparison cost — useful once agreement is
+   * established and you only want the data present for the flip.
+   */
+  compareReads?: boolean;
+}
+
+/**
+ * Fields compared between stores.
+ *
+ * Deliberately explicit rather than a deep-equal over the whole record. A
+ * blanket comparison would flag differences that carry no meaning — key order,
+ * an absent optional versus an explicit `undefined` — and a report full of
+ * those is one nobody reads. Every field here is one whose disagreement would
+ * mean the stores genuinely remember different things.
+ */
+const COMPARED = [
+  "taskId",
+  "seq",
+  "recipeName",
+  "trigger",
+  "status",
+  "createdAt",
+  "doneAt",
+  "durationMs",
+  "errorMessage",
+  "parentSeq",
+  "manualRunId",
+  "hadStepErrors",
+] as const;
+
+function stepIds(steps: RunStepResult[] | undefined): string {
+  return (steps ?? [])
+    .map((s) => s?.id)
+    .filter(Boolean)
+    .join(",");
+}
+
+/** Differences between one run as each store remembers it. Empty ⇒ agreement. */
+export function diffRun(primary: RecipeRun, mirror: RecipeRun): string[] {
+  const out: string[] = [];
+  for (const k of COMPARED) {
+    const a = primary[k as keyof RecipeRun];
+    const b = mirror[k as keyof RecipeRun];
+    // `undefined` and absent mean the same thing to every reader of this data,
+    // so treat them as equal rather than manufacturing a difference.
+    if ((a ?? undefined) !== (b ?? undefined)) {
+      out.push(`${k}: primary=${String(a)} mirror=${String(b)}`);
+    }
+  }
+  const pa = stepIds(primary.stepResults);
+  const pb = stepIds(mirror.stepResults);
+  if (pa !== pb) out.push(`stepResults: primary=[${pa}] mirror=[${pb}]`);
+  return out;
+}
+
+export class DualWriteRunRepository implements RunRepository {
+  constructor(
+    private readonly primary: RunRepository,
+    private readonly mirror: RunRepository,
+    private readonly opts: DualWriteOptions = {},
+  ) {}
+
+  /** Run a mirror operation. Never throws; a failure is reported and dropped. */
+  private safely<T>(operation: string, fn: () => T): T | undefined {
+    try {
+      return fn();
+    } catch (err) {
+      try {
+        this.opts.onMirrorFailure?.({
+          operation,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } catch {
+        // A reporting callback that throws must not become the outage the
+        // mirror was forbidden from causing.
+      }
+      return undefined;
+    }
+  }
+
+  private report(d: Divergence): void {
+    try {
+      this.opts.onDivergence?.(d);
+    } catch {
+      // Same reasoning as above.
+    }
+  }
+
+  private get comparing(): boolean {
+    return this.opts.compareReads !== false;
+  }
+
+  startRun(input: StartRunInput): number {
+    const seq = this.primary.startRun(input);
+    // Mirror adopts the primary's seq — see StartRunInput.seq. Without this
+    // every mirrored row differs on `seq` and the comparison is all noise.
+    this.safely("startRun", () => this.mirror.startRun({ ...input, seq }));
+    return seq;
+  }
+
+  updateRunSteps(seq: number, stepResults: RunStepResult[]): void {
+    this.primary.updateRunSteps(seq, stepResults);
+    this.safely("updateRunSteps", () =>
+      this.mirror.updateRunSteps(seq, stepResults),
+    );
+  }
+
+  completeRun(seq: number, input: CompleteRunInput): void {
+    this.primary.completeRun(seq, input);
+    this.safely("completeRun", () => this.mirror.completeRun(seq, input));
+  }
+
+  query(q: RunQuery = {}): RecipeRun[] {
+    const primary = this.primary.query(q);
+    if (!this.comparing) return primary;
+
+    const mirror = this.safely("query", () => this.mirror.query(q));
+    if (mirror === undefined) return primary;
+
+    if (primary.length !== mirror.length) {
+      this.report({
+        operation: "query",
+        detail: `row count: primary=${primary.length} mirror=${mirror.length}`,
+      });
+      return primary;
+    }
+    // Compare by taskId rather than by position: a pure ORDER difference is
+    // worth knowing about, but it must not masquerade as every row differing.
+    const byId = new Map(mirror.map((r) => [r.taskId, r]));
+    for (const p of primary) {
+      const m = byId.get(p.taskId);
+      if (!m) {
+        this.report({
+          operation: "query",
+          taskId: p.taskId,
+          detail: "present in primary, absent from mirror",
+        });
+        continue;
+      }
+      for (const d of diffRun(p, m)) {
+        this.report({ operation: "query", taskId: p.taskId, detail: d });
+      }
+    }
+    const orderPrimary = primary.map((r) => r.taskId).join(",");
+    const orderMirror = mirror.map((r) => r.taskId).join(",");
+    if (orderPrimary !== orderMirror) {
+      this.report({
+        operation: "query",
+        detail: "same rows, different order",
+      });
+    }
+    return primary;
+  }
+
+  getBySeq(seq: number): RecipeRun | null {
+    const primary = this.primary.getBySeq(seq);
+    if (!this.comparing) return primary;
+
+    const mirror = this.safely("getBySeq", () => this.mirror.getBySeq(seq));
+    if (mirror === undefined) return primary;
+
+    if (primary && mirror) {
+      for (const d of diffRun(primary, mirror)) {
+        this.report({
+          operation: "getBySeq",
+          taskId: primary.taskId,
+          detail: d,
+        });
+      }
+    } else if (primary !== mirror) {
+      this.report({
+        operation: "getBySeq",
+        detail: `presence: primary=${primary ? "found" : "null"} mirror=${mirror ? "found" : "null"}`,
+      });
+    }
+    return primary;
+  }
+
+  getChildSeqs(parentSeq: number): number[] {
+    const primary = this.primary.getChildSeqs(parentSeq);
+    if (!this.comparing) return primary;
+
+    const mirror = this.safely("getChildSeqs", () =>
+      this.mirror.getChildSeqs(parentSeq),
+    );
+    if (mirror === undefined) return primary;
+
+    const a = [...primary].sort((x, y) => x - y).join(",");
+    const b = [...mirror].sort((x, y) => x - y).join(",");
+    if (a !== b) {
+      this.report({
+        operation: "getChildSeqs",
+        detail: `children of ${parentSeq}: primary=[${a}] mirror=[${b}]`,
+      });
+    }
+    return primary;
+  }
+
+  size(): number {
+    const primary = this.primary.size();
+    if (!this.comparing) return primary;
+
+    const mirror = this.safely("size", () => this.mirror.size());
+    if (mirror !== undefined && mirror !== primary) {
+      this.report({
+        operation: "size",
+        detail: `primary=${primary} mirror=${mirror}`,
+      });
+    }
+    return primary;
+  }
+}

--- a/src/runStore/runRepository.ts
+++ b/src/runStore/runRepository.ts
@@ -47,6 +47,21 @@ export interface StartRunInput {
   manualRunId?: string;
   /** Test seam — defaults to this process. See `RecipeRun.ownerPid`. */
   ownerPid?: number;
+  /**
+   * Adopt this `seq` instead of minting one. MIRRORING ONLY.
+   *
+   * Exists because dual-write is otherwise unusable: both stores mint their
+   * own per-instance counter, so a mirrored run would carry a different `seq`
+   * in each store, on every row. Comparison would then report a difference
+   * every single time — and a divergence signal that always fires is
+   * indistinguishable from one that never does. The noise would hide exactly
+   * the real disagreement the comparison exists to catch.
+   *
+   * Ordinary callers must not pass this. It is not a way to choose an id: the
+   * value is meaningless outside the process that minted it (#1324), which is
+   * precisely why `task_id` is the real identity.
+   */
+  seq?: number;
 }
 
 /** Arguments to {@link RunRepository.completeRun}. Mirrors `RecipeRunLog.completeRun`. */

--- a/src/runStore/sqliteRunRepository.ts
+++ b/src/runStore/sqliteRunRepository.ts
@@ -272,7 +272,12 @@ export class SqliteRunRepository implements RunRepository {
   }
 
   startRun(input: StartRunInput): number {
-    const seq = ++this.seq;
+    // Adopt a mirrored seq when given one, so a dual-write pair agrees on
+    // every field instead of disagreeing on this one in every row. The
+    // counter still advances past it, so a later locally-minted seq cannot
+    // collide with one already adopted.
+    const seq = input.seq ?? ++this.seq;
+    if (input.seq !== undefined && input.seq > this.seq) this.seq = input.seq;
     this.db
       .prepare(
         `INSERT INTO runs (task_id, seq, recipe_name, trigger, status, created_at,


### PR DESCRIPTION
Third slice of [ADR-0022](../blob/main/docs/adr/0022-durable-evidence-store.md). **The mechanism only** — nothing in production constructs this yet. Wiring the 8 `RecipeRunLog` construction sites is the next slice, kept separate so this one stays reviewable.

## What it does

JSONL stays the source of truth and answers every read. SQLite receives every write and is read **only to be compared**.

## Two rules that make it safe — both asserted, not just documented

1. **The mirror can never break the primary.** Every mirror call is wrapped; a failure is reported and swallowed. A migration aid that can cause the outage it's de-risking is worse than no migration aid.
2. **The mirror can never change an answer.** Reads return the primary's result *even when the mirror looks more correct*. The moment divergence could alter behaviour, this stops being an observation and becomes an untested cutover.

## Why not just cut over

A test suite only checks cases someone thought to write. This checks the two stores against **real traffic**, while the store being replaced is still authoritative — including through the first rotation, which on this installation has **never executed** (`runs.jsonl.1` has never been written) and is exactly where the old store is most likely to lose something.

## One interface change, and it's load-bearing

`StartRunInput` gains an optional `seq`. Both stores mint their own per-instance counter, so without this a mirrored run carries a *different* `seq` in each store, on every row — and **a divergence signal that always fires is indistinguishable from one that never does.** That noise would hide the real disagreements the comparison exists to catch.

Documented as mirroring-only. It is not a way for callers to choose an id: the value is meaningless outside the process that minted it, which is the whole of #1324.

## Comparison design

An explicit field list, not a deep equal — a blanket compare would flag key order and absent-vs-`undefined`, and a report full of those is one nobody reads. Rows are matched by `taskId`, so a pure **order** difference is reported once rather than masquerading as every row differing.

## Result worth noting

**JSONL and SQLite agree on every contract operation, with zero divergences.** First real evidence the two stores behave identically.

## Verified by mutation

A detector that reports nothing looks exactly like two stores agreeing, so:

| Mutant | Caught by |
|---|---|
| `diffRun` always returns `[]` | the #1341-shape test |
| mirror failures rethrown | the broken-mirror test |

Restored: **53/53** across `runStore`. Full suite: **9653/9653**.

Tests cover: contract transparency (the pair satisfies the same contract as either store alone), a totally broken mirror, a mirror that records the wrong outcome, a run missing from the mirror, agreement being silent, a *throwing callback* not taking the caller down, and `compareReads: false` as a volume control that still populates the mirror.

## Next

Wire it at the 8 construction sites, then watch real traffic. The flip stays gated: #1324, #1340 and rotation loss replayed against both stores, with JSONL visibly losing all three (ADR-0022 §4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
