### PR TITLE
fix(config): a hand edit to config.json must survive the bridge's next write (#1361)

### DIFF
--- a/src/__tests__/configCacheStaleness.test.ts
+++ b/src/__tests__/configCacheStaleness.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #1361 — a hand edit to `config.json` must not be silently discarded.
+ *
+ * `loadConfig` caches for 30 seconds with NO check against the file. Every
+ * runtime write is a read-modify-write built on that read (recipe
+ * enable/disable, `POST /config/patchwork`), so an operator editing the file
+ * by hand inside the window has their change read back as the pre-edit copy
+ * and written straight over. No error, no conflict, no log line — the edit is
+ * simply gone, and the next read shows the bridge's version, which looks
+ * correct.
+ *
+ * That is why disabling `approval-gate-demo` by editing the file did not stick
+ * and had to be routed through the bridge instead.
+ *
+ * The fix mirrors a pattern this codebase already uses: the outcome-log cache
+ * is gated on `(mtimeMs, size)` for the same reason. Gating the READ fixes
+ * every consumer, not only the write path — a stale read is wrong on its own
+ * terms, quite apart from what a later write does with it.
+ */
+
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearConfigCache, loadConfig } from "../patchworkConfig.js";
+
+let dir: string;
+let configPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "cfgcache-"));
+  configPath = path.join(dir, "config.json");
+  clearConfigCache();
+});
+
+afterEach(() => {
+  clearConfigCache();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Write the file and force a distinct mtime, so the test cannot pass merely
+ *  because two writes landed in the same filesystem timestamp tick. */
+const writeConfig = (obj: unknown, ageOffsetSec = 0) => {
+  writeFileSync(configPath, JSON.stringify(obj, null, 2));
+  if (ageOffsetSec) {
+    const t = new Date(Date.now() + ageOffsetSec * 1000);
+    utimesSync(configPath, t, t);
+  }
+};
+
+describe("config cache staleness (#1361)", () => {
+  it("sees an edit made to the file after the first read", () => {
+    writeConfig({ model: "claude" });
+    expect(loadConfig(configPath).model).toBe("claude");
+
+    // The operator edits the file by hand, well inside the 30s TTL.
+    writeConfig({ model: "gemini" }, 2);
+
+    expect(
+      loadConfig(configPath).model,
+      "a hand edit must not be invisible to the next read — that read is what " +
+        "every runtime write is built on",
+    ).toBe("gemini");
+  });
+
+  /**
+   * The clobber itself, in the shape it actually occurs: read (cached),
+   * modify, write. If the read was stale, the write silently reverts the
+   * operator's edit.
+   */
+  it("a read-modify-write does not revert a concurrent hand edit", () => {
+    writeConfig({ model: "claude", recipes: { disabled: [] } });
+    loadConfig(configPath); // warm the cache, as a running bridge would have
+
+    // Operator disables a recipe by editing the file directly.
+    writeConfig(
+      { model: "claude", recipes: { disabled: ["approval-gate-demo"] } },
+      2,
+    );
+
+    // The bridge now does its own unrelated update, built on a fresh read.
+    const current = loadConfig(configPath);
+    const next = { ...current, model: "gemini" };
+    writeFileSync(configPath, JSON.stringify(next, null, 2));
+
+    const after = JSON.parse(readFileSync(configPath, "utf8")) as {
+      recipes?: { disabled?: string[] };
+    };
+    expect(
+      after.recipes?.disabled,
+      "the operator's edit must survive an unrelated bridge write",
+    ).toEqual(["approval-gate-demo"]);
+  });
+
+  /** The cache must still BE a cache — an unchanged file should not be
+   *  re-read and re-parsed on every call, or a hot path pays for this fix. */
+  it("still serves repeated reads of an unchanged file from cache", () => {
+    writeConfig({ model: "claude" });
+    const first = loadConfig(configPath);
+    const second = loadConfig(configPath);
+    expect(second, "same object identity ⇒ served from cache").toBe(first);
+    expect(statSync(configPath).size).toBeGreaterThan(0);
+  });
+});

--- a/src/patchworkConfig.ts
+++ b/src/patchworkConfig.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { dirname } from "node:path";
 import type { ModelChoice } from "./adapters/index.js";
 import {
@@ -209,9 +209,31 @@ export function getApiKeysPresent(): Record<ApiKeyProvider, boolean> {
 // cuts the per-webhook 9+ kernel-call burst to ~1 per 30 s at steady state.
 const _configCache = new Map<
   string,
-  { result: PatchworkConfig; expires: number }
+  { result: PatchworkConfig; expires: number; mtimeMs: number; size: number }
 >();
 const _CONFIG_TTL_MS = 30_000;
+
+/**
+ * Identity of the file backing a cache entry.
+ *
+ * The TTL alone was not enough: a cached entry stayed authoritative for 30s
+ * regardless of what happened to the file, so an operator's hand edit was
+ * invisible to the next read — and every runtime write is a read-modify-write
+ * built on that read, so the edit was then written straight over. Silently
+ * (#1361).
+ *
+ * `-1` for a missing file is a real value, not a sentinel for "unknown": it
+ * distinguishes "no config on disk" from any real stat, so creating or
+ * deleting the file both count as a change.
+ */
+function fileStamp(path: string): { mtimeMs: number; size: number } {
+  try {
+    const st = statSync(path);
+    return { mtimeMs: st.mtimeMs, size: st.size };
+  } catch {
+    return { mtimeMs: -1, size: -1 };
+  }
+}
 
 /** Clear the loadConfig cache. Exposed for tests and after saveConfig. */
 export function clearConfigCache(): void {
@@ -234,8 +256,19 @@ export function loadConfig(path = defaultConfigPath()): PatchworkConfig {
   // Say so when an override is active but the real config was left behind.
   warnIfLegacyConfigStranded("config.json");
   const now = Date.now();
+  const stamp = fileStamp(path);
   const cached = _configCache.get(path);
-  if (cached && now < cached.expires) return cached.result;
+  // Serve from cache only when the file is BOTH un-expired and unchanged.
+  // Size as well as mtime, because a filesystem whose timestamps are coarse
+  // can give an edit the same mtime as the write before it.
+  if (
+    cached &&
+    now < cached.expires &&
+    cached.mtimeMs === stamp.mtimeMs &&
+    cached.size === stamp.size
+  ) {
+    return cached.result;
+  }
   if (!existsSync(path)) {
     const fromStore = loadApiKeysFromSecureStore();
     const result: PatchworkConfig = withHomeDefaults(
@@ -243,7 +276,11 @@ export function loadConfig(path = defaultConfigPath()): PatchworkConfig {
         ? { ...DEFAULTS, apiKeys: fromStore }
         : { ...DEFAULTS },
     );
-    _configCache.set(path, { result, expires: now + _CONFIG_TTL_MS });
+    _configCache.set(path, {
+      result,
+      expires: now + _CONFIG_TTL_MS,
+      ...stamp,
+    });
     return result;
   }
   const raw = readFileSync(path, "utf8");
@@ -297,7 +334,11 @@ export function loadConfig(path = defaultConfigPath()): PatchworkConfig {
   // Don't cache migrated configs — the file has just been rewritten; next load
   // should see the stripped version. This path is once-per-key, not hot.
   if (!migrated)
-    _configCache.set(path, { result, expires: now + _CONFIG_TTL_MS });
+    _configCache.set(path, {
+      result,
+      expires: now + _CONFIG_TTL_MS,
+      ...stamp,
+    });
   return result;
 }
 


### PR DESCRIPTION
Closes #1361.

## The bug

`loadConfig` cached for 30 seconds with **no check against the file**. Every runtime write is a read-modify-write built on that read — recipe enable/disable, `POST /config/patchwork` — so an operator editing `config.json` by hand inside the window had their change read back as the *pre-edit* copy and written straight over.

No error, no conflict, no log line. The edit is simply gone, and the next read shows the bridge's version, which looks correct.

That's why disabling `approval-gate-demo` by editing the file didn't stick and had to be routed through the bridge.

## The fix

Gate the cache on `(mtimeMs, size)` — the same pattern this codebase already uses for the outcome-log cache.

Gating the **read** fixes every consumer, not just the write path: a stale read is wrong on its own terms, quite apart from what a later write does with it.

Details that matter:
- **Size as well as mtime** — a coarse-timestamp filesystem can give an edit the same mtime as the write before it.
- **A missing file stamps as `(-1, -1)`**, a real value rather than an "unknown" sentinel, so creating *or* deleting `config.json` both count as a change.

## Verification

Test-first. Both failing cases reproduce before the fix:

| Case | Before | After |
|---|---|---|
| sees an edit made after the first read | ❌ | ✅ |
| read-modify-write doesn't revert a hand edit | ❌ | ✅ |
| repeated reads of an **unchanged** file still cached | ✅ | ✅ |

That third case is the important guard: a "fix" that simply disabled the cache would make the first two pass too. It asserts object identity, so the cache must still be a cache.

Mutation: forcing the identity check to `true` fails exactly the two, nothing else.

**End-to-end against a copy of the real config** (75 disabled recipes — live file untouched):

```
1. bridge read config, disabled count = 75
2. operator hand-edited the file (added approval-gate-demo)
3. bridge did an unrelated read-modify-write
4. operator edit survived: YES ✅
```

Full suite: **9698/9698**.

## Note

This unblocks disabling `approval-gate-demo` by hand once the bridge is running a build with this fix. I've deliberately **not** changed your live config — it's your call, and that recipe is currently useful for exercising the run-store mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
