### PR TITLE
feat(runstore): add appendDirect — the write path the interface was missing

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,19 +29,21 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-13 `feat/runstore-dual-write` — third slice of
-  [ADR-0022](adr/0022-durable-evidence-store.md). The seam + conformance
-  contract landed in #1366; the SQLite store in #1370 (passes the same
-  contract; `task_id` is the PRIMARY KEY, which is #1324 as a schema
-  constraint). This slice wires DUAL-WRITE: JSONL stays the source of truth,
-  every write also goes to SQLite, and a shadow-read comparison reports
-  divergence — through the first rotation, before any flip. Branch reserved,
-  not yet cut. Will touch `src/runLog.ts` and all 8 `RecipeRunLog`
-  construction sites (bridge.ts, index.ts ×3, yamlRunner, chainedRunner ×2,
-  runWorkerShadow) — coordinate before touching the recipe runner or the
-  worker-trust replay path. Gate before the flip: replay #1324 / #1340 /
-  rotation loss against both stores; JSONL must visibly LOSE all three
-  (ADR-0022 §4). — build session
+- 2026-08-14 `feat/runstore-wire-sites` — fifth slice of
+  [ADR-0022](adr/0022-durable-evidence-store.md). Mechanism merged: seam +
+  shared contract (#1366), SQLite store (#1370), dual-write with shadow
+  reads (#1372), and `appendDirect` — the DOMINANT production write path,
+  missing from the first cut of the interface. This slice finally WIRES the
+  8 `RecipeRunLog` construction sites (bridge.ts, index.ts x3, yamlRunner,
+  chainedRunner x2, runWorkerShadow) behind a factory + default-off flag,
+  so a mirror can be switched on without changing behaviour when it is off.
+  Note `record` and `readArchive` are still NOT on the interface (2 call
+  sites each) — decide per site whether to widen the interface or leave
+  that site on `RecipeRunLog` directly. Touches the recipe runner and the
+  worker-trust replay path; coordinate before working in either. Also lands
+  the deferred `ExperimentalWarning` suppression at an entry point. Flip
+  gate unchanged: #1324 / #1340 / rotation loss replayed against both
+  stores, JSONL must visibly LOSE all three (ADR-0022 §4). — build session
 
 Swept 2026-08-08: all 10 distinct entries here were MERGED (#1249, #1255,
 #1256, #1257, #1258, #1259, #1278, #1279, #1280, #1281), several listed twice

--- a/src/runStore/__tests__/dualWriteRunRepository.test.ts
+++ b/src/runStore/__tests__/dualWriteRunRepository.test.ts
@@ -72,6 +72,9 @@ const brokenMirror = (): RunRepository => ({
   completeRun: () => {
     throw new Error("mirror down");
   },
+  appendDirect: () => {
+    throw new Error("mirror down");
+  },
   query: () => {
     throw new Error("mirror down");
   },
@@ -99,6 +102,11 @@ class LyingMirror implements RunRepository {
     // Silently records the wrong outcome: the #1341 shape, where a run that
     // succeeded is remembered as having been interrupted.
     this.inner.completeRun(seq, { ...i, status: "interrupted" });
+  }
+  appendDirect(run: Omit<RecipeRun, "seq">): void {
+    // Lies on this path too, in the same direction: a finished run is
+    // recorded as though it had been interrupted.
+    this.inner.appendDirect({ ...run, status: "interrupted" });
   }
   query(q: RunQuery = {}): RecipeRun[] {
     return this.inner.query(q);
@@ -209,6 +217,54 @@ describe("dual-write safety rules", () => {
 
     repo.query({ limit: 10 });
     expect(divergences.some((d) => d.detail.includes("row count"))).toBe(true);
+  });
+
+  /**
+   * The mirror must actually RECEIVE the dominant write path.
+   *
+   * This test exists because a mutation caught nothing: deleting the mirror's
+   * `appendDirect` call left all 62 conformance cases green. They read through
+   * the primary, so an empty mirror is invisible to them — the exact shape of
+   * failure this migration is meant to prevent, sitting in the migration
+   * tooling itself. Asserted against the mirror DIRECTLY, not via the pair.
+   */
+  it("appendDirect reaches the mirror, not just the primary", () => {
+    const mirror = sqliteMirror();
+    const repo = build(mirror);
+
+    repo.appendDirect({
+      taskId: "t-direct-mirrored",
+      recipeName: "direct",
+      trigger: "cron",
+      status: "done",
+      createdAt: 1_000,
+      doneAt: 2_000,
+      durationMs: 1_000,
+    });
+
+    expect(
+      mirror.query({ limit: 10 }).map((r) => r.taskId),
+      "the mirror must hold the run, or dual-write is not mirroring the path production mostly uses",
+    ).toEqual(["t-direct-mirrored"]);
+  });
+
+  /** ...and the pair must agree about it, with no divergence reported. */
+  it("appendDirect leaves the two stores in agreement", () => {
+    const repo = build(sqliteMirror());
+    for (let i = 0; i < 3; i++) {
+      repo.appendDirect({
+        taskId: `t-direct-agree-${i}`,
+        recipeName: "direct",
+        trigger: "cron",
+        status: "done",
+        createdAt: 1_000 + i,
+        doneAt: 2_000 + i,
+        durationMs: 1_000,
+      });
+    }
+    repo.query({ limit: 50 });
+    repo.size();
+    expect(divergences, JSON.stringify(divergences)).toEqual([]);
   });
 
   /** Agreement must be silent. A comparison that always fires tells you

--- a/src/runStore/__tests__/runRepositoryConformance.ts
+++ b/src/runStore/__tests__/runRepositoryConformance.ts
@@ -237,6 +237,70 @@ export function describeRunRepositoryContract(
       expect(h.repo.getChildSeqs(parent)).toContain(child);
     });
 
+    /**
+     * `appendDirect` is the DOMINANT production write path — the flat and
+     * chained runners and the CLI use it (5 call sites, versus 2 for
+     * `startRun`). The first cut of this interface omitted it entirely, which
+     * would have made dual-write silently miss every run recorded this way
+     * and then report divergence on all of them.
+     */
+    it("appendDirect records a finished run and allocates a seq", () => {
+      h.repo.appendDirect({
+        taskId: "t-direct",
+        recipeName: "direct",
+        trigger: "cron",
+        status: "done",
+        createdAt: 1_000,
+        doneAt: 2_000,
+        durationMs: 1_000,
+        stepResults: [step("d1")],
+      });
+      const run = h.repo
+        .query({ limit: 10 })
+        .find((r) => r.taskId === "t-direct");
+      expect(run?.status).toBe("done");
+      expect(run?.seq, "a seq must be allocated").toBeGreaterThan(0);
+      expect(run?.stepResults?.map((s) => s.id)).toEqual(["d1"]);
+    });
+
+    /** Derived, never trusted from the caller — and by the same rule
+     *  `completeRun` uses, so a run is indistinguishable whichever path
+     *  recorded it. A flat-green "done" that hides a failed step is precisely
+     *  the dishonest state `hadStepErrors` exists to prevent. */
+    it("appendDirect derives hadStepErrors from the steps", () => {
+      h.repo.appendDirect({
+        taskId: "t-direct-err",
+        recipeName: "direct",
+        trigger: "cron",
+        status: "done",
+        createdAt: 1_000,
+        doneAt: 2_000,
+        durationMs: 1_000,
+        stepResults: [step("ok1"), step("bad", "error")],
+      });
+      const run = h.repo
+        .query({ limit: 10 })
+        .find((r) => r.taskId === "t-direct-err");
+      expect(run?.hadStepErrors).toBe(true);
+    });
+
+    it("an appendDirect run is durable to a second instance", () => {
+      h.repo.appendDirect({
+        taskId: "t-direct-durable",
+        recipeName: "direct",
+        trigger: "cron",
+        status: "done",
+        createdAt: 1_000,
+        doneAt: 2_000,
+        durationMs: 1_000,
+      });
+      const seen = h
+        .reopen()
+        .query({ limit: 50 })
+        .find((r) => r.taskId === "t-direct-durable");
+      expect(seen?.status).toBe("done");
+    });
+
     it("getBySeq returns null for an unknown seq", () => {
       expect(h.repo.getBySeq(999_999)).toBeNull();
     });

--- a/src/runStore/dualWriteRunRepository.ts
+++ b/src/runStore/dualWriteRunRepository.ts
@@ -173,6 +173,15 @@ export class DualWriteRunRepository implements RunRepository {
     this.safely("completeRun", () => this.mirror.completeRun(seq, input));
   }
 
+  appendDirect(run: Omit<RecipeRun, "seq">): void {
+    this.primary.appendDirect(run);
+    // No seq to mirror here: each store allocates its own for this path. They
+    // agree because both counters advance in lockstep over the same call
+    // sequence — and if they ever stop agreeing, the comparison says so
+    // instead of the mismatch hiding.
+    this.safely("appendDirect", () => this.mirror.appendDirect(run));
+  }
+
   query(q: RunQuery = {}): RecipeRun[] {
     const primary = this.primary.query(q);
     if (!this.comparing) return primary;

--- a/src/runStore/jsonlRunRepository.ts
+++ b/src/runStore/jsonlRunRepository.ts
@@ -29,7 +29,7 @@ export class JsonlRunRepository implements RunRepository {
 
   /**
    * Escape hatch for callers still reaching for `RecipeRunLog`-only methods
-   * (`record`, `appendDirect`, `readArchive`). Those are deliberately absent
+   * (`record`, `readArchive`). Those are deliberately absent
    * from `RunRepository` — `readArchive` in particular is a JSONL rotation
    * detail with no meaning in a store that does not rotate by bytes.
    *
@@ -49,6 +49,10 @@ export class JsonlRunRepository implements RunRepository {
 
   completeRun(seq: number, input: CompleteRunInput): void {
     this.log.completeRun(seq, input);
+  }
+
+  appendDirect(run: Omit<RecipeRun, "seq">): void {
+    this.log.appendDirect(run);
   }
 
   query(q: RunQuery = {}): RecipeRun[] {

--- a/src/runStore/runRepository.ts
+++ b/src/runStore/runRepository.ts
@@ -104,6 +104,22 @@ export interface RunRepository {
   /** Finish a run. Must be durable before returning. */
   completeRun(seq: number, input: CompleteRunInput): void;
 
+  /**
+   * Record an ALREADY-FINISHED run in one shot, allocating its `seq`.
+   *
+   * This is not a convenience wrapper around start+complete — it is the
+   * dominant production write path, used by the flat and chained runners and
+   * the CLI (5 call sites, versus 2 for `startRun`). Omitting it was a real
+   * design error in the first cut of this interface: dual-write would have
+   * silently missed every run written this way, and then reported divergence
+   * on all of them.
+   *
+   * Implementations must derive `hadStepErrors` from `stepResults` exactly as
+   * `completeRun` does, so a run recorded through this path is
+   * indistinguishable from one recorded through the lifecycle path.
+   */
+  appendDirect(run: Omit<RecipeRun, "seq">): void;
+
   /** Query runs, newest first. */
   query(q?: RunQuery): RecipeRun[];
 

--- a/src/runStore/sqliteRunRepository.ts
+++ b/src/runStore/sqliteRunRepository.ts
@@ -372,6 +372,55 @@ export class SqliteRunRepository implements RunRepository {
       );
   }
 
+  appendDirect(run: Omit<RecipeRun, "seq">): void {
+    const seq = ++this.seq;
+    // Derived here, not trusted from the caller, and by the same rule
+    // `completeRun` uses — a run recorded through this path must be
+    // indistinguishable from one recorded through the lifecycle path.
+    const hadStepErrors = (run.stepResults ?? []).some(
+      (s) => s.status === "error",
+    );
+    const extra: Row = {};
+    for (const k of EXTRA_KEYS) {
+      const v = (run as unknown as Row)[k];
+      if (v !== undefined) extra[k] = v;
+    }
+    this.db
+      .prepare(
+        `INSERT INTO runs (task_id, seq, recipe_name, trigger, status, created_at,
+                           started_at, done_at, duration_ms, model, output_tail,
+                           error_message, parent_seq, manual_run_id, owner_pid,
+                           had_step_errors, step_results, extra)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         ON CONFLICT(task_id) DO UPDATE SET
+           seq=excluded.seq, status=excluded.status, done_at=excluded.done_at,
+           duration_ms=excluded.duration_ms, output_tail=excluded.output_tail,
+           error_message=excluded.error_message,
+           had_step_errors=excluded.had_step_errors,
+           step_results=excluded.step_results, extra=excluded.extra`,
+      )
+      .run(
+        run.taskId,
+        seq,
+        run.recipeName,
+        run.trigger,
+        run.status,
+        run.createdAt,
+        run.startedAt ?? null,
+        run.doneAt ?? null,
+        run.durationMs ?? null,
+        run.model ?? null,
+        run.outputTail ?? null,
+        run.errorMessage ?? null,
+        run.parentSeq ?? null,
+        run.manualRunId ?? null,
+        run.ownerPid ?? null,
+        hadStepErrors ? 1 : 0,
+        run.stepResults ? JSON.stringify(run.stepResults) : null,
+        Object.keys(extra).length > 0 ? JSON.stringify(extra) : null,
+      );
+  }
+
   query(q: RunQuery = {}): RecipeRun[] {
     const where: string[] = [];
     const args: unknown[] = [];


### PR DESCRIPTION
Surveying the 8 construction sites **before** wiring them found that `RunRepository` didn't cover the path production mostly uses.

## The gap

Production call counts:

| method | calls | on the interface? |
|---|---|---|
| `query` | 21 | ✅ |
| **`appendDirect`** | **5** | ❌ **was missing** |
| `completeRun` | 3 | ✅ |
| `record` | 2 | ❌ |
| `readArchive` | 2 | ❌ |
| `startRun` | 2 | ✅ |
| `updateRunSteps` | 1 | ✅ |
| `size` | 0 | ✅ |

The interface had the *lifecycle* API and omitted `appendDirect`, which records an already-finished run in one shot — how the flat runner, the chained runner and the CLI write.

**Had this shipped:** dual-write would have silently missed every run written that way, then reported divergence on all of them.

#1366's PR body called the construction sites "mechanical". That was wrong, and this is the correction.

## The fix

`appendDirect` added to the interface, both stores, and the dual-write pair. In the SQLite implementation `hadStepErrors` is **derived** from `stepResults` by the same rule `completeRun` uses, so a run is indistinguishable whichever path recorded it. Three contract cases now run against all three configurations.

## A mutant escaped — the most useful thing in this PR

Deleting the mirror's `appendDirect` call left **all 62 conformance cases green**. They read through the primary, so an empty mirror is invisible to them.

That is exactly the failure this migration exists to prevent, sitting inside the migration tooling itself. Two tests now assert against the **mirror directly**, and the same mutant is caught by both.

| Mutant | Before | After |
|---|---|---|
| dual-write drops `appendDirect` | 🟢 62/62 (escaped) | 🔴 2 tests fail |
| sqlite `appendDirect` ignores step errors | 🔴 derive case fails | 🔴 derive case fails |

Restored: **64/64**. Full suite: **9664/9664**.

## Still not on the interface

`record` and `readArchive` (2 call sites each) — deliberately. Decide per site during wiring whether to widen the interface or leave that site on `RecipeRunLog` directly.

## Ledger

Repointed at `feat/runstore-wire-sites`, and **corrected**: this slice unblocks the wiring rather than performing it. The entry previously claimed this branch would do the wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
