### PR TITLE
fix: remove a private project's identifier from tracked files

### DIFF
--- a/docs/adr/0022-durable-evidence-store.md
+++ b/docs/adr/0022-durable-evidence-store.md
@@ -57,7 +57,7 @@ That was accurate when measured and is **not** the state today. Measured
 | Retention span | **58.8h** (window is 24h — currently sufficient) |
 | File size | 851,327 bytes — **81.2% of the 1 MB rotation cap** |
 | `runs.jsonl.1` (rotation archive) | **does not exist — has never been written** |
-| Highest-volume recipe | `gigsecure-withdrawal-alert`, 953 rows (**85%**) |
+| Highest-volume recipe | one high-frequency recipe, 953 rows (**85%**) |
 | `butler-errand` (the governed worker) | 26 rows (2.3%) |
 
 This changes the argument, and the honest version is weaker but still decisive.

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -123,8 +123,8 @@
 
 <h2>9. Contact</h2>
 <p>
-  Questions about this policy: <a href="mailto:support@gigsecure.co.ke">support@gigsecure.co.ke</a>
-  or open an issue at <a href="https://github.com/Oolab-labs/patchwork-os/issues" target="_blank" rel="noopener">github.com/Oolab-labs/patchwork-os/issues</a>.
+  Questions about this policy: open an issue at
+  <a href="https://github.com/Oolab-labs/patchwork-os/issues" target="_blank" rel="noopener">github.com/Oolab-labs/patchwork-os/issues</a>.
 </p>
 
 </body>

--- a/src/__tests__/runLogSeqCollision.test.ts
+++ b/src/__tests__/runLogSeqCollision.test.ts
@@ -55,20 +55,20 @@ describe("run log: colliding seqs must not destroy runs", () => {
   it("keeps BOTH runs when two instances hand out the same seq", () => {
     seed([
       row(12540, "yaml:butler-errand:1", "butler-errand", 1000),
-      row(12540, "yaml:gigsecure:2", "gigsecure-withdrawal-alert", 2000),
+      row(12540, "yaml:noisy-recipe:2", "noisy-recipe", 2000),
     ]);
     const log = new RecipeRunLog({ dir });
     const all = log.query({ limit: 500 });
     expect(all.map((r) => r.recipeName).sort()).toEqual([
       "butler-errand",
-      "gigsecure-withdrawal-alert",
+      "noisy-recipe",
     ]);
   });
 
   it("a per-recipe query still finds the run the collision used to hide", () => {
     seed([
       row(12540, "yaml:butler-errand:1", "butler-errand", 1000),
-      row(12540, "yaml:gigsecure:2", "gigsecure-withdrawal-alert", 2000),
+      row(12540, "yaml:noisy-recipe:2", "noisy-recipe", 2000),
     ]);
     const log = new RecipeRunLog({ dir });
     expect(log.query({ recipe: "butler-errand", limit: 500 })).toHaveLength(1);

--- a/src/runStore/__tests__/flipGate.test.ts
+++ b/src/runStore/__tests__/flipGate.test.ts
@@ -98,7 +98,7 @@ describe("ADR-0022 flip gate — what the new store actually buys", () => {
    * durability in TIME, and nothing reconciles the two. A high-frequency
    * recipe therefore evicts a worker's filing before it can settle — which is
    * not slow trust, it is trust that cannot be earned in principle. Every row
-   * here belongs to ONE noisy recipe, exactly as `gigsecure-withdrawal-alert`
+   * here belongs to ONE noisy recipe, exactly as `noisy-recipe`
    * held 85% of the live log.
    */
   it("JSONL loses the oldest evidence to rotation; SQLite does not", () => {


### PR DESCRIPTION
Four tracked files carried the name of a separate private project. This
repository is MIT and world-readable, so that name was published.

Replaced, with the substance kept in every case:

  docs/adr/0022  a table row attributed 85% of run volume to the named
                 project. Two violations in one line: the name, and an
                 operational statistic about it. The measurement is the
                 part that carries the argument, so it stays — "one
                 high-frequency recipe, 953 rows (85%)" makes exactly the
                 same point about rotation pressure while disclosing
                 nothing about who generated it.

  docs/privacy   a live support address on a published privacy page. The
                 page already offered the repository's issue tracker as a
                 contact route, so removing the address leaves a working
                 contact rather than none.

  2 test files   fixture recipe names, now the neutral placeholder the
                 CLAUDE.md privacy section prescribes. These were the
                 quietest instance: a real identifier reads as an ordinary
                 test string, which is precisely why the content gate
                 cannot catch it.

The identifier is deliberately absent from this commit message. Naming it
here would move the disclosure into permanent history rather than remove
it — a commit message cannot be edited later without rewriting history.

SCOPE, stated plainly: this removes it from the working tree only. It
remains in 9 earlier commits' diffs and 2 commit messages, the oldest from
2026-04-18. Removing it from history requires a rewrite and a force-push
over shared history, which is an operator decision, not a cleanup.

Verified: no occurrence remains in any tracked file; the two touched test
files pass (8/8); doc-links and business-content gates green. Note that
business-content passing proves nothing here — it reads tracked markdown
for commercial terms and never inspects code, tests or HTML, which is why
three of these four sat green for months.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)