### PR TITLE
fix(paths): route the evidence ledgers through patchworkHome() (#1265)

### DIFF
--- a/scripts/audit-patchwork-home-allowlist.json
+++ b/scripts/audit-patchwork-home-allowlist.json
@@ -15,8 +15,6 @@
     "shape of this bug."
   ],
   "allow": [
-    "src/activationMetrics.ts",
-    "src/approvalPersistence.ts",
     "src/bridge.ts",
     "src/commands/dashboard.ts",
     "src/commands/recipe.ts",
@@ -44,7 +42,6 @@
     "src/recipeOrchestration.ts",
     "src/recipeRoutes.ts",
     "src/recipes/yamlRunner.ts",
-    "src/recipesHttp.ts",
-    "src/workers/outcomeStore.ts"
+    "src/recipesHttp.ts"
   ]
 }

--- a/src/__tests__/approvalPersistence.test.ts
+++ b/src/__tests__/approvalPersistence.test.ts
@@ -33,7 +33,9 @@ describe("resolveApprovalLogDir", () => {
     const customHome = path.join(os.tmpdir(), "pw-custom-home");
     process.env.PATCHWORK_HOME = customHome;
     try {
-      expect(resolveApprovalLogDir()).toBe(customHome);
+      // `path.resolve` for the same reason as outcomeStore: the override is
+      // resolved, and os.tmpdir() can differ from its resolved form.
+      expect(resolveApprovalLogDir()).toBe(path.resolve(customHome));
     } finally {
       if (prior === undefined) delete process.env.PATCHWORK_HOME;
       else process.env.PATCHWORK_HOME = prior;

--- a/src/__tests__/ledgerPathsHonourHome.test.ts
+++ b/src/__tests__/ledgerPathsHonourHome.test.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveApprovalLogDir } from "../approvalPersistence.js";
+import { resolveOutcomeLogDir } from "../workers/outcomeStore.js";
+
+const original = process.env.PATCHWORK_HOME;
+afterEach(() => {
+  if (original === undefined) delete process.env.PATCHWORK_HOME;
+  else process.env.PATCHWORK_HOME = original;
+});
+
+describe("evidence ledgers resolve their home through patchworkHome() (#1265)", () => {
+  it("pins a RELATIVE override to an absolute path", () => {
+    // The property gained by routing through the helper rather than reading
+    // the env var by hand. The old form returned the raw string, so the
+    // directory re-pointed whenever the process changed working directory —
+    // and this process has a CwdChanged hook, so that is a live hazard.
+    //
+    // An audit ledger that silently moves mid-session is the worst version of
+    // this bug: nothing errors, and the evidence simply lands somewhere the
+    // operator is not looking.
+    process.env.PATCHWORK_HOME = "relative-home";
+
+    for (const resolve of [resolveApprovalLogDir, resolveOutcomeLogDir]) {
+      const dir = resolve();
+      expect(path.isAbsolute(dir), `${dir} must be absolute`).toBe(true);
+      expect(dir).toBe(path.resolve("relative-home"));
+    }
+  });
+
+  it("still lets an explicit override win, unresolved", () => {
+    // Callers pass a tmp dir (tests) or the shadow's `patchworkDir`. That path
+    // is already what the caller means and must not be reinterpreted.
+    process.env.PATCHWORK_HOME = "/env/home";
+    expect(resolveApprovalLogDir("/explicit")).toBe("/explicit");
+    expect(resolveOutcomeLogDir("/explicit")).toBe("/explicit");
+  });
+
+  it("falls back to the legacy home when the override is unset or blank", () => {
+    // Blank must not resolve to the process cwd — that would scatter ledgers
+    // into whatever directory the bridge happened to start in.
+    for (const value of [undefined, "", "   "]) {
+      if (value === undefined) delete process.env.PATCHWORK_HOME;
+      else process.env.PATCHWORK_HOME = value;
+      const dir = resolveOutcomeLogDir();
+      expect(path.isAbsolute(dir)).toBe(true);
+      expect(dir.endsWith(".patchwork")).toBe(true);
+    }
+  });
+});

--- a/src/activationMetrics.ts
+++ b/src/activationMetrics.ts
@@ -24,9 +24,9 @@
  */
 
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { getAnalyticsPref } from "./analyticsPrefs.js";
+import { patchworkHome } from "./patchworkHome.js";
 import { writeFileAtomicSync } from "./writeFileAtomic.js";
 
 export interface ActivationMetrics {
@@ -60,8 +60,8 @@ const MAX_DAYS_RETAINED = 14;
 
 function resolveMetricsPath(configDir?: string): string {
   if (configDir) return path.join(configDir, METRICS_FILENAME);
-  const root =
-    process.env.PATCHWORK_HOME ?? path.join(os.homedir(), ".patchwork");
+  // `patchworkHome()` pins a relative override at read time (see its comment).
+  const root = patchworkHome();
   return path.join(root, METRICS_FILENAME);
 }
 

--- a/src/approvalPersistence.ts
+++ b/src/approvalPersistence.ts
@@ -1,9 +1,9 @@
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import path from "node:path";
 import type { ApprovalDecision, PendingApproval } from "./approvalQueue.js";
 import { withFileLockSync } from "./fileLockSync.js";
 import type { Logger } from "./logger.js";
+import { patchworkHome } from "./patchworkHome.js";
 
 /**
  * Durable event log backing `ApprovalQueue` (ADR-0018: "persist the request,
@@ -58,7 +58,11 @@ export type ApprovalLogEvent = ApprovalRequestEvent | ApprovalDecisionEvent;
  */
 export function resolveApprovalLogDir(override?: string): string {
   return (
-    override ?? process.env.PATCHWORK_HOME ?? path.join(homedir(), ".patchwork")
+    // `patchworkHome()` rather than reading the env var here: it `resolve()`s a
+    // RELATIVE override, so the path cannot re-point when the process changes
+    // directory. This process has a CwdChanged hook, so that is live, not
+    // theoretical — and an audit log that moves mid-session is the worst case.
+    override ?? patchworkHome()
   );
 }
 

--- a/src/workers/__tests__/outcomeStore.test.ts
+++ b/src/workers/__tests__/outcomeStore.test.ts
@@ -26,7 +26,11 @@ describe("resolveOutcomeLogDir — one file for every read + write path", () => 
 
   it("honors PATCHWORK_HOME when set (so write + trust-replay read agree)", () => {
     process.env.PATCHWORK_HOME = "/data/pw";
-    expect(resolveOutcomeLogDir()).toBe("/data/pw");
+    // Compared against `path.resolve`, not the literal: the override is
+    // resolved (#1265), and on Windows a POSIX-absolute path gains a drive
+    // letter — `/data/pw` becomes `D:\data\pw`. Asserting the literal passes
+    // on POSIX and fails on Windows for a path that is in fact correct.
+    expect(resolveOutcomeLogDir()).toBe(path.resolve("/data/pw"));
   });
 
   it("falls back to ~/.patchwork when PATCHWORK_HOME is unset", () => {

--- a/src/workers/outcomeStore.ts
+++ b/src/workers/outcomeStore.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, existsSync, readFileSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import path from "node:path";
+import { patchworkHome } from "../patchworkHome.js";
 import {
   type ActionRef,
   AmbiguousActionRefError,
@@ -38,7 +38,9 @@ export type OutcomeDisposition = "confirmed" | "junk" | "unknown";
  */
 export function resolveOutcomeLogDir(override?: string): string {
   return (
-    override ?? process.env.PATCHWORK_HOME ?? path.join(homedir(), ".patchwork")
+    // See `patchworkHome()`: a relative override is pinned at read time, so a
+    // cwd change cannot split the confirm-write path from the dial-read path.
+    override ?? patchworkHome()
   );
 }
 


### PR DESCRIPTION
First conversion batch, taking the PATCHWORK_HOME ratchet 31 -> 28. The
issue asks for ledgers before inbox/recipes before connectors, and these
are the ledgers: the approval log, the outcome log and the local activation
counters.

All three already read PATCHWORK_HOME, so this is not "they ignored the
override". They read it BY HAND:

    process.env.PATCHWORK_HOME ?? path.join(homedir(), ".patchwork")

which returns the raw string. `patchworkHome()` `resolve()`s it. The
difference only shows up for a RELATIVE override, and then it is real: the
hand-rolled form re-points whenever the process changes working directory,
and this process has a CwdChanged hook, so that is live rather than
theoretical.

An audit ledger that silently moves mid-session is the worst shape this bug
takes. Nothing errors. Evidence simply lands somewhere the operator is not
looking, and the only way to notice is to go hunting for a file that is
still in the old place. That is the same failure the ratchet's own header
describes, one directory deeper.

Second, smaller correction from the same change: a blank or whitespace-only
override now falls back to the legacy home instead of resolving to the
process cwd, which would have scattered ledgers into whatever directory the
bridge happened to start in.

An explicit `override` argument still wins and is deliberately NOT resolved
— callers pass a tmp dir or the shadow's `patchworkDir`, which already mean
exactly what they say.

Verified by mutation rather than by green: restoring the raw-env form fails
two of the three new assertions. Full suite 9751/9751; ratchet audit reports
28 files with 28 listed.

Refs #1265.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)