### PR TITLE
feat(runstore): wire the shadow mirror at the append chokepoint

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,21 +29,23 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-14 `feat/runstore-wire-sites` — fifth slice of
-  [ADR-0022](adr/0022-durable-evidence-store.md). Mechanism merged: seam +
-  shared contract (#1366), SQLite store (#1370), dual-write with shadow
-  reads (#1372), and `appendDirect` — the DOMINANT production write path,
-  missing from the first cut of the interface. This slice finally WIRES the
-  8 `RecipeRunLog` construction sites (bridge.ts, index.ts x3, yamlRunner,
-  chainedRunner x2, runWorkerShadow) behind a factory + default-off flag,
-  so a mirror can be switched on without changing behaviour when it is off.
-  Note `record` and `readArchive` are still NOT on the interface (2 call
-  sites each) — decide per site whether to widen the interface or leave
-  that site on `RecipeRunLog` directly. Touches the recipe runner and the
-  worker-trust replay path; coordinate before working in either. Also lands
-  the deferred `ExperimentalWarning` suppression at an entry point. Flip
-  gate unchanged: #1324 / #1340 / rotation loss replayed against both
-  stores, JSONL must visibly LOSE all three (ADR-0022 §4). — build session
+- 2026-08-14 `feat/runstore-compare-report` — sixth slice of
+  [ADR-0022](adr/0022-durable-evidence-store.md). Merged so far: the seam +
+  shared contract (#1366), the SQLite store (#1370), dual-write with shadow
+  reads (#1372), `appendDirect` (#1373), and the wiring — all 8 sites now
+  build their run log through `createRecipeRunLog`, with the mirror hooked
+  to `RecipeRunLog.append()`, the single chokepoint every row passes
+  through. Default OFF (`PATCHWORK_FLAG_RUNSTORE_MIRROR`).
+  **Known gap this slice closes:** the mirror currently only WRITES.
+  `DualWriteRunRepository` can compare reads but nothing in production uses
+  it, so divergence is not yet observable outside tests — a mirror nobody
+  compares proves nothing. Wants an operator-facing comparison (CLI verb
+  and/or a report) over the two stores. Also still pending: the deferred
+  `ExperimentalWarning` suppression at an entry point, and `record` /
+  `readArchive` remaining off the interface (2 call sites each).
+  Flip gate unchanged and NOT part of this slice: #1324 / #1340 / rotation
+  loss replayed against both stores, JSONL must visibly LOSE all three
+  (ADR-0022 §4). — build session
 
 Swept 2026-08-08: all 10 distinct entries here were MERGED (#1249, #1255,
 #1256, #1257, #1258, #1259, #1278, #1279, #1280, #1281), several listed twice

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -66,7 +66,8 @@ import {
 import { warnAboutLegacyPermissionsSidecars } from "./recipes/migrationWarnings.js";
 import { RecipeOrchestrator } from "./recipes/RecipeOrchestrator.js";
 import { evaluateInProcessGate } from "./riskSignals.js";
-import { RecipeRunLog } from "./runLog.js";
+import type { RecipeRunLog } from "./runLog.js";
+import { createRecipeRunLog } from "./runStore/createRunLog.js";
 import { Server } from "./server.js";
 import { type CheckpointData, SessionCheckpoint } from "./sessionCheckpoint.js";
 import { buildSessionDetail } from "./sessionDetail.js";
@@ -1272,7 +1273,7 @@ export class Bridge {
       );
       if (driver) {
         // Recipe run-history needs the orchestrator to produce anything.
-        this.recipeRunLog = new RecipeRunLog({
+        this.recipeRunLog = createRecipeRunLog({
           dir: patchworkDir,
           logger: this.logger,
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1643,8 +1643,10 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
 
       // Append to run log so CLI runs appear in ctxQueryTraces + dashboard /runs
       try {
-        const { RecipeRunLog } = await import("./runLog.js");
-        const runLog = new RecipeRunLog({
+        const { createRecipeRunLog } = await import(
+          "./runStore/createRunLog.js"
+        );
+        const runLog = createRecipeRunLog({
           dir: path.join(os.homedir(), ".patchwork"),
         });
         const startedAt = Date.now();
@@ -1773,7 +1775,7 @@ if (process.argv[2] === "suggest") {
       }
 
       const { ActivityLog } = await import("./activityLog.js");
-      const { RecipeRunLog } = await import("./runLog.js");
+      const { createRecipeRunLog } = await import("./runStore/createRunLog.js");
       const { computeAutomationSuggestions } = await import(
         "./automationSuggestions.js"
       );
@@ -1803,7 +1805,7 @@ if (process.argv[2] === "suggest") {
         // suggestions just return fewer / no items.
       }
 
-      const recipeRunLog = new RecipeRunLog({ dir: patchworkDir });
+      const recipeRunLog = createRecipeRunLog({ dir: patchworkDir });
 
       const opts: Parameters<typeof computeAutomationSuggestions>[0] = {
         activityLog,
@@ -3724,8 +3726,10 @@ if (process.argv[2] === "recipe" && process.argv[3] === "watch") {
 
           // Append to run log
           try {
-            const { RecipeRunLog } = await import("./runLog.js");
-            const runLog = new RecipeRunLog({
+            const { createRecipeRunLog } = await import(
+              "./runStore/createRunLog.js"
+            );
+            const runLog = createRecipeRunLog({
               dir: path.join(os.homedir(), ".patchwork"),
             });
             const now = Date.now();

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -1283,8 +1283,10 @@ export async function runChainedRecipe(
             errorMessage: fatalGraphError,
           });
         } else if (options.runLogDir) {
-          const { RecipeRunLog } = await import("../runLog.js");
-          const log = new RecipeRunLog({ dir: options.runLogDir });
+          const { createRecipeRunLog } = await import(
+            "../runStore/createRunLog.js"
+          );
+          const log = createRecipeRunLog({ dir: options.runLogDir });
           log.appendDirect({
             taskId: runTaskId,
             recipeName: recipe.name,
@@ -1754,8 +1756,10 @@ export async function runChainedRecipe(
           }
         }
       } else if (options.runLogDir) {
-        const { RecipeRunLog } = await import("../runLog.js");
-        const log = new RecipeRunLog({ dir: options.runLogDir });
+        const { createRecipeRunLog } = await import(
+          "../runStore/createRunLog.js"
+        );
+        const log = createRecipeRunLog({ dir: options.runLogDir });
         log.appendDirect({
           taskId: runTaskId,
           recipeName: recipe.name,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -2855,11 +2855,13 @@ export async function runYamlRecipe(
           ts: doneAt,
         });
       } else {
-        const { RecipeRunLog } = await import("../runLog.js");
+        const { createRecipeRunLog } = await import(
+          "../runStore/createRunLog.js"
+        );
         const { homedir } = await import("node:os");
         const resolvedLogDir =
           deps.logDir ?? path.join(homedir(), ".patchwork");
-        const log = new RecipeRunLog({ dir: resolvedLogDir });
+        const log = createRecipeRunLog({ dir: resolvedLogDir });
         log.appendDirect({
           taskId: `yaml:${recipe.name}:${recipeStartedAt}`,
           recipeName: recipe.name,

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -322,6 +322,16 @@ export interface RunLogOptions {
   mirror?: (run: RecipeRun) => void;
   /** Called when the mirror throws. Must not throw. */
   onMirrorFailure?: (message: string) => void;
+  /**
+   * Release whatever the mirror holds. Invoked by `close()`.
+   *
+   * Exists because a factory that OPENS a resource must give callers a way to
+   * release it. Without this the mirror's file handle was unreachable — the
+   * caller only ever receives a `RecipeRunLog`. On POSIX that is merely untidy;
+   * on Windows an open handle cannot be unlinked, so the directory could not
+   * be removed at all.
+   */
+  onClose?: () => void;
 }
 
 export interface RunQuery {
@@ -354,6 +364,7 @@ export class RecipeRunLog {
    *  `updateRunSteps` (which receives the FULL step list each call) from
    *  re-appending every prior step on every step completion. */
   private readonly persistedStepIds = new Map<number, Set<string>>();
+  private closed = false;
   private readonly now: () => number;
 
   constructor(private readonly opts: RunLogOptions) {
@@ -794,6 +805,26 @@ export class RecipeRunLog {
     } catch (err) {
       this.opts.logger?.warn?.(
         `[runlog] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Release resources held on behalf of this run log — today, the ADR-0022
+   * mirror's database handle. Idempotent and never throws: callers close from
+   * teardown and shutdown paths, and a cleanup that can itself fail just turns
+   * one problem into two.
+   *
+   * The run log itself needs no closing; `runs.jsonl` is opened per write.
+   */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.opts.onClose?.();
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[runlog] close failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -303,6 +303,25 @@ export interface RunLogOptions {
   memoryCap?: number;
   /** Test hook — default Date.now. */
   now?: () => number;
+  /**
+   * ADR-0022 migration mirror. Receives every row that reaches disk, AFTER
+   * the authoritative write succeeds.
+   *
+   * Hooked to `append()` rather than to the public write methods on purpose:
+   * `append` is the single chokepoint every row passes through (`record`,
+   * `appendDirect`, `startRun`, `completeRun`, and the interrupted-sweep all
+   * funnel into it), so no writer can be missed — including one added later.
+   * A missed writer would leave the mirror permanently short of rows and
+   * produce divergence reports that are true but meaningless, which is the
+   * fastest way to make people stop reading them.
+   *
+   * Never allowed to affect the authoritative write: failures are reported
+   * and swallowed. Absent by default, so the run log behaves exactly as
+   * before unless something opts in.
+   */
+  mirror?: (run: RecipeRun) => void;
+  /** Called when the mirror throws. Must not throw. */
+  onMirrorFailure?: (message: string) => void;
 }
 
 export interface RunQuery {
@@ -766,11 +785,35 @@ export class RecipeRunLog {
           if (code !== "ENOENT") throw err;
         }
         appendFileSync(this.file, `${JSON.stringify(run)}\n`, { mode: 0o600 });
+        // Mirror only after the authoritative write has succeeded. Mirroring
+        // first would let a row exist in the copy that never reached the
+        // source of truth — divergence manufactured by the tool meant to
+        // measure it.
+        this.mirrorRow(run);
       });
     } catch (err) {
       this.opts.logger?.warn?.(
         `[runlog] append failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+    }
+  }
+
+  /** Hand one durable row to the migration mirror. Never throws — the mirror
+   *  is an observer and must not become a way for the run log to fail. */
+  private mirrorRow(run: RecipeRun): void {
+    const mirror = this.opts.mirror;
+    if (!mirror) return;
+    try {
+      mirror(run);
+    } catch (err) {
+      try {
+        this.opts.onMirrorFailure?.(
+          err instanceof Error ? err.message : String(err),
+        );
+      } catch {
+        // A reporting callback that throws must not become the failure the
+        // mirror was forbidden from causing.
+      }
     }
   }
 

--- a/src/runStore/__tests__/createRunLog.test.ts
+++ b/src/runStore/__tests__/createRunLog.test.ts
@@ -19,6 +19,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RecipeRunLog } from "../../runLog.js";
 import {
   createRecipeRunLog,
   mirrorEnabled,
@@ -32,15 +33,29 @@ const OFF = {} as NodeJS.ProcessEnv;
 describe("run-log mirror wiring", () => {
   let dir: string;
   let readers: SqliteRunRepository[];
+  let logs: RecipeRunLog[];
 
   beforeEach(() => {
     dir = mkdtempSync(path.join(tmpdir(), "wire-mirror-"));
     readers = [];
+    logs = [];
   });
   afterEach(() => {
+    // Close the run logs too, not just the readers: with the mirror on, the
+    // run log owns a database handle. Leaving it open makes `rmSync` throw
+    // EBUSY on Windows while POSIX deletes the open file silently — the leak
+    // is invisible on macOS and fails the whole file on windows-latest.
+    for (const l of logs) l.close();
     for (const r of readers) r.close();
     rmSync(dir, { recursive: true, force: true });
   });
+
+  /** Build a run log and track it for teardown. */
+  const makeLog = (env: NodeJS.ProcessEnv, extra: object = {}) => {
+    const l = createRecipeRunLog({ dir, env, ...extra });
+    logs.push(l);
+    return l;
+  };
 
   const mirrorDir = () => path.join(dir, "runstore-mirror");
   const readMirror = () => {
@@ -78,7 +93,7 @@ describe("run-log mirror wiring", () => {
 
   describe("off (the default)", () => {
     it("creates no mirror and behaves as before", () => {
-      const log = createRecipeRunLog({ dir, env: OFF });
+      const log = makeLog(OFF);
       log.appendDirect(finishedRun("t-off"));
 
       expect(existsSync(mirrorDir()), "no mirror directory").toBe(false);
@@ -94,7 +109,7 @@ describe("run-log mirror wiring", () => {
      * all three funnel through `append()`.
      */
     it("mirrors every write path", () => {
-      const log = createRecipeRunLog({ dir, env: ON });
+      const log = makeLog(ON);
 
       // 1. appendDirect — the dominant production path.
       log.appendDirect(finishedRun("t-direct"));
@@ -130,7 +145,7 @@ describe("run-log mirror wiring", () => {
     });
 
     it("mirrors rows identically, including seq", () => {
-      const log = createRecipeRunLog({ dir, env: ON });
+      const log = makeLog(ON);
       log.appendDirect(finishedRun("t-same"));
 
       const primary = log.query({ limit: 10 })[0];
@@ -146,7 +161,7 @@ describe("run-log mirror wiring", () => {
      *  JSONL readers take the last; the mirror upserts. Both must end up
      *  saying the same thing, or every long-running run reports divergence. */
     it("a run that starts then finishes ends up terminal, not duplicated", () => {
-      const log = createRecipeRunLog({ dir, env: ON });
+      const log = makeLog(ON);
       const seq = log.startRun({
         taskId: "t-twice",
         recipeName: "demo",
@@ -165,6 +180,47 @@ describe("run-log mirror wiring", () => {
       expect(rows[0]?.status).toBe("done");
     });
 
+    /**
+     * That `close()` genuinely RELEASES the handle, observable on every
+     * platform.
+     *
+     * Written because deleting the factory's disposer was caught only by
+     * Windows (EBUSY on teardown) and passed 7/7 on POSIX. A leak that one
+     * platform reports and the others ignore is one most people never see.
+     * Here the released handle is proved by USING it: once closed, the next
+     * write can no longer reach the mirror and says so.
+     */
+    it("close() releases the mirror handle, not just the reference", () => {
+      const warnings: string[] = [];
+      const log = makeLog(ON, {
+        logger: { warn: (m: string) => warnings.push(m) } as never,
+      });
+      log.appendDirect(finishedRun("t-before-close"));
+      expect(warnings.filter((w) => w.includes("write failed"))).toEqual([]);
+
+      log.close();
+
+      // The row still lands in the authoritative store...
+      log.appendDirect(finishedRun("t-after-close"));
+      expect(log.query({ limit: 10 }).map((r) => r.taskId)).toContain(
+        "t-after-close",
+      );
+      // ...and the mirror is genuinely gone, reported rather than silent.
+      expect(
+        warnings.some((w) => w.includes("shadow mirror write failed")),
+        `expected a mirror-write failure after close; saw ${JSON.stringify(warnings)}`,
+      ).toBe(true);
+    });
+
+    it("close() is idempotent", () => {
+      const log = makeLog(ON);
+      log.appendDirect(finishedRun("t-idem"));
+      expect(() => {
+        log.close();
+        log.close();
+      }).not.toThrow();
+    });
+
     /** Fail-soft, same rule as the mirror itself: an OBSERVER that cannot
      *  start must not take down the store it is observing. */
     it("an unopenable mirror leaves a working run log", () => {
@@ -176,9 +232,7 @@ describe("run-log mirror wiring", () => {
       expect(existsSync(mirrorDir())).toBe(true);
 
       const warnings: string[] = [];
-      const log = createRecipeRunLog({
-        dir,
-        env: ON,
+      const log = makeLog(ON, {
         logger: { warn: (m: string) => warnings.push(m) } as never,
       });
 

--- a/src/runStore/__tests__/createRunLog.test.ts
+++ b/src/runStore/__tests__/createRunLog.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Wiring the ADR-0022 shadow mirror.
+ *
+ * Two things need proving here, and only one of them is about the flag.
+ *
+ * 1. OFF BY DEFAULT means *nothing changes* — no mirror directory, no
+ *    behaviour difference. A migration that alters the system before anyone
+ *    opts in is not a migration, it is a change.
+ *
+ * 2. ON means EVERY write path reaches the mirror. The mirror hangs off
+ *    `append()` because that is the single chokepoint all five writers funnel
+ *    through, and the value of that claim is exactly the value of the test
+ *    that checks it: a writer missed by the mirror leaves it permanently
+ *    short of rows, producing divergence reports that are true, meaningless,
+ *    and quickly ignored.
+ */
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createRecipeRunLog,
+  mirrorEnabled,
+  RUNSTORE_MIRROR_FLAG,
+} from "../createRunLog.js";
+import { SqliteRunRepository } from "../sqliteRunRepository.js";
+
+const ON = { [RUNSTORE_MIRROR_FLAG]: "1" } as NodeJS.ProcessEnv;
+const OFF = {} as NodeJS.ProcessEnv;
+
+describe("run-log mirror wiring", () => {
+  let dir: string;
+  let readers: SqliteRunRepository[];
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "wire-mirror-"));
+    readers = [];
+  });
+  afterEach(() => {
+    for (const r of readers) r.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const mirrorDir = () => path.join(dir, "runstore-mirror");
+  const readMirror = () => {
+    const r = new SqliteRunRepository({ dir: mirrorDir() });
+    readers.push(r);
+    return r;
+  };
+
+  const finishedRun = (taskId: string) => ({
+    taskId,
+    recipeName: "demo",
+    trigger: "cron" as const,
+    status: "done" as const,
+    createdAt: 1_000,
+    doneAt: 2_000,
+    durationMs: 1_000,
+  });
+
+  describe("the flag itself", () => {
+    it("is off unless explicitly enabled", () => {
+      expect(mirrorEnabled({})).toBe(false);
+      expect(mirrorEnabled({ [RUNSTORE_MIRROR_FLAG]: "1" })).toBe(true);
+      expect(mirrorEnabled({ [RUNSTORE_MIRROR_FLAG]: "true" })).toBe(true);
+    });
+
+    /** An ambiguous value on a TRUST LEDGER must resolve to the behaviour we
+     *  already trust, not to the new thing. "false" enabling a mirror would be
+     *  a genuinely nasty surprise. */
+    it("treats anything unrecognised as off", () => {
+      for (const v of ["0", "false", "no", "", "off", "TRUE ", "yep"]) {
+        expect(mirrorEnabled({ [RUNSTORE_MIRROR_FLAG]: v }), v).toBe(false);
+      }
+    });
+  });
+
+  describe("off (the default)", () => {
+    it("creates no mirror and behaves as before", () => {
+      const log = createRecipeRunLog({ dir, env: OFF });
+      log.appendDirect(finishedRun("t-off"));
+
+      expect(existsSync(mirrorDir()), "no mirror directory").toBe(false);
+      expect(log.query({ limit: 10 }).map((r) => r.taskId)).toEqual(["t-off"]);
+    });
+  });
+
+  describe("on", () => {
+    /**
+     * The chokepoint claim, checked against every writer rather than asserted.
+     * `appendDirect`, `record` and `startRun`/`completeRun` are three
+     * different public entry points; all three must land in the mirror because
+     * all three funnel through `append()`.
+     */
+    it("mirrors every write path", () => {
+      const log = createRecipeRunLog({ dir, env: ON });
+
+      // 1. appendDirect — the dominant production path.
+      log.appendDirect(finishedRun("t-direct"));
+
+      // 2. record — the bridge's task-completion path.
+      log.record({
+        id: "t-record",
+        triggerSource: "recipe:demo",
+        status: "done",
+        createdAt: 1_000,
+        doneAt: 2_000,
+      });
+
+      // 3. startRun + completeRun — the lifecycle path.
+      const seq = log.startRun({
+        taskId: "t-lifecycle",
+        recipeName: "demo",
+        trigger: "cron",
+        createdAt: 1_000,
+      });
+      log.completeRun(seq, {
+        status: "done",
+        doneAt: 2_000,
+        durationMs: 1_000,
+        stepResults: [],
+      });
+
+      const mirrored = readMirror()
+        .query({ limit: 50 })
+        .map((r) => r.taskId)
+        .sort();
+      expect(mirrored).toEqual(["t-direct", "t-lifecycle", "t-record"]);
+    });
+
+    it("mirrors rows identically, including seq", () => {
+      const log = createRecipeRunLog({ dir, env: ON });
+      log.appendDirect(finishedRun("t-same"));
+
+      const primary = log.query({ limit: 10 })[0];
+      const mirrored = readMirror().query({ limit: 10 })[0];
+
+      expect(mirrored?.seq).toBe(primary?.seq);
+      expect(mirrored?.status).toBe(primary?.status);
+      expect(mirrored?.createdAt).toBe(primary?.createdAt);
+      expect(mirrored?.recipeName).toBe(primary?.recipeName);
+    });
+
+    /** A run that starts and later finishes writes TWO rows for one task.
+     *  JSONL readers take the last; the mirror upserts. Both must end up
+     *  saying the same thing, or every long-running run reports divergence. */
+    it("a run that starts then finishes ends up terminal, not duplicated", () => {
+      const log = createRecipeRunLog({ dir, env: ON });
+      const seq = log.startRun({
+        taskId: "t-twice",
+        recipeName: "demo",
+        trigger: "cron",
+        createdAt: 1_000,
+      });
+      log.completeRun(seq, {
+        status: "done",
+        doneAt: 2_000,
+        durationMs: 1_000,
+        stepResults: [],
+      });
+
+      const rows = readMirror().query({ limit: 10 });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.status).toBe("done");
+    });
+
+    /** Fail-soft, same rule as the mirror itself: an OBSERVER that cannot
+     *  start must not take down the store it is observing. */
+    it("an unopenable mirror leaves a working run log", () => {
+      // Occupy the mirror's directory path with a FILE, so mkdir/open fails.
+      // The first draft of this test only *described* doing that and would
+      // have passed with the mirror opening perfectly — a check that could
+      // not fail.
+      writeFileSync(mirrorDir(), "not a directory");
+      expect(existsSync(mirrorDir())).toBe(true);
+
+      const warnings: string[] = [];
+      const log = createRecipeRunLog({
+        dir,
+        env: ON,
+        logger: { warn: (m: string) => warnings.push(m) } as never,
+      });
+
+      expect(() => log.appendDirect(finishedRun("t-soft"))).not.toThrow();
+      expect(log.query({ limit: 10 }).map((r) => r.taskId)).toEqual(["t-soft"]);
+      // ...and it said so, rather than disabling itself in silence.
+      expect(warnings.some((w) => w.includes("shadow mirror disabled"))).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/src/runStore/createRunLog.ts
+++ b/src/runStore/createRunLog.ts
@@ -75,5 +75,8 @@ export function createRecipeRunLog(opts: CreateRunLogOptions): RecipeRunLog {
     mirror: (run) => mirror.mirrorRow(run),
     onMirrorFailure: (message) =>
       logger?.warn?.(`[runstore] shadow mirror write failed: ${message}`),
+    // The factory opened this handle, so the factory supplies the way to
+    // release it. `RecipeRunLog.close()` is the caller's single lever.
+    onClose: () => mirror.close(),
   });
 }

--- a/src/runStore/createRunLog.ts
+++ b/src/runStore/createRunLog.ts
@@ -1,0 +1,79 @@
+/**
+ * The one place a run log is constructed — ADR-0022 wiring.
+ *
+ * Every `new RecipeRunLog(...)` call site moves here so the migration mirror
+ * is a single decision rather than eight independent ones. Eight sites each
+ * deciding whether to mirror is how a writer gets missed, and a missed writer
+ * leaves the mirror permanently short of rows — producing divergence reports
+ * that are true, meaningless, and quickly ignored.
+ *
+ * ## Default OFF
+ *
+ * With `PATCHWORK_FLAG_RUNSTORE_MIRROR` unset this returns a plain
+ * `RecipeRunLog` with no mirror attached, so behaviour is byte-identical to
+ * before this file existed. That is the whole point of shipping the wiring
+ * separately from the decision to use it.
+ *
+ * ## Failure posture
+ *
+ * If the mirror cannot even be opened — no SQLite, unwritable directory,
+ * corrupt database — this logs and returns the unmirrored run log. The
+ * authoritative store must not become unavailable because an OBSERVER could
+ * not start. Same rule that governs the mirror once it is running.
+ */
+
+import path from "node:path";
+import type { Logger } from "../logger.js";
+import { RecipeRunLog, type RunLogOptions } from "../runLog.js";
+import { SqliteRunRepository } from "./sqliteRunRepository.js";
+
+/** Env flag enabling the ADR-0022 shadow mirror. Off unless explicitly on. */
+export const RUNSTORE_MIRROR_FLAG = "PATCHWORK_FLAG_RUNSTORE_MIRROR";
+
+/** Truthy values accepted for the flag. Anything else — including "false",
+ *  "0" and typos — leaves the mirror off, because the safe reading of an
+ *  ambiguous flag on a trust ledger is "do the thing we already trust". */
+export function mirrorEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env[RUNSTORE_MIRROR_FLAG];
+  return v === "1" || v === "true" || v === "yes";
+}
+
+export interface CreateRunLogOptions extends RunLogOptions {
+  /** Test seam — defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Build a run log, attaching the shadow mirror when the flag is on.
+ *
+ * The mirror lives in a `runstore-mirror/` subdirectory rather than beside
+ * `runs.jsonl`, so nothing that globs the patchwork directory for ledgers
+ * picks up a binary file it cannot parse.
+ */
+export function createRecipeRunLog(opts: CreateRunLogOptions): RecipeRunLog {
+  const { env = process.env, ...runLogOpts } = opts;
+  if (!mirrorEnabled(env)) return new RecipeRunLog(runLogOpts);
+
+  const logger: Logger | undefined = opts.logger;
+  let mirror: SqliteRunRepository;
+  try {
+    mirror = new SqliteRunRepository({
+      dir: path.join(opts.dir, "runstore-mirror"),
+      logger,
+    });
+  } catch (err) {
+    logger?.warn?.(
+      `[runstore] shadow mirror disabled — could not open: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return new RecipeRunLog(runLogOpts);
+  }
+
+  return new RecipeRunLog({
+    ...runLogOpts,
+    mirror: (run) => mirror.mirrorRow(run),
+    onMirrorFailure: (message) =>
+      logger?.warn?.(`[runstore] shadow mirror write failed: ${message}`),
+  });
+}

--- a/src/runStore/sqliteRunRepository.ts
+++ b/src/runStore/sqliteRunRepository.ts
@@ -421,6 +421,64 @@ export class SqliteRunRepository implements RunRepository {
       );
   }
 
+  /**
+   * Upsert one complete row, PRESERVING its `seq`. Migration mirror only.
+   *
+   * Deliberately not on `RunRepository`: ordinary callers must not choose a
+   * `seq`, because the value is meaningless outside the process that minted
+   * it (#1324). This exists so a mirrored row is identical to its source in
+   * every field — a mirror that renumbered rows would report a difference on
+   * every one, and a divergence signal that always fires is indistinguishable
+   * from one that never does.
+   *
+   * Upsert, not insert: the run log appends a "running" row and later a
+   * terminal row for the same task, and JSONL readers take the last. Last
+   * write wins here reproduces that exactly.
+   */
+  mirrorRow(run: RecipeRun): void {
+    if (run.seq > this.seq) this.seq = run.seq;
+    const extra: Row = {};
+    for (const k of EXTRA_KEYS) {
+      const v = (run as unknown as Row)[k];
+      if (v !== undefined) extra[k] = v;
+    }
+    this.db
+      .prepare(
+        `INSERT INTO runs (task_id, seq, recipe_name, trigger, status, created_at,
+                           started_at, done_at, duration_ms, model, output_tail,
+                           error_message, parent_seq, manual_run_id, owner_pid,
+                           had_step_errors, step_results, extra)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         ON CONFLICT(task_id) DO UPDATE SET
+           seq=excluded.seq, status=excluded.status, done_at=excluded.done_at,
+           duration_ms=excluded.duration_ms, output_tail=excluded.output_tail,
+           error_message=excluded.error_message,
+           had_step_errors=excluded.had_step_errors,
+           step_results=excluded.step_results, extra=excluded.extra,
+           started_at=excluded.started_at, owner_pid=excluded.owner_pid`,
+      )
+      .run(
+        run.taskId,
+        run.seq,
+        run.recipeName,
+        run.trigger,
+        run.status,
+        run.createdAt,
+        run.startedAt ?? null,
+        run.doneAt ?? null,
+        run.durationMs ?? null,
+        run.model ?? null,
+        run.outputTail ?? null,
+        run.errorMessage ?? null,
+        run.parentSeq ?? null,
+        run.manualRunId ?? null,
+        run.ownerPid ?? null,
+        run.hadStepErrors ? 1 : 0,
+        run.stepResults ? JSON.stringify(run.stepResults) : null,
+        Object.keys(extra).length > 0 ? JSON.stringify(extra) : null,
+      );
+  }
+
   query(q: RunQuery = {}): RecipeRun[] {
     const where: string[] = [];
     const args: unknown[] = [];

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -2,7 +2,8 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { patchworkHome } from "../patchworkHome.js";
-import { MAX_PERSIST_LINES, RecipeRunLog } from "../runLog.js";
+import { MAX_PERSIST_LINES } from "../runLog.js";
+import { createRecipeRunLog } from "../runStore/createRunLog.js";
 import { classifyActionClass } from "./actionClass.js";
 import { deriveActionKey } from "./actionRef.js";
 import { backtestWorker, formatBacktestReport } from "./backtest.js";
@@ -66,7 +67,7 @@ function readRuns(patchworkDir: string, recipeNames?: string[]): RunRecord[] {
     // after it — even with a per-recipe filter (the filter is applied AFTER ring
     // eviction). Matching the ring to the disk cap means worker evidence is
     // bounded only by what the log actually retains, not by global run volume.
-    const log = new RecipeRunLog({
+    const log = createRecipeRunLog({
       dir: patchworkDir,
       memoryCap: MAX_PERSIST_LINES,
     });


### PR DESCRIPTION
All 8 `RecipeRunLog` construction sites now build through `createRecipeRunLog()`. **Default OFF** — with `PATCHWORK_FLAG_RUNSTORE_MIRROR` unset, behaviour is byte-identical to before this PR.

## The mirror hooks `append()`, not the public write methods

Surveying the file showed `append` is the **single chokepoint every row passes through**: `record`, `appendDirect`, `startRun`, `completeRun` and the interrupted-sweep all funnel into it, and it holds the only row-level `appendFileSync` (the other two writes are whole-file rotation rewrites).

Hooking there means **no writer can be missed — including one added later**. That matters more than it sounds: a writer the mirror misses leaves it permanently short of rows, producing divergence reports that are true, meaningless, and quickly ignored.

It also made the wiring far smaller than planned. The interface never needed `record` or `readArchive` after all — sites keep their `RecipeRunLog` type and swap only the constructor call. One line per site instead of a type change across eight.

## Safety posture

- **Ambiguous flag ⇒ OFF.** `"false"`, `"0"`, `"off"` and typos all leave the mirror disabled. The safe reading of an ambiguous flag on a trust ledger is *"keep doing the thing we already trust"*.
- **Fail-soft twice.** A mirror that cannot be *opened* logs and returns an unmirrored run log; a mirror that throws mid-write is reported and swallowed. An observer must not take down what it observes.
- **Mirror after the durable write.** Mirroring first could put a row in the copy that never reached the source of truth — divergence manufactured by the tool meant to measure it.

## Verified by mutation

| Mutant | Caught by |
|---|---|
| remove the `append()` hook | 3 write-path tests |
| ignore the flag (always on) | the default-off test |

Restored **7/7**. Full suite **9671/9671**.

The write-path test exercises all three public entry points — `appendDirect`, `record`, and `startRun`+`completeRun` — rather than trusting the chokepoint claim.

## One test was fake on first draft

`"an unopenable mirror leaves a working run log"` *described* occupying the mirror's path with a file, but never did it — so it passed with the mirror opening perfectly. It now writes the blocking file, asserts it exists, and checks the warning was emitted. Flagging it because a check that cannot fail is worse than no check.

## Known gap — recorded, not implied

**The mirror only writes.** `DualWriteRunRepository` can compare reads, but nothing in production constructs it, so divergence is not yet observable outside tests. A mirror nobody compares proves nothing. That's the next slice, and it's in the ledger.

Also still pending: the deferred `ExperimentalWarning` suppression at an entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
