### PR TITLE
feat(runstore): backfill + compare, and `patchwork runstore`

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,23 +29,21 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-14 `feat/runstore-compare-report` — sixth slice of
-  [ADR-0022](adr/0022-durable-evidence-store.md). Merged so far: the seam +
-  shared contract (#1366), the SQLite store (#1370), dual-write with shadow
-  reads (#1372), `appendDirect` (#1373), and the wiring — all 8 sites now
-  build their run log through `createRecipeRunLog`, with the mirror hooked
-  to `RecipeRunLog.append()`, the single chokepoint every row passes
-  through. Default OFF (`PATCHWORK_FLAG_RUNSTORE_MIRROR`).
-  **Known gap this slice closes:** the mirror currently only WRITES.
-  `DualWriteRunRepository` can compare reads but nothing in production uses
-  it, so divergence is not yet observable outside tests — a mirror nobody
-  compares proves nothing. Wants an operator-facing comparison (CLI verb
-  and/or a report) over the two stores. Also still pending: the deferred
-  `ExperimentalWarning` suppression at an entry point, and `record` /
-  `readArchive` remaining off the interface (2 call sites each).
-  Flip gate unchanged and NOT part of this slice: #1324 / #1340 / rotation
-  loss replayed against both stores, JSONL must visibly LOSE all three
-  (ADR-0022 §4). — build session
+- 2026-08-14 `feat/runstore-flip-gate` — seventh slice of
+  [ADR-0022](adr/0022-durable-evidence-store.md). Merged so far: seam +
+  contract (#1366), SQLite store (#1370), dual-write (#1372),
+  `appendDirect` (#1373), wiring at the `append()` chokepoint (#1374), and
+  backfill + compare with the `patchwork runstore` verb. The mirror can now
+  be seeded and checked; against the REAL log it reproduces all 424 runs
+  from 1,123 raw lines and agrees on every compared field.
+  This slice is the FLIP GATE itself (ADR-0022 §4): replay #1324, #1340 and
+  rotation loss against both stores and require JSONL to visibly LOSE all
+  three. Nothing flips before that passes. Branch reserved, not yet cut.
+  Still pending and NOT in this slice: the deferred `ExperimentalWarning`
+  suppression at an entry point, and enabling
+  `PATCHWORK_FLAG_RUNSTORE_MIRROR` on the live bridge (an operator
+  decision — the mirror must be backfilled first or every pre-existing run
+  reports as a difference). — build session
 
 Swept 2026-08-08: all 10 distinct entries here were MERGED (#1249, #1255,
 #1256, #1257, #1258, #1259, #1278, #1279, #1280, #1281), several listed twice

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,7 @@ const KNOWN_SUBCOMMANDS = [
   "panic",
   "halts",
   "judgments",
+  "runstore",
   "analytics",
   "doctor",
   "codex",
@@ -2341,6 +2342,70 @@ if (process.argv[2] === "panic") {
 // per-category breakdown plus the 5 most-recent halt reasons. Default
 // window is "overnight" (since 6pm yesterday local) so it lines up with
 // "what halted while I was asleep?".
+if (process.argv[2] === "runstore") {
+  const sub = process.argv[3];
+  const args = process.argv.slice(4);
+  const json = args.includes("--json");
+  if (!sub || sub === "--help" || sub === "-h") {
+    process.stdout.write(
+      "Usage: patchwork runstore <backfill|compare> [--json]\n" +
+        "\n" +
+        "  backfill   seed the ADR-0022 shadow mirror from runs.jsonl (idempotent)\n" +
+        "  compare    report where the authoritative store and the mirror disagree\n" +
+        "\n" +
+        "Both are READ-ONLY with respect to runs.jsonl. The mirror is never\n" +
+        "consulted for answers; it exists to be compared until it has earned a\n" +
+        "flip. Backfill first — an unseeded mirror reports every pre-existing\n" +
+        "run as a difference, and a signal that always fires means nothing.\n",
+    );
+    process.exit(0);
+  }
+  if (sub !== "backfill" && sub !== "compare") {
+    process.stderr.write(`Unknown runstore subcommand: "${sub}"\n`);
+    process.exit(1);
+  }
+  void (async () => {
+    const os = await import("node:os");
+    const pathMod = await import("node:path");
+    const { SqliteRunRepository } = await import(
+      "./runStore/sqliteRunRepository.js"
+    );
+    const { backfillMirror, compareStores, formatCompare } = await import(
+      "./runStore/backfillMirror.js"
+    );
+    const dir = process.env.PATCHWORK_HOME
+      ? process.env.PATCHWORK_HOME
+      : pathMod.join(os.homedir(), ".patchwork");
+    const mirror = new SqliteRunRepository({
+      dir: pathMod.join(dir, "runstore-mirror"),
+    });
+    try {
+      if (sub === "backfill") {
+        const r = backfillMirror(dir, mirror);
+        if (json) {
+          process.stdout.write(`${JSON.stringify(r, null, 2)}\n`);
+        } else {
+          process.stdout.write(
+            `Seeded the mirror from ${r.rawSourceLines} raw line(s) → ` +
+              `${r.sourceRows} distinct run(s); mirror now holds ${r.mirrorRows}.\n` +
+              'Raw lines exceed runs because a run appends a "running" row and ' +
+              "later a terminal one; readers take the last. Not loss.\n",
+          );
+        }
+        process.exit(0);
+      }
+      const r = compareStores(dir, mirror);
+      process.stdout.write(
+        json ? `${JSON.stringify(r, null, 2)}\n` : formatCompare(r),
+      );
+      // Non-zero on disagreement so this is usable as a gate before the flip.
+      process.exit(r.agree ? 0 : 1);
+    } finally {
+      mirror.close();
+    }
+  })();
+}
+
 if (process.argv[2] === "halts") {
   const args = process.argv.slice(3);
   const wantHelp = args.includes("--help") || args.includes("-h");

--- a/src/runStore/__tests__/backfillMirror.test.ts
+++ b/src/runStore/__tests__/backfillMirror.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Backfill + compare — the migration rehearsed on a small scale.
+ *
+ * These exist because the same code was first run against the REAL log
+ * (1,123 raw lines → 424 runs) and found two things a green unit test would
+ * not have: the mirror normalising an absent `hadStepErrors` into an explicit
+ * `false` (52 spurious differences), and a counter that structurally could
+ * never fire. Both are pinned here so neither can come back.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RecipeRun } from "../../runLog.js";
+import {
+  backfillMirror,
+  compareStores,
+  formatCompare,
+} from "../backfillMirror.js";
+import { SqliteRunRepository } from "../sqliteRunRepository.js";
+
+describe("backfill + compare", () => {
+  let dir: string;
+  let mirrors: SqliteRunRepository[];
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "backfill-"));
+    mirrors = [];
+  });
+  afterEach(() => {
+    for (const m of mirrors) m.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const openMirror = () => {
+    const m = new SqliteRunRepository({
+      dir: path.join(dir, "runstore-mirror"),
+    });
+    mirrors.push(m);
+    return m;
+  };
+
+  const row = (over: Partial<RecipeRun> = {}): RecipeRun =>
+    ({
+      seq: 1,
+      taskId: "t-1",
+      recipeName: "demo",
+      trigger: "cron",
+      status: "done",
+      createdAt: 1_000,
+      doneAt: 2_000,
+      durationMs: 1_000,
+      ...over,
+    }) as RecipeRun;
+
+  /** Write raw JSONL, exactly as the run log would have. */
+  const writeLog = (rows: RecipeRun[], file = "runs.jsonl") =>
+    writeFileSync(
+      path.join(dir, file),
+      `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`,
+    );
+
+  it("seeds the mirror and the two then agree", () => {
+    writeLog([row({ seq: 1, taskId: "a" }), row({ seq: 2, taskId: "b" })]);
+    const mirror = openMirror();
+
+    const result = backfillMirror(dir, mirror);
+    expect(result.sourceRows).toBe(2);
+    expect(result.mirrorRows).toBe(2);
+    expect(compareStores(dir, mirror).agree).toBe(true);
+  });
+
+  /**
+   * The bug the real-data rehearsal found. A row written before
+   * `hadStepErrors` existed has it ABSENT; the mirror stored `false`, and 52
+   * real runs reported as different. Mirroring must reproduce its source, not
+   * improve it — an observer that quietly normalises cannot be used to judge
+   * whether the source was reproduced.
+   */
+  it("an absent hadStepErrors stays absent, it does not become false", () => {
+    const r = row({ taskId: "no-flag" });
+    delete (r as Partial<RecipeRun>).hadStepErrors;
+    writeLog([r]);
+    const mirror = openMirror();
+
+    backfillMirror(dir, mirror);
+
+    const mirrored = mirror.query({ limit: 10 })[0];
+    expect(mirrored?.hadStepErrors).toBeUndefined();
+    expect(compareStores(dir, mirror).agree).toBe(true);
+  });
+
+  it("a genuine hadStepErrors:true survives", () => {
+    writeLog([row({ taskId: "flagged", hadStepErrors: true })]);
+    const mirror = openMirror();
+    backfillMirror(dir, mirror);
+    expect(mirror.query({ limit: 10 })[0]?.hadStepErrors).toBe(true);
+  });
+
+  /** Re-running must be a no-op, not a duplication — an operator will run it
+   *  twice, and a backfill that grows each time is unusable as a rehearsal. */
+  it("is idempotent", () => {
+    writeLog([row({ seq: 1, taskId: "a" }), row({ seq: 2, taskId: "b" })]);
+    const mirror = openMirror();
+
+    backfillMirror(dir, mirror);
+    const second = backfillMirror(dir, mirror);
+
+    expect(second.mirrorRows).toBe(2);
+    expect(compareStores(dir, mirror).agree).toBe(true);
+  });
+
+  /**
+   * Raw lines exceed distinct runs because a run appends a "running" row and
+   * later a terminal one. Reported so the numbers reconcile — otherwise the
+   * mirror looks like it dropped most of the history. On the live log this is
+   * 1,123 lines against 424 runs.
+   */
+  it("reports raw lines separately from distinct runs", () => {
+    writeLog([
+      row({ seq: 1, taskId: "a", status: "running" }),
+      row({ seq: 1, taskId: "a", status: "done" }),
+      row({ seq: 2, taskId: "b" }),
+    ]);
+    const mirror = openMirror();
+
+    const result = backfillMirror(dir, mirror);
+    expect(result.rawSourceLines).toBe(3);
+    expect(result.sourceRows, "distinct runs, last row winning").toBe(2);
+    expect(result.mirrorRows).toBe(2);
+    // The surviving row must be the TERMINAL one, as every JSONL reader sees.
+    expect(
+      mirror.query({ limit: 10 }).find((r) => r.taskId === "a")?.status,
+    ).toBe("done");
+  });
+
+  it("counts the rotation archive as source too", () => {
+    writeLog([row({ seq: 9, taskId: "archived" })], "runs.jsonl.1");
+    writeLog([row({ seq: 10, taskId: "live" })]);
+    const mirror = openMirror();
+
+    const result = backfillMirror(dir, mirror);
+    expect(result.rawSourceLines).toBe(2);
+    expect(result.mirrorRows).toBe(2);
+  });
+
+  describe("compare detects real disagreement", () => {
+    it("a run missing from the mirror", () => {
+      writeLog([row({ seq: 1, taskId: "a" }), row({ seq: 2, taskId: "b" })]);
+      const mirror = openMirror();
+      backfillMirror(dir, mirror);
+
+      // Add a run to the source only.
+      writeLog([
+        row({ seq: 1, taskId: "a" }),
+        row({ seq: 2, taskId: "b" }),
+        row({ seq: 3, taskId: "c" }),
+      ]);
+
+      const r = compareStores(dir, mirror);
+      expect(r.agree).toBe(false);
+      expect(r.missingFromMirror).toEqual(["c"]);
+    });
+
+    it("a field that disagrees", () => {
+      writeLog([row({ seq: 1, taskId: "a", status: "done" })]);
+      const mirror = openMirror();
+      backfillMirror(dir, mirror);
+
+      writeLog([row({ seq: 1, taskId: "a", status: "error" })]);
+
+      const r = compareStores(dir, mirror);
+      expect(r.agree).toBe(false);
+      expect(r.fieldDifferences[0]?.taskId).toBe("a");
+      expect(r.fieldDifferences[0]?.differences.join(" ")).toContain("status");
+    });
+  });
+
+  /** Agreement is STATED, not implied by silence — silence is ambiguous with
+   *  a command that did nothing. */
+  it("formats agreement explicitly", () => {
+    writeLog([row({ taskId: "a" })]);
+    const mirror = openMirror();
+    backfillMirror(dir, mirror);
+    expect(formatCompare(compareStores(dir, mirror))).toContain("AGREE");
+  });
+});

--- a/src/runStore/backfillMirror.ts
+++ b/src/runStore/backfillMirror.ts
@@ -1,0 +1,217 @@
+/**
+ * Backfill and compare the ADR-0022 shadow mirror.
+ *
+ * ## Why backfill has to come first
+ *
+ * `runs.jsonl` already holds the installation's history — 1,123 rows on the
+ * machine this was written for. The mirror starts empty. Enable the mirror and
+ * compare immediately and every pre-existing row reports as a difference:
+ * ~1,123 findings, all expected, none meaningful. A divergence signal that
+ * always fires is indistinguishable from one that never does, and it teaches
+ * whoever reads it to stop.
+ *
+ * So the mirror is seeded from the authoritative file FIRST, and only then is
+ * a disagreement worth reporting.
+ *
+ * ## Backfill is also the rehearsal
+ *
+ * This is the migration performed in miniature: read every row the old store
+ * holds, write it to the new one, then check they agree. If the database
+ * cannot reproduce the history the file already has, the plan is dead — and
+ * that is much better learned now than at the flip.
+ *
+ * ## What it does not do
+ *
+ * It does not modify `runs.jsonl` in any way. Backfill is read-only with
+ * respect to the source of truth, and the mirror remains something nothing
+ * reads for answers.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { RecipeRun } from "../runLog.js";
+import { MAX_PERSIST_LINES, RecipeRunLog } from "../runLog.js";
+import { diffRun } from "./dualWriteRunRepository.js";
+import type { SqliteRunRepository } from "./sqliteRunRepository.js";
+
+export interface BackfillResult {
+  /** Rows read from the authoritative store (live file + rotation archive). */
+  sourceRows: number;
+  /** Rows written to the mirror. */
+  written: number;
+  /** Distinct runs in the mirror afterwards. */
+  mirrorRows: number;
+  /**
+   * Raw lines in the authoritative file, versus the distinct runs in
+   * `sourceRows`.
+   *
+   * These differ a lot and it is NOT loss: the run log appends a "running"
+   * row and later a terminal row for the same task, and every JSONL reader
+   * takes the last. On the live log 1,123 lines are 424 runs. Reported so the
+   * numbers reconcile rather than looking like the mirror dropped two-thirds
+   * of the history.
+   *
+   * An earlier version of this counted collapses during the write loop and
+   * could only ever report 0, because the reader dedupes upstream. A field
+   * that structurally cannot fire is worse than no field.
+   */
+  rawSourceLines: number;
+}
+
+export interface CompareResult {
+  /** Runs present in the authoritative store. */
+  sourceRows: number;
+  /** Runs present in the mirror. */
+  mirrorRows: number;
+  /** Runs in the source with no counterpart in the mirror. */
+  missingFromMirror: string[];
+  /** Runs in the mirror with no counterpart in the source. */
+  onlyInMirror: string[];
+  /** Per-run field disagreements, `taskId` → differences. */
+  fieldDifferences: Array<{ taskId: string; differences: string[] }>;
+  /** True when the two stores agree on every run and every compared field. */
+  agree: boolean;
+}
+
+/** Raw non-blank lines across the live file and its rotation archive. Counted
+ *  from disk because every reader dedupes by taskId before anything can see
+ *  the original row count. */
+function countRawLines(dir: string): number {
+  let n = 0;
+  for (const f of ["runs.jsonl", "runs.jsonl.1"]) {
+    const p = path.join(dir, f);
+    if (!existsSync(p)) continue;
+    try {
+      for (const line of readFileSync(p, "utf-8").split("\n")) {
+        if (line.trim()) n++;
+      }
+    } catch {
+      // Unreadable archive must not fail a backfill; the count is context,
+      // not a correctness signal.
+    }
+  }
+  return n;
+}
+
+/** Read every run the authoritative store retains — live file AND the rotation
+ *  archive, because the archive is still evidence the trust replay reads. */
+export function readAuthoritative(dir: string): RecipeRun[] {
+  const log = new RecipeRunLog({ dir, memoryCap: MAX_PERSIST_LINES });
+  try {
+    // Archive first, then live: later rows win on taskId collision, which is
+    // the same precedence every JSONL reader already applies.
+    return [...log.readArchive(), ...log.query({ limit: MAX_PERSIST_LINES })];
+  } finally {
+    log.close();
+  }
+}
+
+/**
+ * Seed the mirror from the authoritative store. Idempotent — rows upsert by
+ * `taskId`, so running it twice is a no-op rather than a duplication.
+ */
+export function backfillMirror(
+  dir: string,
+  mirror: SqliteRunRepository,
+): BackfillResult {
+  const rows = readAuthoritative(dir);
+  let written = 0;
+  for (const run of rows) {
+    if (!run?.taskId) continue;
+    mirror.mirrorRow(run);
+    written++;
+  }
+  return {
+    sourceRows: rows.length,
+    written,
+    mirrorRows: mirror.size(),
+    rawSourceLines: countRawLines(dir),
+  };
+}
+
+/**
+ * Compare the two stores run by run.
+ *
+ * Keyed on `taskId`, never `seq`: `seq` is a per-instance counter that
+ * collided on 142 of 145 rows in the live log (#1324), so comparing by it
+ * would pair unrelated runs and report differences between two things that
+ * were never the same run.
+ */
+export function compareStores(
+  dir: string,
+  mirror: SqliteRunRepository,
+): CompareResult {
+  const source = readAuthoritative(dir);
+  // Later row wins, matching JSONL read precedence.
+  const sourceById = new Map<string, RecipeRun>();
+  for (const r of source) if (r?.taskId) sourceById.set(r.taskId, r);
+
+  const mirrorRuns = mirror.query({ limit: MAX_PERSIST_LINES });
+  const mirrorById = new Map(mirrorRuns.map((r) => [r.taskId, r]));
+
+  const missingFromMirror: string[] = [];
+  const fieldDifferences: CompareResult["fieldDifferences"] = [];
+  for (const [taskId, s] of sourceById) {
+    const m = mirrorById.get(taskId);
+    if (!m) {
+      missingFromMirror.push(taskId);
+      continue;
+    }
+    const differences = diffRun(s, m);
+    if (differences.length > 0) fieldDifferences.push({ taskId, differences });
+  }
+  const onlyInMirror = [...mirrorById.keys()].filter(
+    (id) => !sourceById.has(id),
+  );
+
+  return {
+    sourceRows: sourceById.size,
+    mirrorRows: mirrorById.size,
+    missingFromMirror,
+    onlyInMirror,
+    fieldDifferences,
+    agree:
+      missingFromMirror.length === 0 &&
+      onlyInMirror.length === 0 &&
+      fieldDifferences.length === 0,
+  };
+}
+
+/** Operator-facing rendering. Silence on agreement would be ambiguous with a
+ *  broken command, so agreement is stated explicitly. */
+export function formatCompare(r: CompareResult): string {
+  const lines: string[] = [];
+  lines.push(
+    `Authoritative (runs.jsonl): ${r.sourceRows} run(s)   Mirror (runs.db): ${r.mirrorRows} run(s)`,
+  );
+  if (r.agree) {
+    lines.push("");
+    lines.push("The two stores AGREE on every run and every compared field.");
+    return `${lines.join("\n")}\n`;
+  }
+  if (r.missingFromMirror.length > 0) {
+    lines.push("");
+    lines.push(`Missing from the mirror (${r.missingFromMirror.length}):`);
+    for (const id of r.missingFromMirror.slice(0, 10)) lines.push(`  ${id}`);
+    if (r.missingFromMirror.length > 10)
+      lines.push(`  … and ${r.missingFromMirror.length - 10} more`);
+  }
+  if (r.onlyInMirror.length > 0) {
+    lines.push("");
+    lines.push(`Only in the mirror (${r.onlyInMirror.length}):`);
+    for (const id of r.onlyInMirror.slice(0, 10)) lines.push(`  ${id}`);
+    if (r.onlyInMirror.length > 10)
+      lines.push(`  … and ${r.onlyInMirror.length - 10} more`);
+  }
+  if (r.fieldDifferences.length > 0) {
+    lines.push("");
+    lines.push(`Field differences (${r.fieldDifferences.length} run(s)):`);
+    for (const d of r.fieldDifferences.slice(0, 10)) {
+      lines.push(`  ${d.taskId}`);
+      for (const diff of d.differences) lines.push(`    ${diff}`);
+    }
+    if (r.fieldDifferences.length > 10)
+      lines.push(`  … and ${r.fieldDifferences.length - 10} more run(s)`);
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/src/runStore/sqliteRunRepository.ts
+++ b/src/runStore/sqliteRunRepository.ts
@@ -473,7 +473,13 @@ export class SqliteRunRepository implements RunRepository {
         run.parentSeq ?? null,
         run.manualRunId ?? null,
         run.ownerPid ?? null,
-        run.hadStepErrors ? 1 : 0,
+        // ABSENT stays absent. `run.hadStepErrors ? 1 : 0` turned a row that
+        // never carried the field into an explicit `false`, which the
+        // migration rehearsal surfaced as 52 spurious differences against the
+        // real log. Mirroring must reproduce the source, not normalise it —
+        // an observer that quietly improves its input cannot be used to judge
+        // whether the input was reproduced.
+        run.hadStepErrors === undefined ? null : run.hadStepErrors ? 1 : 0,
         run.stepResults ? JSON.stringify(run.stepResults) : null,
         Object.keys(extra).length > 0 ? JSON.stringify(extra) : null,
       );


### PR DESCRIPTION
Makes the shadow mirror **observable**. Until now it could be written but never checked — and a mirror nobody compares proves nothing.

## Backfill must come first, and that's forced

The live log already holds the installation's history; the mirror starts empty. Compare before seeding and **every pre-existing run reports as a difference** — 424 findings, all expected, none meaningful. A divergence signal that always fires is indistinguishable from one that never does, and it teaches whoever reads it to stop.

Backfill is also the migration rehearsed in miniature: read every row the old store holds, write it to the new one, check they agree. Far better to learn it can't than to learn at the flip.

## Running it against the REAL log found two things unit tests would not have

**1. The mirror was normalising, not mirroring.** An *absent* `hadStepErrors` became an explicit `false`, reporting **52 real runs as different**. An observer that quietly improves its input cannot be used to judge whether the input was reproduced. Absent now stays absent.

**2. `collapsedDuplicates` could only ever report `0`** — the reader dedupes by `taskId` upstream, so the counter structurally could not fire. A field that can never fire is worse than no field. Replaced with `rawSourceLines`, read from disk.

After both fixes, against the real log:

```
1,123 raw lines → 424 distinct runs → 424 mirrored
The two stores AGREE on every run and every compared field.
40ms · idempotent on re-run
```

## The command

```
patchwork runstore backfill|compare [--json]
```

`compare` **exits 1 on disagreement**, so it can gate the flip. Both subcommands are read-only with respect to `runs.jsonl`.

Comparison keys on `taskId`, never `seq` — `seq` collided on 142 of 145 rows (#1324), so comparing by it would pair unrelated runs and report differences between two things that were never the same run.

## Verification

| Check | Result |
|---|---|
| Mutant: reinstate the normalisation bug | 4 tests fail ✅ |
| Exit code, agreeing | `0` |
| Exit code, disagreeing (row deleted from mirror) | `1` |

Exit codes were measured **directly, not through a pipe** — my first reading piped through `grep`, so `$?` was grep's status and all three came back `0`. That check couldn't have failed.

Restored **82/82** across `runStore`. Full suite **9682/9682**.

## Next

The ledger reserves `feat/runstore-flip-gate`: replay #1324, #1340 and rotation loss against both stores, requiring JSONL to visibly **lose** all three (ADR-0022 §4). Nothing flips before that passes.

Also still pending: the deferred `ExperimentalWarning` suppression, and enabling `PATCHWORK_FLAG_RUNSTORE_MIRROR` on the live bridge — an operator decision, and one that needs a backfill first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
