### PR TITLE
fix(runstore): silence the node:sqlite ExperimentalWarning, correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,17 @@
 #!/usr/bin/env node
 
+// Silence the one-per-process `node:sqlite` ExperimentalWarning (ADR-0022).
+// FIRST, before anything can import node:sqlite — the warning fires at import
+// time, so installing this later would suppress nothing. Entry point only:
+// it mutates global process state, which no leaf module should do on import.
+// Unrelated warnings still surface; that is the property its tests guard.
+{
+  const { suppressSqliteExperimentalWarning } = await import(
+    "./runStore/suppressSqliteWarning.js"
+  );
+  suppressSqliteExperimentalWarning();
+}
+
 // Load .env from repo root if present (connector credentials, etc.).
 // Uses Node 20.6+ native dotenv loader; falls back to manual parse for older Node.
 {

--- a/src/runStore/__tests__/suppressSqliteWarning.test.ts
+++ b/src/runStore/__tests__/suppressSqliteWarning.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The dangerous half of suppressing a warning is what ELSE stops being seen.
+ *
+ * So the test that matters is not "is the SQLite warning gone" — a suppressor
+ * that silenced everything would pass that perfectly. It is "does an unrelated
+ * warning still get through".
+ *
+ * These tests are also why this module works the way it does. The first
+ * implementation used `process.on("warning")`, on the assumption that a
+ * listener intercepts. It does not — Node prints from its own handler
+ * regardless — so that version suppressed nothing and duplicated every other
+ * warning. Caught here, not in production.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  restoreWarnings,
+  suppressSqliteExperimentalWarning,
+} from "../suppressSqliteWarning.js";
+
+describe("SQLite experimental-warning suppression", () => {
+  let emitted: Array<{ warning: unknown; type: unknown }>;
+  let spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restoreWarnings();
+    emitted = [];
+    // Spy on the ORIGINAL before wrapping, so we observe what actually
+    // reaches Node rather than what we handed to our own wrapper.
+    spy = vi.spyOn(process, "emitWarning").mockImplementation(((
+      warning: unknown,
+      type: unknown,
+    ) => {
+      emitted.push({ warning, type });
+    }) as typeof process.emitWarning);
+    suppressSqliteExperimentalWarning();
+  });
+
+  afterEach(() => {
+    // Order matters: unwrap OUR emitWarning wrapper before restoring the spy,
+    // or the wrapper is left holding a mock as its delegate and leaks into the
+    // next test file in this worker.
+    restoreWarnings();
+    spy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  const messages = () =>
+    emitted
+      .map((e) =>
+        typeof e.warning === "string"
+          ? e.warning
+          : ((e.warning as Error)?.message ?? ""),
+      )
+      .join("\n");
+
+  it("swallows the node:sqlite experimental warning", () => {
+    process.emitWarning(
+      "SQLite is an experimental feature and might change at any time",
+      "ExperimentalWarning",
+    );
+    expect(emitted, "nothing should reach Node").toHaveLength(0);
+  });
+
+  /**
+   * THE test. If this fails, the suppressor has disarmed warnings across the
+   * whole process — far worse than the noise it was hiding.
+   */
+  it("still passes unrelated warnings through", () => {
+    process.emitWarning("something you should know about", "SomeOtherWarning");
+    expect(messages()).toContain("something you should know about");
+  });
+
+  /** A DIFFERENT experimental warning is not ours to hide. */
+  it("still passes other ExperimentalWarnings through", () => {
+    process.emitWarning(
+      "Type Stripping is an experimental feature",
+      "ExperimentalWarning",
+    );
+    expect(messages()).toContain("Type Stripping");
+  });
+
+  /** The Error overload — `emitWarning(err)` carries its type as `err.name`,
+   *  not as a second argument. Handled explicitly because reading the type
+   *  wrongly would either leak the warning or swallow unrelated ones. */
+  it("handles the Error overload without swallowing unrelated errors", () => {
+    const unrelated = Object.assign(new Error("disk is nearly full"), {
+      name: "ResourceWarning",
+    });
+    process.emitWarning(unrelated);
+    expect(messages()).toContain("disk is nearly full");
+  });
+
+  it("is idempotent — no double delivery", () => {
+    suppressSqliteExperimentalWarning();
+    suppressSqliteExperimentalWarning();
+    process.emitWarning("delivered once please", "SomeOtherWarning");
+    expect(emitted).toHaveLength(1);
+  });
+
+  it("restoreWarnings puts Node's own behaviour back", () => {
+    restoreWarnings();
+    process.emitWarning(
+      "SQLite is an experimental feature",
+      "ExperimentalWarning",
+    );
+    expect(messages(), "suppression must be reversible").toContain("SQLite");
+  });
+});

--- a/src/runStore/sqliteRunRepository.ts
+++ b/src/runStore/sqliteRunRepository.ts
@@ -38,8 +38,8 @@
  */
 
 import { mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import type { Logger } from "../logger.js";
 import type {
   RecipeRun,
@@ -139,8 +139,40 @@ const EXTRA_KEYS = [
 
 type Row = Record<string, unknown>;
 
+/**
+ * `node:sqlite` is loaded LAZILY, on first construction, not by a static
+ * import.
+ *
+ * Not a performance tweak. A static import is HOISTED — evaluated before any
+ * top-level statement in the entry file — so the entry point's
+ * `suppressSqliteExperimentalWarning()` could never run first, however early
+ * it was placed. The chain index.ts -> bridge.ts -> createRunLog.ts -> here
+ * meant the ExperimentalWarning fired during hoisting and the suppression was
+ * always too late. Verified against the live bridge log, where the count went
+ * up rather than staying flat.
+ *
+ * Making the import first in source order would also have worked, and would
+ * have been silently broken by the next formatter run that sorts imports.
+ * Laziness removes the ordering dependency instead of depending on it.
+ */
+type DatabaseSyncCtor = new (
+  path: string,
+) => import("node:sqlite").DatabaseSync;
+
+let DatabaseSyncImpl: DatabaseSyncCtor | null = null;
+
+function loadDatabaseSync(): DatabaseSyncCtor {
+  if (!DatabaseSyncImpl) {
+    const require = createRequire(import.meta.url);
+    DatabaseSyncImpl = (
+      require("node:sqlite") as { DatabaseSync: DatabaseSyncCtor }
+    ).DatabaseSync;
+  }
+  return DatabaseSyncImpl;
+}
+
 export class SqliteRunRepository implements RunRepository {
-  private readonly db: DatabaseSync;
+  private readonly db: import("node:sqlite").DatabaseSync;
   private readonly now: () => number;
   private readonly isAlive: (pid: number | undefined) => boolean;
   private seq = 0;
@@ -150,6 +182,7 @@ export class SqliteRunRepository implements RunRepository {
     this.now = opts.now ?? Date.now;
     this.isAlive = opts.isAlive ?? defaultIsAlive;
     mkdirSync(opts.dir, { recursive: true, mode: 0o700 });
+    const DatabaseSync = loadDatabaseSync();
     this.db = new DatabaseSync(path.join(opts.dir, "runs.db"));
     // WAL: a reader must not block the writer, and vice versa. The whole
     // reason this store exists is that eight construction sites touch one

--- a/src/runStore/suppressSqliteWarning.ts
+++ b/src/runStore/suppressSqliteWarning.ts
@@ -1,0 +1,84 @@
+/**
+ * Silence Node's `ExperimentalWarning` for `node:sqlite` — and nothing else.
+ *
+ * ## Why it wraps `process.emitWarning` rather than listening for warnings
+ *
+ * The obvious implementation — `process.on("warning", …)` and return early for
+ * the one you want gone — DOES NOT WORK, and fails in the worst direction.
+ * Node prints warnings from its own internal handler regardless of how many
+ * listeners are attached; a listener observes, it does not intercept. The
+ * first version of this file assumed otherwise, suppressed nothing, and
+ * re-printed every unrelated warning a second time. Its own test caught it.
+ *
+ * Wrapping `emitWarning` works because Node routes experimental notices
+ * through it, so declining to delegate genuinely stops the warning at source.
+ *
+ * ## Why it is a function you CALL, not an import side effect
+ *
+ * This mutates global process state. A leaf module doing that on import would
+ * change behaviour for anyone who happened to import it, including code that
+ * never asked. The decision belongs at an entry point.
+ *
+ * ## Why suppress at all
+ *
+ * ADR-0022 puts `node:sqlite` in the trust-evidence path and accepted its
+ * experimental status as a known risk. The warning fires once per process,
+ * says nothing an operator can act on, and lands in `bridge.err` beside real
+ * incidents — and a log carrying a permanent unexplained warning trains people
+ * to skim it. Same reasoning that removed the permanently-red CI cell (#1369).
+ *
+ * The RISK, stated rather than buried: if Node ever gives an
+ * ExperimentalWarning mentioning SQLite a different meaning — a deprecation, a
+ * behaviour change — this hides it. Scoped as narrowly as the text allows, and
+ * it is one call to delete once `node:sqlite` is stable.
+ */
+
+type EmitWarning = typeof process.emitWarning;
+
+let original: EmitWarning | null = null;
+
+function isSqliteExperimental(message: string, type: string | undefined) {
+  return type === "ExperimentalWarning" && /\bSQLite\b/i.test(message);
+}
+
+/**
+ * Install the filter. Idempotent — safe to call from more than one entry
+ * point. Wrapping twice would build a chain that still works but is harder to
+ * unwind, so the second call is a no-op.
+ */
+export function suppressSqliteExperimentalWarning(): void {
+  if (original) return;
+  original = process.emitWarning.bind(process);
+  const delegate = original;
+
+  process.emitWarning = ((
+    warning: string | Error,
+    ...rest: unknown[]
+  ): void => {
+    // `emitWarning` has several overloads: (msg, type), (msg, options),
+    // (err). Read the type defensively rather than assuming one shape — a
+    // wrong guess here would either leak the warning or, far worse, swallow
+    // unrelated ones.
+    const first = rest[0];
+    const type =
+      typeof first === "string"
+        ? first
+        : typeof first === "object" && first !== null
+          ? (first as { type?: string }).type
+          : warning instanceof Error
+            ? warning.name
+            : undefined;
+    const message =
+      typeof warning === "string" ? warning : (warning?.message ?? "");
+
+    if (isSqliteExperimental(message, type)) return;
+    (delegate as (...a: unknown[]) => void)(warning, ...rest);
+  }) as EmitWarning;
+}
+
+/** Restore Node's original behaviour. Test seam, and an escape hatch. */
+export function restoreWarnings(): void {
+  if (!original) return;
+  process.emitWarning = original;
+  original = null;
+}


### PR DESCRIPTION
The loose end deferred twice in #1370 and #1374. With the mirror live, the bridge log carried a permanent unexplained warning next to real incidents — and a log with one of those trains people to skim it. Same reasoning that removed the permanently-red CI cell in #1369.

## Two wrong implementations on the way

Both caught by verification rather than review, and both recorded in comments because the next person will reach for the first one.

**1. `process.on("warning", …)` does not intercept.** Node prints from its own handler regardless of how many listeners exist — a listener *observes*. That version suppressed nothing **and** re-printed every unrelated warning a second time. Its own test caught it. Replaced with a wrapper around `process.emitWarning`, which Node genuinely routes experimental notices through.

**2. Installing it at the top of the entry file was still too late.** ESM static imports are hoisted above every top-level statement, and the chain

```
index.ts → bridge.ts → createRunLog.ts → sqliteRunRepository.ts → node:sqlite
```

pulled in `node:sqlite` during hoisting. Fixed by loading it **lazily**, on first construction.

Making the suppressor the first import would also have worked — and would have been silently broken by the next formatter run that sorts imports. Laziness removes the ordering dependency instead of depending on it.

## An earlier "verified end to end" was worthless

`runstore backfill` calls `process.exit()`, and warnings are emitted asynchronously, so the process died before Node could print. **Zero warnings before *and* after the mutant** — a check that could not fail.

The real verification is the live bridge log across a restart:

| | before fix | after fix |
|---|---|---|
| warning count across restart | 1 → **2** | 2 → **2** |

## What the tests actually guard

Not "is the SQLite warning gone" — a suppressor that silenced *everything* would pass that perfectly. The load-bearing test is **"does an unrelated warning still get through"**. Also covered: other `ExperimentalWarning`s, the `emitWarning(err)` overload, idempotence, and reversal via `restoreWarnings()`.

## Risk, stated not buried

If Node ever gives an `ExperimentalWarning` mentioning SQLite a different meaning — a deprecation, a behaviour change — this hides it. Scoped as narrowly as the text allows, and it's one call to delete once `node:sqlite` is stable.

Full suite **9690/9690**. Bridge healthy, mirror still capturing live runs (427/427 agreement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
