### PR TITLE
fix(workers): classify tracker, docs and support writes (#1311 batch 3)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,24 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-14 `fix/1311-batch3-tracker-writes` — #1311 batch 3: the per-tool
+  review of declared WRITES that batch 1 deferred and batch 2 began. 17 tracker
+  / knowledge-base / support tools taken off the classification ratchet (34 →
+  17). Two distinct moves, kept apart on purpose: 15 LOOSENED
+  (irreversible → compensable) only where the inverse is an ordinary supported
+  operation of the product — delete/close the issue, restore the page version,
+  reopen the ticket; 2 DEBUCKETED only (`intercom.replyToConversation`,
+  `zendesk.addComment` stay irreversible — they deliver text to a customer and
+  a sent message has no inverse). New domains `docs-write` and `support`;
+  `support` is brand-exposed, `docs-write` deliberately is not. Touches
+  `src/workers/actionClass.ts` — the autonomy gate — so it collides with any
+  other trust-gate work. Deliberately left on the ratchet:
+  `obsidian.write_note` (looks like a sibling of the Notion/Confluence page
+  writes but overwrites with no version history and no WriteEffectLedger) and
+  `outcomes.classify_issues` (writes the outcome-log the trust ramp READS —
+  classifying it is a governance question about a worker writing its own
+  evidence, not a reversibility one). Remaining 17 are CRM and
+  infrastructure writes.
 
 Swept 2026-08-08: all 10 distinct entries here were MERGED (#1249, #1255,
 #1256, #1257, #1258, #1259, #1278, #1279, #1280, #1281), several listed twice

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,38 +29,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-14 `fix/1311-batch3-tracker-writes` — #1311 batch 3: the per-tool
-  review of declared WRITES that batch 1 deferred and batch 2 began. 17 tracker
-  / knowledge-base / support tools taken off the classification ratchet (34 →
-  17). Two distinct moves, kept apart on purpose: 15 LOOSENED
-  (irreversible → compensable) only where the inverse is an ordinary supported
-  operation of the product — delete/close the issue, restore the page version,
-  reopen the ticket; 2 DEBUCKETED only (`intercom.replyToConversation`,
-  `zendesk.addComment` stay irreversible — they deliver text to a customer and
-  a sent message has no inverse). New domains `docs-write` and `support`;
-  `support` is brand-exposed, `docs-write` deliberately is not. Touches
-  `src/workers/actionClass.ts` — the autonomy gate — so it collides with any
-  other trust-gate work. Deliberately left on the ratchet:
-  `obsidian.write_note` (looks like a sibling of the Notion/Confluence page
-  writes but overwrites with no version history and no WriteEffectLedger) and
-  `outcomes.classify_issues` (writes the outcome-log the trust ramp READS —
-  classifying it is a governance question about a worker writing its own
-  evidence, not a reversibility one). Remaining 17 are CRM and
-  infrastructure writes.
-
-Swept 2026-08-08: all 10 distinct entries here were MERGED (#1249, #1255,
-#1256, #1257, #1258, #1259, #1278, #1279, #1280, #1281), several listed twice
-by union-merge. The oldest had been closed for four days while CLAUDE.md told
-every session to read this file first — so the ledger built to stop two
-sessions colliding was itself handing them stale state.
-
-This is the third sweep (#1247 was the second, on 2026-08-03, and it decayed
-within five days). `scripts/audit-in-flight.mjs` now fails CI when an entry
-here names a merged PR or a branch that no longer exists, because three
-manual sweeps is enough evidence that the convention does not hold on its
-own.
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-14 `fix/1311-batch3-tracker-writes` — #1311 batch 3: the per-tool review of declared WRITES that batch 1 deferred and batch 2 began. 17 tracker / knowledge-base / support tools taken off the classification ratchet (34 → 17). Two distinct moves, kept apart on purpose: 15 LOOSENED (irreversible → compensable) only where the inverse is an ordinary supported operation of the product — delete/close the issue, restore the page version, reopen the ticket; 2 DEBUCKETED only (`intercom.replyToConversation`, `zendesk.addComment` stay irreversible — they deliver text to a customer and a sent message has no inverse). New domains `docs-write` and `support`; `support` is brand-exposed, `docs-write` deliberately is not. Touches `src/workers/actionClass.ts` — the autonomy gate — so it collides with any other trust-gate work. Deliberately left on the ratchet: `obsidian.write_note` (looks like a sibling of the Notion/Confluence page writes but overwrites with no version history and no WriteEffectLedger) and `outcomes.classify_issues` (writes the outcome-log the trust ramp READS — classifying it is a governance question about a worker writing its own evidence, not a reversibility one). Remaining 17 are CRM and infrastructure writes. Swept 2026-08-08: all 10 distinct entries here were MERGED (#1249, #1255, #1256, #1257, #1258, #1259, #1278, #1279, #1280, #1281), several listed twice by union-merge. The oldest had been closed for four days while CLAUDE.md told every session to read this file first — so the ledger built to stop two sessions colliding was itself handing them stale state. This is the third sweep (#1247 was the second, on 2026-08-03, and it decayed within five days). `scripts/audit-in-flight.mjs` now fails CI when an entry here names a merged PR or a branch that no longer exists, because three manual sweeps is enough evidence that the convention does not hold on its own — merged as #1381
 
 - 2026-08-11 `feat/trust-reads-archive` — Item (1) of the retention scope, plus the measurement that should have caught it. FINDING: `runs.jsonl` is capped by BYTES while the durability window is defined in TIME, and nothing reconciled the two — retention measured **18.2h against a 24h window**, so a non-reversible success was DELETED BEFORE IT COULD SETTLE. Compensable/irreversible trust was therefore unearnable in principle, not merely slow, which is why `worker_trust/` has never existed (`folded > 0` never holds). Cause of the squeeze: one non-worker recipe wrote 1243 of 1275 rows in 18.2h; worker rows were 3 of 1275, then 0 of 729 forty minutes later — every worker run on this machine was evicted mid-session by unrelated traffic. Fix: trust replay now reads `runs.jsonl.1` (the archive #1334 created) as well as the live file, deduped by taskId across both (a crash between archive-write and trim can leave a run in each). ~11 days of retention at current volume vs 24h needed. PLUS `evidenceRetention()` — the honest half: the read-side version of this exact bug was already fixed once (see the ring `memoryCap` note in runWorkerShadow.ts) and survived one layer down in disk retention because nothing measured whether the invariant held. `workers shadow` now says so out loud when span < window, because a starved ledger otherwise looks identical to a quiet worker. Deliberately NOT (3) a filtered worker-run ledger — that is the durable design (immune to noise; worker rows are ~0.2% of volume) but spans 8 write paths where a miss is a silent evidence gap, and it should land against a measurement rather than my estimate. Two vacuous tests caught mid-build: a dedup test asserted on the confirm queue, which dedups by actionKey itself, so it passed whether or not readRuns deduped at all (moved to the dial's observation count); and the `audit-patchwork-home` gate caught a hardcoded homedir join. — merged as #1338
 

--- a/scripts/audit-tool-classification-allowlist.json
+++ b/scripts/audit-tool-classification-allowlist.json
@@ -17,31 +17,17 @@
     "",
     "2026-08-10 batch 1 (#1311): 144 entries cleared \u2014 every connector tool declaring isWrite:false, plus two camelCase aliases that were governed differently from the identical canonical tool.",
     "Remaining 42 are declared WRITES. Each needs a real judgement about whether it can be undone; loosening is the dangerous direction, so these get per-tool review, not a sweep.",
-    "2026-08-10 batch 2 (#1311): 8 irreversible writes given a real domain (messaging, db-write). Reversibility unchanged \u2014 this batch loosens nothing; it only stops them sharing one undifferentiated bucket."
+    "2026-08-10 batch 2 (#1311): 8 irreversible writes given a real domain (messaging, db-write). Reversibility unchanged \u2014 this batch loosens nothing; it only stops them sharing one undifferentiated bucket.",
+    "2026-08-14 batch 3 (#1311): 17 tracker / knowledge-base / support writes reviewed one by one. 15 given a real inverse (issue, tasks, docs-write, support \u2014 compensable); 2 (intercom.replyToConversation, zendesk.addComment) DEBUCKETED only, staying irreversible because they deliver text to a customer. obsidian.write_note deliberately left here: it overwrites with no version history and no WriteEffectLedger, so it has no inverse. outcomes.classify_issues also left here on purpose \u2014 it writes the outcome-log the trust ramp reads, so classifying it is a governance decision (a worker writing its own evidence), not a reversibility one."
   ],
   "allow": [
     "airtable.create_record",
-    "asana.add_task_comment",
     "caldiy.cancel_booking",
     "circleci.trigger_pipeline",
     "cloudflare.create_dns_record",
-    "confluence.appendToPage",
-    "confluence.createPage",
     "datadog.muteMonitor",
     "grafana.create_annotation",
     "hubspot.createNote",
-    "intercom.closeConversation",
-    "intercom.replyToConversation",
-    "jira.add_comment",
-    "jira.create_issue",
-    "jira.update_status",
-    "linear.addComment",
-    "linear.createIssue",
-    "linear.updateIssue",
-    "meetingNotes.createLinearIssues",
-    "monday.create_item",
-    "notion.appendBlock",
-    "notion.createPage",
     "obsidian.write_note",
     "outcomes.classify_issues",
     "pagerduty.acknowledge_incident",
@@ -51,8 +37,6 @@
     "pipedrive.create_deal",
     "posthog.capture_event",
     "salesforce.create_record",
-    "supabase.upload_file",
-    "zendesk.addComment",
-    "zendesk.updateStatus"
+    "supabase.upload_file"
   ]
 }

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   classifyActionClass,
@@ -283,10 +284,17 @@ describe("connector reads (#1311 batch 1)", () => {
     // a real judgement about whether they can be undone, and loosening is the
     // dangerous direction, so they must stay on the conservative default until
     // reviewed one by one.
+    // The three Linear writes this originally named were reviewed in batch 3
+    // and now carry a stated inverse, so they moved. The guard itself still
+    // holds and is retargeted at writes NOT yet reviewed — including
+    // `obsidian.write_note`, which looks like a sibling of the Notion and
+    // Confluence page writes batch 3 did loosen but has no version history to
+    // restore from.
     for (const tool of [
-      "linear.createIssue",
-      "linear.updateIssue",
-      "linear.addComment",
+      "obsidian.write_note",
+      "salesforce.create_record",
+      "cloudflare.create_dns_record",
+      "circleci.trigger_pipeline",
     ]) {
       expect(classifyActionClass(tool, {}).reversibility).toBe("irreversible");
     }
@@ -325,5 +333,89 @@ describe("irreversible writes get a domain, not a discount (#1311 batch 2)", () 
     expect(mail.domain).toBe("messaging");
     expect(sql.domain).toBe("db-write");
     expect(mail.key).not.toBe(sql.key);
+  });
+});
+
+describe("tracker / docs / support writes (#1311 batch 3)", () => {
+  // The per-tool review, as a table. Each row is a claim about the real world
+  // — "this act has THIS inverse" — and the test is what stops the claim from
+  // drifting away from the mapping later.
+  const REVIEWED: Array<[tool: string, key: string, brandExposed: boolean]> = [
+    // Inverse: delete/close the issue, revert the field, delete the comment.
+    ["jira.create_issue", "issue:compensable:medium", true],
+    ["jira.add_comment", "issue:compensable:medium", true],
+    ["jira.update_status", "issue:compensable:medium", true],
+    ["linear.createIssue", "issue:compensable:medium", true],
+    ["linear.updateIssue", "issue:compensable:medium", true],
+    ["linear.addComment", "issue:compensable:medium", true],
+    ["meetingNotes.createLinearIssues", "issue:compensable:medium", true],
+    // Inverse: delete the item / the comment.
+    ["asana.add_task_comment", "tasks:compensable:medium", false],
+    ["monday.create_item", "tasks:compensable:medium", false],
+    // Inverse: delete the page or restore the prior version (page history).
+    ["notion.createPage", "docs-write:compensable:medium", false],
+    ["notion.appendBlock", "docs-write:compensable:medium", false],
+    ["confluence.createPage", "docs-write:compensable:medium", false],
+    ["confluence.appendToPage", "docs-write:compensable:medium", false],
+    // NO inverse — text was delivered to a customer. Debucketed only.
+    ["intercom.replyToConversation", "messaging:irreversible:medium", true],
+    ["zendesk.addComment", "messaging:irreversible:medium", true],
+    // Inverse: reopen the ticket.
+    ["intercom.closeConversation", "support:compensable:medium", true],
+    ["zendesk.updateStatus", "support:compensable:medium", true],
+  ];
+
+  it.each(REVIEWED)("classifies %s as %s", (tool, key, brandExposed) => {
+    const c = classifyActionClass(tool, {});
+    expect(c.key).toBe(key);
+    expect(c.brandExposed).toBe(brandExposed);
+  });
+
+  it("keeps DELIVERING text apart from flipping ticket state", () => {
+    // The distinction this batch turns on, and the one most likely to be
+    // flattened by a later sweep: within a SINGLE product, replying to a
+    // customer is irreversible and closing their ticket is not. If these ever
+    // collapse into one class, evidence from harmless status flips would
+    // authorise sending mail to customers.
+    const reply = classifyActionClass("intercom.replyToConversation", {});
+    const close = classifyActionClass("intercom.closeConversation", {});
+    expect(reply.reversibility).toBe("irreversible");
+    expect(close.reversibility).toBe("compensable");
+    expect(reply.key).not.toBe(close.key);
+  });
+
+  it("does not loosen the tools it debucketed", () => {
+    // Same guard batch 2 carried: these two were already irreversible via the
+    // `other` catch-all and must stay that way. Giving them a domain changes
+    // which bucket the evidence lands in, nothing about what the gate permits.
+    for (const tool of ["intercom.replyToConversation", "zendesk.addComment"]) {
+      expect(
+        classifyActionClass(tool, {}).reversibility,
+        `${tool} must stay irreversible`,
+      ).toBe("irreversible");
+    }
+  });
+
+  it("leaves every tool still on the ratchet unclassified", () => {
+    // Makes the ratchet file honest in BOTH directions. Without this the
+    // allowlist could quietly list a tool that is in fact classified — an
+    // entry that can never be "cleared" because there is nothing to fix — and
+    // the audit would still pass, reporting a gap that does not exist.
+    const allowlist = JSON.parse(
+      readFileSync(
+        new URL(
+          "../../../scripts/audit-tool-classification-allowlist.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as { allow: string[] };
+    expect(allowlist.allow.length).toBeGreaterThan(0);
+    for (const tool of allowlist.allow) {
+      expect(
+        classifyActionClass(tool, {}).domain,
+        `${tool} is on the ratchet but IS classified — delete its line`,
+      ).toBe("other");
+    }
   });
 });

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -156,6 +156,67 @@ const DOMAIN_BY_TOOL: Record<string, string> = {
   "postgres.query": "db-write",
   "snowflake.execute_query": "db-write",
 
+  // ── tracker / docs / support writes (#1311 batch 3) ─────────────────────
+  // The per-tool review batch 1 deferred and batch 2 began. Every id below is
+  // a declared WRITE, so each carries a stated inverse rather than a guess
+  // from its name — the question asked of each was "what is the concrete act
+  // that undoes this, and what residue does it leave?".
+  //
+  // Two different things happen in this block, and they are kept apart on
+  // purpose:
+  //   * DEBUCKETING (no reversibility change) — the tool stays irreversible
+  //     and only stops sharing one bucket with every other unclassified write.
+  //   * LOOSENING (irreversible → compensable) — the tool has a real inverse.
+  //     This is the dangerous direction, so it is claimed only where the
+  //     inverse is an ordinary, supported operation of the product itself.
+  //
+  // Issue trackers. Inverse: delete or close the issue, revert the field, or
+  // delete the comment — all first-class operations in Jira and Linear. The
+  // residue (a watcher may have seen it, a notification already went out) is
+  // exactly what `compensable` means as distinct from `reversible`.
+  "jira.create_issue": "issue",
+  "jira.add_comment": "issue",
+  "jira.update_status": "issue",
+  "linear.createIssue": "issue",
+  "linear.updateIssue": "issue",
+  "linear.addComment": "issue",
+  "meetingNotes.createLinearIssues": "issue",
+
+  // Work trackers. Same inverse (delete the item / the comment); separate
+  // domain because "may file engineering issues" and "may act on the task
+  // board" are different authorities, and `tasks` already exists and is
+  // already compensable for the same stated reason (#1268).
+  "asana.add_task_comment": "tasks",
+  "monday.create_item": "tasks",
+
+  // Knowledge bases. Inverse: delete the page, or restore the previous
+  // version — both products keep page history, which is what makes this a
+  // real inverse rather than a hopeful one.
+  //
+  // `obsidian.write_note` is deliberately NOT here despite looking like a
+  // sibling: it overwrites a vault file with no version history and is not
+  // covered by the WriteEffectLedger that makes `fs-write` reversible, so
+  // its prior content is simply gone. It stays on the ratchet.
+  "notion.createPage": "docs-write",
+  "notion.appendBlock": "docs-write",
+  "confluence.createPage": "docs-write",
+  "confluence.appendToPage": "docs-write",
+
+  // Customer-facing support. Split by what the act actually IS, not by which
+  // product it belongs to:
+  //   * replying/commenting DELIVERS text to a customer (usually by email).
+  //     That is a sent message and cannot be unsent — DEBUCKETING only, it
+  //     stays irreversible, and `messaging` is where sent things live.
+  //   * flipping ticket state is reopenable in both products — a genuine
+  //     inverse, so `support` is compensable. Kept out of `issue` because
+  //     "may close a customer's ticket" is a different authority from "may
+  //     close an engineering issue", and it is brand-exposed in a way an
+  //     internal tracker is not.
+  "intercom.replyToConversation": "messaging",
+  "zendesk.addComment": "messaging",
+  "intercom.closeConversation": "support",
+  "zendesk.updateStatus": "support",
+
   // ── connector reads (#1311 batch 1) ─────────────────────────────────────
   // Derived from the registry's own `isWrite: false`, never guessed from the
   // name. Writes are deliberately NOT swept: each needs a real reversibility
@@ -366,6 +427,16 @@ const REVERSIBILITY_BY_DOMAIN: Record<string, Reversibility> = {
   // list showed the task, a collaborator may have seen it. "Undoable" and
   // "as if it never happened" are not the same claim.
   tasks: "compensable",
+  // Knowledge-base page writes (#1311 batch 3). Compensable, not reversible:
+  // both Notion and Confluence keep page history, so "delete the page" and
+  // "restore the previous version" are ordinary supported operations — but a
+  // reader may already have seen it and a watch notification already fired.
+  "docs-write": "compensable",
+  // Customer-facing ticket STATE (#1311 batch 3) — not ticket text, which is
+  // classified `messaging` and stays irreversible. Reopening a ticket is a
+  // first-class operation in both Zendesk and Intercom, so the inverse is
+  // real; the residue is that the customer was told it was closed.
+  support: "compensable",
   payments: "irreversible", // a settled charge/transfer has no generic inverse;
   // a refund is a NEW compensating action with residue (fees kept, two
   // statement lines), not an undo — see src/recipes/fileRollback.ts's note.
@@ -424,6 +495,10 @@ const BRAND_EXPOSED_DOMAINS = new Set([
   "vcs-push",
   "vcs-merge",
   "issue",
+  // A customer watched their ticket close. Internal knowledge-base pages
+  // (`docs-write`) are deliberately NOT here — the failure is embarrassing
+  // internally, not customer-visible.
+  "support",
   "http",
   "payments", // a wrong charge is a customer-visible, reputational failure
 ]);


### PR DESCRIPTION
The per-tool review batch 1 deferred and batch 2 began. 17 declared WRITES
come off the classification ratchet (34 -> 17), each with a stated inverse
rather than a guess from its name: what is the concrete act that undoes
this, and what residue does it leave?

Two different things happen here and they are kept apart on purpose.

LOOSENED (irreversible -> compensable), 15 tools, claimed only where the
inverse is an ordinary supported operation of the product itself:
  issue       jira.create_issue / add_comment / update_status,
              linear.createIssue / updateIssue / addComment,
              meetingNotes.createLinearIssues
              - delete or close the issue, revert the field, delete the
                comment
  tasks       asana.add_task_comment, monday.create_item
              - delete the item or the comment
  docs-write  notion.createPage / appendBlock,
              confluence.createPage / appendToPage
              - delete the page or restore the previous version; both
                products keep page history, which is what makes this a real
                inverse rather than a hopeful one
  support     intercom.closeConversation, zendesk.updateStatus
              - reopen the ticket

DEBUCKETED ONLY (still irreversible), 2 tools:
  messaging   intercom.replyToConversation, zendesk.addComment

The support split is by what the act IS, not by which product it belongs
to. Replying to a customer DELIVERS text, usually by email, and cannot be
unsent; flipping ticket state is reopenable. Within a single product those
are now different classes, and a test pins them apart: if they ever
collapse, evidence from harmless status flips would authorise sending mail
to customers.

`support` is brand-exposed (a customer watched their ticket close);
`docs-write` deliberately is not - an internal wiki mistake is
embarrassing, not customer-visible.

Deliberately LEFT on the ratchet, both worth stating because both look
like they belong in a batch above:
  obsidian.write_note      - sibling of the Notion/Confluence page writes
                             in shape only. It overwrites a vault file with
                             no version history and is not covered by the
                             WriteEffectLedger that makes `fs-write`
                             reversible, so the prior content is simply
                             gone. No inverse, no reclassification.
  outcomes.classify_issues - writes the outcome-log the trust ramp READS.
                             Classifying it is a governance question about
                             a worker writing its own evidence, not a
                             reversibility one.

The remaining 17 are CRM and infrastructure writes (salesforce, pipedrive,
hubspot, cloudflare, circleci, supabase, posthog, airtable, datadog,
pagerduty, caldiy, grafana) and want their own batch.

Batch 1's guard test named the three Linear writes as "must stay
irreversible until reviewed one by one". This IS that review, so the guard
is retargeted at writes still unreviewed rather than deleted.

Verified by mutation, not by green: loosening a debucket-only tool fails 3
tests; adding an already-classified id to the ratchet fails the
cross-check that keeps the allowlist honest in both directions (without it
a stale entry could sit there forever describing a gap that does not
exist). Full suite 9718/9718, ratchet 34 -> 17.

src/ is vendored verbatim by patchwork-multitenant - this needs
snapshotting there.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Refs #1311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)