### PR TITLE
fix(workers): classify the last 17 tools, closing the #1311 ratchet at zero

### DIFF
--- a/scripts/audit-tool-classification-allowlist.json
+++ b/scripts/audit-tool-classification-allowlist.json
@@ -18,25 +18,8 @@
     "2026-08-10 batch 1 (#1311): 144 entries cleared \u2014 every connector tool declaring isWrite:false, plus two camelCase aliases that were governed differently from the identical canonical tool.",
     "Remaining 42 are declared WRITES. Each needs a real judgement about whether it can be undone; loosening is the dangerous direction, so these get per-tool review, not a sweep.",
     "2026-08-10 batch 2 (#1311): 8 irreversible writes given a real domain (messaging, db-write). Reversibility unchanged \u2014 this batch loosens nothing; it only stops them sharing one undifferentiated bucket.",
-    "2026-08-14 batch 3 (#1311): 17 tracker / knowledge-base / support writes reviewed one by one. 15 given a real inverse (issue, tasks, docs-write, support \u2014 compensable); 2 (intercom.replyToConversation, zendesk.addComment) DEBUCKETED only, staying irreversible because they deliver text to a customer. obsidian.write_note deliberately left here: it overwrites with no version history and no WriteEffectLedger, so it has no inverse. outcomes.classify_issues also left here on purpose \u2014 it writes the outcome-log the trust ramp reads, so classifying it is a governance decision (a worker writing its own evidence), not a reversibility one."
+    "2026-08-14 batch 3 (#1311): 17 tracker / knowledge-base / support writes reviewed one by one. 15 given a real inverse (issue, tasks, docs-write, support \u2014 compensable); 2 (intercom.replyToConversation, zendesk.addComment) DEBUCKETED only, staying irreversible because they deliver text to a customer. obsidian.write_note deliberately left here: it overwrites with no version history and no WriteEffectLedger, so it has no inverse. outcomes.classify_issues also left here on purpose \u2014 it writes the outcome-log the trust ramp reads, so classifying it is a governance decision (a worker writing its own evidence), not a reversibility one.",
+    "2026-08-14 batch 4 (#1311): the final 17 \u2014 CRM, incident, monitoring-control, telemetry, infra, storage, scheduling and the trust-evidence writer \u2014 given real domains. DEBUCKETING ONLY: every one stays irreversible, exactly as the catch-all had it, so nothing is loosened. Where an inverse plausibly exists (delete the CRM record, unmute the monitor) the claim is deliberately unmade; over-restriction is the safe failure and each case deserves its own reviewable argument. The list is now EMPTY and the gate rejects any new unclassified tool."
   ],
-  "allow": [
-    "airtable.create_record",
-    "caldiy.cancel_booking",
-    "circleci.trigger_pipeline",
-    "cloudflare.create_dns_record",
-    "datadog.muteMonitor",
-    "grafana.create_annotation",
-    "hubspot.createNote",
-    "obsidian.write_note",
-    "outcomes.classify_issues",
-    "pagerduty.acknowledge_incident",
-    "pagerduty.add_incident_note",
-    "pagerduty.create_incident",
-    "pagerduty.resolve_incident",
-    "pipedrive.create_deal",
-    "posthog.capture_event",
-    "salesforce.create_record",
-    "supabase.upload_file"
-  ]
+  "allow": []
 }

--- a/src/workers/__tests__/actionClass.test.ts
+++ b/src/workers/__tests__/actionClass.test.ts
@@ -410,12 +410,107 @@ describe("tracker / docs / support writes (#1311 batch 3)", () => {
         "utf8",
       ),
     ) as { allow: string[] };
-    expect(allowlist.allow.length).toBeGreaterThan(0);
+    // Batch 3 asserted this list was non-empty, as a guard against the test
+    // passing vacuously. Batch 4 emptied it, and emptiness is now asserted
+    // directly by the batch-4 block below — so the vacuity concern is covered
+    // there and this test keeps only the invariant that matters: ANY entry
+    // that reappears must be genuinely unclassified.
     for (const tool of allowlist.allow) {
       expect(
         classifyActionClass(tool, {}).domain,
         `${tool} is on the ratchet but IS classified — delete its line`,
       ).toBe("other");
     }
+  });
+});
+
+describe("CRM + infrastructure writes (#1311 batch 4 — the last 17)", () => {
+  const DEBUCKETED: Array<[tool: string, domain: string]> = [
+    ["airtable.create_record", "crm-write"],
+    ["hubspot.createNote", "crm-write"],
+    ["pipedrive.create_deal", "crm-write"],
+    ["salesforce.create_record", "crm-write"],
+    ["pagerduty.create_incident", "incident"],
+    ["pagerduty.acknowledge_incident", "incident"],
+    ["pagerduty.add_incident_note", "incident"],
+    ["pagerduty.resolve_incident", "incident"],
+    ["datadog.muteMonitor", "monitoring-control"],
+    ["grafana.create_annotation", "telemetry-write"],
+    ["posthog.capture_event", "telemetry-write"],
+    ["cloudflare.create_dns_record", "infra"],
+    ["circleci.trigger_pipeline", "infra"],
+    ["supabase.upload_file", "storage-write"],
+    ["obsidian.write_note", "storage-write"],
+    ["caldiy.cancel_booking", "scheduling"],
+    ["outcomes.classify_issues", "trust-evidence"],
+  ];
+
+  it.each(DEBUCKETED)("puts %s in the %s domain", (tool, domain) => {
+    expect(classifyActionClass(tool, {}).domain).toBe(domain);
+  });
+
+  it("loosens NOTHING — every one stays irreversible", () => {
+    // The entire safety argument for this batch. These already classified
+    // irreversible via the `other` catch-all; each new domain is irreversible
+    // too, and blast tier derives from the tool NAME, so what the gate permits
+    // is byte-identical before and after. If this test ever goes red, the
+    // change under review is a LOOSENING and needs the per-tool argument
+    // batch 3 applied to trackers — not a bulk sweep.
+    for (const [tool] of DEBUCKETED) {
+      expect(
+        classifyActionClass(tool, {}).reversibility,
+        `${tool} must stay irreversible`,
+      ).toBe("irreversible");
+    }
+  });
+
+  it("keeps muting alerts apart from writing telemetry", () => {
+    // Both touch observability; only one makes the system quieter about
+    // failure. Sharing a bucket would let annotation-writing evidence
+    // authorise alert suppression.
+    const mute = classifyActionClass("datadog.muteMonitor", {});
+    const annotate = classifyActionClass("grafana.create_annotation", {});
+    expect(mute.domain).toBe("monitoring-control");
+    expect(annotate.domain).toBe("telemetry-write");
+    expect(mute.key).not.toBe(annotate.key);
+  });
+
+  it("gives the trust-evidence writer a domain of its own", () => {
+    // `outcomes.classify_issues` writes the outcome-log the ramp READS. It
+    // must never share a bucket with ordinary world-changing actions, because
+    // evidence about it is evidence about the evidence system.
+    const c = classifyActionClass("outcomes.classify_issues", {});
+    expect(c.domain).toBe("trust-evidence");
+    expect(c.reversibility).toBe("irreversible");
+    expect(c.key).not.toBe(classifyActionClass("file.write", {}).key);
+  });
+
+  it("marks only the externally-visible failures as brand-exposed", () => {
+    expect(
+      classifyActionClass("cloudflare.create_dns_record", {}).brandExposed,
+    ).toBe(true);
+    expect(classifyActionClass("caldiy.cancel_booking", {}).brandExposed).toBe(
+      true,
+    );
+    // Internal: embarrassing, not reputational.
+    expect(
+      classifyActionClass("pagerduty.create_incident", {}).brandExposed,
+    ).toBe(false);
+    expect(
+      classifyActionClass("salesforce.create_record", {}).brandExposed,
+    ).toBe(false);
+  });
+
+  it("leaves the ratchet EMPTY — every registered tool is now classified", () => {
+    const allowlist = JSON.parse(
+      readFileSync(
+        new URL(
+          "../../../scripts/audit-tool-classification-allowlist.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as { allow: string[] };
+    expect(allowlist.allow).toEqual([]);
   });
 });

--- a/src/workers/actionClass.ts
+++ b/src/workers/actionClass.ts
@@ -217,6 +217,74 @@ const DOMAIN_BY_TOOL: Record<string, string> = {
   "intercom.closeConversation": "support",
   "zendesk.updateStatus": "support",
 
+  // ── CRM + infrastructure writes (#1311 batch 4) ─────────────────────────
+  // The last 17 on the ratchet, and the batch that finishes #1311.
+  //
+  // DEBUCKETING ONLY. Every domain below is irreversible, which is exactly
+  // what these tools already got from the `other` catch-all, and blast tier
+  // comes from the tool NAME (classifyTool) rather than the domain. So this
+  // block changes NOTHING about what the gate permits — it only stops
+  // seventeen unrelated authorities sharing one undifferentiated bucket,
+  // which is what made that bucket meaningless as evidence.
+  //
+  // Several of these are arguably compensable — a CRM record can be deleted,
+  // an incident resolved, a monitor unmuted. Those claims are deliberately
+  // NOT made here. Loosening is the dangerous direction and each needs the
+  // same per-tool argument batch 3 applied to trackers; withholding it costs
+  // only over-restriction, which is the safe failure. Anyone making that case
+  // later does it in a change that can be reviewed on its own merits.
+
+  // Customer-record systems. Distinct from `tasks`/`issue`: this is business
+  // data about a third party, not our own work item.
+  "airtable.create_record": "crm-write",
+  "hubspot.createNote": "crm-write",
+  "pipedrive.create_deal": "crm-write",
+  "salesforce.create_record": "crm-write",
+
+  // Incident lifecycle. Creating one PAGES A HUMAN, and no later action
+  // un-pages them — the clearest irreversible-by-side-effect case in the set.
+  // Ack/resolve/note share the domain because they act on the same object and
+  // the same on-call audience.
+  "pagerduty.create_incident": "incident",
+  "pagerduty.acknowledge_incident": "incident",
+  "pagerduty.add_incident_note": "incident",
+  "pagerduty.resolve_incident": "incident",
+
+  // Suppressing alerting is its OWN authority, deliberately not `monitoring`
+  // alongside annotations: muting is the one action here that makes the system
+  // quieter about failure. Unmuting restores the monitor, never the page that
+  // was not sent during the window.
+  "datadog.muteMonitor": "monitoring-control",
+
+  // Telemetry writes — additive, observational, no control effect.
+  "grafana.create_annotation": "telemetry-write",
+  "posthog.capture_event": "telemetry-write",
+
+  // Live infrastructure. DNS propagation and a triggered pipeline both escape
+  // our control the moment they start: resolver caches obey TTLs we do not
+  // own, and a pipeline that has begun deploying cannot be un-begun.
+  "cloudflare.create_dns_record": "infra",
+  "circleci.trigger_pipeline": "infra",
+
+  // Object/file writes with no pre-image. `obsidian.write_note` was held back
+  // from batch 3's docs group for exactly this reason: it overwrites with no
+  // version history and is not covered by the WriteEffectLedger that makes
+  // `fs-write` reversible, so the prior content is simply gone.
+  "supabase.upload_file": "storage-write",
+  "obsidian.write_note": "storage-write",
+
+  // Cancelling someone's booking is visible to the other party immediately
+  // and re-booking is a new negotiation, not an undo.
+  "caldiy.cancel_booking": "scheduling",
+
+  // Writes the outcome-log THAT THE TRUST RAMP READS. Its own domain because
+  // the risk is categorically different from every other entry: this is not
+  // an action in the world, it is an action on the evidence the gate uses to
+  // decide future actions. Classifying it does not make it safe — the real
+  // control is that a worker must never reach it, which is a forbid-rule and
+  // an interface question, not a reversibility one (see #1311).
+  "outcomes.classify_issues": "trust-evidence",
+
   // ── connector reads (#1311 batch 1) ─────────────────────────────────────
   // Derived from the registry's own `isWrite: false`, never guessed from the
   // name. Writes are deliberately NOT swept: each needs a real reversibility
@@ -437,6 +505,22 @@ const REVERSIBILITY_BY_DOMAIN: Record<string, Reversibility> = {
   // first-class operation in both Zendesk and Intercom, so the inverse is
   // real; the residue is that the customer was told it was closed.
   support: "compensable",
+  // ── #1311 batch 4 — all irreversible, all unchanged from the catch-all ──
+  // Each of these tools already classified irreversible via `other`. Giving
+  // them a domain changes which bucket their evidence lands in and nothing
+  // else. Where a genuine inverse plausibly exists (delete the CRM record,
+  // resolve the incident, unmute the monitor), the claim is deliberately left
+  // unmade — see the block in DOMAIN_BY_TOOL.
+  "crm-write": "irreversible",
+  incident: "irreversible", // creating one pages a human; no action un-pages
+  "monitoring-control": "irreversible", // unmuting restores the monitor, not the missed page
+  "telemetry-write": "irreversible", // an emitted event is downstream immediately
+  infra: "irreversible", // DNS caches and started pipelines escape our control
+  "storage-write": "irreversible", // overwrite with no pre-image
+  scheduling: "irreversible", // the counterparty already saw the cancellation
+  // Acts on the EVIDENCE the gate reasons from, not on the world. The control
+  // that matters is unreachability from a recipe step, not reversibility.
+  "trust-evidence": "irreversible",
   payments: "irreversible", // a settled charge/transfer has no generic inverse;
   // a refund is a NEW compensating action with residue (fees kept, two
   // statement lines), not an undo — see src/recipes/fileRollback.ts's note.
@@ -499,6 +583,12 @@ const BRAND_EXPOSED_DOMAINS = new Set([
   // (`docs-write`) are deliberately NOT here — the failure is embarrassing
   // internally, not customer-visible.
   "support",
+  // #1311 batch 4. Only the two whose failure is visible OUTSIDE the company:
+  // a bad DNS record takes the public site down, and a cancelled booking is
+  // seen by the person who booked it. Incidents, CRM rows, telemetry and
+  // storage writes are internal — embarrassing, not reputational.
+  "infra",
+  "scheduling",
   "http",
   "payments", // a wrong charge is a customer-visible, reputational failure
 ]);


### PR DESCRIPTION
The final batch. The classification ratchet goes 17 -> 0, and the audit now
rejects any newly registered tool that has no domain.

DEBUCKETING ONLY — nothing is loosened. Every tool here already classified
`other:irreversible` via the catch-all; every domain added is irreversible
too, and blast tier derives from the tool NAME rather than the domain. What
the gate permits is byte-identical before and after. What changes is that
seventeen unrelated authorities stop sharing one bucket, which is what made
that bucket worthless as evidence.

  crm-write          airtable / hubspot / pipedrive / salesforce record
                     writes — business data about a third party, distinct
                     from our own work items
  incident           the four pagerduty verbs. Creating one PAGES A HUMAN
                     and no later action un-pages them
  monitoring-control datadog.muteMonitor, deliberately NOT grouped with
                     annotations: muting is the one action that makes the
                     system quieter about failure, and unmuting restores
                     the monitor, never the page not sent during the window
  telemetry-write    grafana annotations, posthog events — additive and
                     observational, no control effect
  infra              cloudflare DNS, circleci pipeline triggers. Both
                     escape our control once started: resolver caches obey
                     TTLs we do not own, a deploying pipeline cannot be
                     un-begun
  storage-write      supabase uploads and obsidian notes — overwrite with
                     no pre-image, and not covered by the WriteEffectLedger
                     that makes `fs-write` reversible
  scheduling         caldiy.cancel_booking — the counterparty saw it, and
                     re-booking is a new negotiation, not an undo
  trust-evidence     outcomes.classify_issues, alone, because its risk is
                     categorically different: it writes the outcome-log the
                     trust ramp READS. That is an action on the evidence the
                     gate reasons from, not an action in the world.
                     Classifying it does not make it safe — the control that
                     matters is that a worker cannot reach it, which is a
                     forbid-rule and an interface question

Several of these are arguably compensable: a CRM record can be deleted, an
incident resolved, a monitor unmuted. Those claims are deliberately NOT
made. Loosening is the dangerous direction and each deserves the same
per-tool argument batch 3 gave the trackers; withholding it costs only
over-restriction, which is the safe failure, and leaves any future
loosening as a change reviewable on its own merits.

brand-exposed is set only where the failure is visible OUTSIDE the company
— a bad DNS record takes the public site down, a cancelled booking is seen
by whoever booked it. Incidents, CRM rows, telemetry and storage writes are
internal: embarrassing, not reputational.

Batch 3's ratchet test asserted the allowlist was non-empty, as a guard
against passing vacuously. That assumption is now false by design, so the
test keeps only the invariant that matters — any entry that reappears must
be genuinely unclassified — and emptiness is asserted directly instead.

Verified by mutation: loosening `crm-write` to compensable fails two
independent guards. Full suite 9740/9740; ratchet audit reports 211
registered, 0 unclassified.

Closes #1311.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)