### PR TITLE
fix(workers): report manifest drift instead of silently reading the stale copy

### DIFF
--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -5,7 +5,8 @@
 
 import { mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, extname, join } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { recordRecipeRun } from "./activationMetrics.js";
@@ -47,6 +48,10 @@ import {
 import type { RecipeRunLog } from "./runLog.js";
 import type { Server } from "./server.js";
 import { boundaryForRecipe } from "./workers/boundaryPreview.js";
+import {
+  detectWorkerManifestDrift,
+  formatWorkerManifestDrift,
+} from "./workers/manifestDrift.js";
 import { OutcomeStore, resolveOutcomeLogDir } from "./workers/outcomeStore.js";
 import { computePendingConfirmations } from "./workers/runWorkerShadow.js";
 import {
@@ -539,6 +544,34 @@ export class RecipeOrchestration {
   // Server fn wiring
   // -------------------------------------------------------------------------
 
+  /**
+   * Emit the worker-manifest drift report, if there is anything to say.
+   *
+   * Fail-soft by construction: a diagnostic that can take the bridge down is
+   * worse than the condition it diagnoses. Resolving the shipped templates
+   * directory relative to this module keeps it correct for both a repo
+   * checkout and an npm install.
+   */
+  private reportWorkerManifestDrift(): void {
+    try {
+      const templatesDir = join(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "templates",
+        "workers",
+      );
+      const drift = detectWorkerManifestDrift({
+        templatesDir,
+        liveDir: join(homedir(), ".patchwork", "workers"),
+      });
+      for (const line of formatWorkerManifestDrift(drift)) {
+        this.deps.logger?.warn?.(line);
+      }
+    } catch {
+      // never block startup on a report
+    }
+  }
+
   wireServerFns(): void {
     const { server } = this.deps;
 
@@ -569,6 +602,14 @@ export class RecipeOrchestration {
       const workersDir = join(homedir(), ".patchwork", "workers");
       return listWorkers(workersDir);
     };
+
+    // #1358 — say so when the live manifests differ from the shipped ones.
+    // The gate reads the LOCAL copy, so a merged template fix has no effect
+    // until someone copies it, and the symptom is silent: a worker that
+    // under-attributes its own evidence looks exactly like a worker that has
+    // not run. Reported, never reconciled — overwriting would discard local
+    // policy edits (see manifestDrift.ts).
+    this.reportWorkerManifestDrift();
 
     server.loadWorkerContentFn = (id: string) => {
       const workersDir = join(homedir(), ".patchwork", "workers");

--- a/src/workers/__tests__/manifestDrift.test.ts
+++ b/src/workers/__tests__/manifestDrift.test.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  detectWorkerManifestDrift,
+  formatWorkerManifestDrift,
+} from "../manifestDrift.js";
+
+const roots: string[] = [];
+function dirs(): { templatesDir: string; liveDir: string } {
+  const root = mkdtempSync(path.join(tmpdir(), "pw-drift-"));
+  roots.push(root);
+  const templatesDir = path.join(root, "templates");
+  const liveDir = path.join(root, "live");
+  mkdirSync(templatesDir);
+  mkdirSync(liveDir);
+  return { templatesDir, liveDir };
+}
+function write(dir: string, name: string, body: string): void {
+  writeFileSync(path.join(dir, name), body);
+}
+afterEach(() => {
+  while (roots.length)
+    rmSync(roots.pop() as string, { recursive: true, force: true });
+});
+
+describe("detectWorkerManifestDrift (#1358)", () => {
+  it("reports a manifest whose live copy differs from the template", () => {
+    // The #1348 shape: the template gained an `owns` entry, the live copy did
+    // not, and the gate silently attributed less evidence than it should.
+    const { templatesDir, liveDir } = dirs();
+    write(templatesDir, "a.worker.yaml", "owns:\n  - issue\n  - fs-write\n");
+    write(liveDir, "a.worker.yaml", "owns:\n  - issue\n");
+
+    const drift = detectWorkerManifestDrift({ templatesDir, liveDir });
+    expect(drift.drifted).toHaveLength(1);
+    expect(drift.drifted[0]?.name).toBe("a.worker.yaml");
+    expect(drift.drifted[0]?.templateHash).not.toBe(drift.drifted[0]?.liveHash);
+  });
+
+  it("says nothing when the copies match", () => {
+    const { templatesDir, liveDir } = dirs();
+    write(templatesDir, "a.worker.yaml", "owns:\n  - issue\n");
+    write(liveDir, "a.worker.yaml", "owns:\n  - issue\n");
+
+    const drift = detectWorkerManifestDrift({ templatesDir, liveDir });
+    expect(drift.drifted).toEqual([]);
+    // A report that always prints is one nobody reads.
+    expect(formatWorkerManifestDrift(drift)).toEqual([]);
+  });
+
+  it("does NOT flag an operator-authored worker as a problem", () => {
+    // Four of the eight manifests on the reference install have no template.
+    // Treating those as findings would train people to ignore the report.
+    const { templatesDir, liveDir } = dirs();
+    write(templatesDir, "shipped.worker.yaml", "owns:\n  - issue\n");
+    write(liveDir, "shipped.worker.yaml", "owns:\n  - issue\n");
+    write(liveDir, "mine.worker.yaml", "owns:\n  - tasks\n");
+
+    const drift = detectWorkerManifestDrift({ templatesDir, liveDir });
+    expect(drift.localOnly).toEqual(["mine.worker.yaml"]);
+    expect(drift.drifted).toEqual([]);
+    expect(formatWorkerManifestDrift(drift)).toEqual([]);
+  });
+
+  it("reports a shipped manifest that was never installed", () => {
+    const { templatesDir, liveDir } = dirs();
+    write(templatesDir, "shipped.worker.yaml", "owns:\n  - issue\n");
+
+    const drift = detectWorkerManifestDrift({ templatesDir, liveDir });
+    expect(drift.missingLocally).toEqual(["shipped.worker.yaml"]);
+    expect(formatWorkerManifestDrift(drift).join("\n")).toContain(
+      "not installed",
+    );
+  });
+
+  it("ignores line-ending differences", () => {
+    // Otherwise a Windows checkout reports every manifest as drifted, and a
+    // signal that always fires is indistinguishable from one that never does.
+    const { templatesDir, liveDir } = dirs();
+    write(templatesDir, "a.worker.yaml", "owns:\n  - issue\n");
+    write(liveDir, "a.worker.yaml", "owns:\r\n  - issue\r\n");
+
+    expect(
+      detectWorkerManifestDrift({ templatesDir, liveDir }).drifted,
+    ).toEqual([]);
+  });
+
+  it("ignores non-manifest files in either directory", () => {
+    const { templatesDir, liveDir } = dirs();
+    write(templatesDir, "README.md", "notes");
+    write(liveDir, "notes.txt", "scratch");
+
+    const drift = detectWorkerManifestDrift({ templatesDir, liveDir });
+    expect(drift).toEqual({ drifted: [], missingLocally: [], localOnly: [] });
+  });
+
+  it("does not throw when a directory is missing entirely", () => {
+    // A fresh install has no live workers dir. A drift report that crashes the
+    // bridge would be a worse failure than the drift it describes.
+    const { templatesDir } = dirs();
+    expect(() =>
+      detectWorkerManifestDrift({
+        templatesDir,
+        liveDir: path.join(templatesDir, "does-not-exist"),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/workers/manifestDrift.ts
+++ b/src/workers/manifestDrift.ts
@@ -1,0 +1,137 @@
+/**
+ * Worker-manifest drift detection (#1358).
+ *
+ * `templates/workers/` (shipped, versioned) and `~/.patchwork/workers/` (what
+ * the gate actually reads) have no sync mechanism. Fixing a manifest in the
+ * repo has no effect on a running bridge until someone hand-copies the file.
+ *
+ * The failure is silent and it is not hypothetical. In #1348 a worker's
+ * manifest was missing `fs-write` from its `owns` list, so roughly a quarter
+ * of its evidence classified as unowned and was dropped. The template fix
+ * merged; the live gate kept reading the stale copy and kept dropping
+ * evidence. Nothing errored — the gate read a valid-looking manifest and
+ * simply attributed less than it should have.
+ *
+ * ## Why this REPORTS and does not reconcile
+ *
+ * The issue offers either. Reporting is the correct one, for two reasons that
+ * both point the same way:
+ *
+ * 1. **Copying would clobber.** The live directory legitimately holds
+ *    operator-authored workers that have no template, and an operator may
+ *    have deliberately tuned a shipped one (an `autonomyCeiling` is exactly
+ *    the kind of thing you lower locally and do not want restored). A sync
+ *    that overwrites is a writer replacing a record it never checked it still
+ *    owned — the same shape as the lock-file delete (#1359) and the config
+ *    read-modify-write (#1361), both fixed the same week.
+ *
+ * 2. **The dangerous direction is silent, not loud.** A stale manifest
+ *    under-attributes evidence, so the visible symptom is a worker that never
+ *    earns trust — indistinguishable from a worker that simply has not run.
+ *    Saying so out loud costs nothing; guessing which copy is authoritative
+ *    can destroy an operator's policy.
+ *
+ * `localOnly` is therefore reported as INFORMATION and never as a warning: a
+ * worker with no template is the normal case for anything the operator wrote,
+ * and flagging it would train people to ignore the report.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export interface ManifestDrift {
+  /** Present in both, contents differ. The actionable case. */
+  drifted: Array<{ name: string; templateHash: string; liveHash: string }>;
+  /** Shipped with the product, absent from the live directory. */
+  missingLocally: string[];
+  /** Present locally with no template — operator-authored. Informational. */
+  localOnly: string[];
+}
+
+const MANIFEST_RE = /\.worker\.ya?ml$/i;
+
+function manifestsIn(dir: string): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!existsSync(dir)) return out;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    if (!MANIFEST_RE.test(name)) continue;
+    try {
+      // Hash CONTENT, not mtime. A copy changes mtime without changing
+      // policy, and an edit can preserve it; only the bytes decide whether
+      // the gate is reading something different from what shipped.
+      const raw = readFileSync(path.join(dir, name), "utf-8");
+      // Normalise line endings so a Windows checkout does not report every
+      // manifest as drifted — that would be a signal that always fires.
+      const normalised = raw.replace(/\r\n/g, "\n");
+      out.set(name, createHash("sha256").update(normalised).digest("hex"));
+    } catch {
+      // Unreadable file: skip rather than throw. A drift REPORT that crashes
+      // the bridge would be a worse failure than the drift it describes.
+    }
+  }
+  return out;
+}
+
+export function detectWorkerManifestDrift(opts: {
+  templatesDir: string;
+  liveDir: string;
+}): ManifestDrift {
+  const templates = manifestsIn(opts.templatesDir);
+  const live = manifestsIn(opts.liveDir);
+
+  const drifted: ManifestDrift["drifted"] = [];
+  const missingLocally: string[] = [];
+  for (const [name, templateHash] of templates) {
+    const liveHash = live.get(name);
+    if (liveHash === undefined) {
+      missingLocally.push(name);
+    } else if (liveHash !== templateHash) {
+      drifted.push({ name, templateHash, liveHash });
+    }
+  }
+
+  const localOnly = [...live.keys()].filter((n) => !templates.has(n));
+
+  drifted.sort((a, b) => a.name.localeCompare(b.name));
+  missingLocally.sort();
+  localOnly.sort();
+  return { drifted, missingLocally, localOnly };
+}
+
+/**
+ * Human-readable lines for the startup report, or `[]` when there is nothing
+ * worth saying. Returning empty rather than "no drift" is deliberate: a
+ * startup line that always prints is one people stop reading, and this one
+ * needs to be noticed on the rare occasion it appears.
+ */
+export function formatWorkerManifestDrift(drift: ManifestDrift): string[] {
+  const lines: string[] = [];
+  if (drift.drifted.length > 0) {
+    lines.push(
+      `[workers] ${drift.drifted.length} manifest(s) differ from the shipped template — ` +
+        "the gate reads the LOCAL copy, so a template fix has not taken effect:",
+    );
+    for (const d of drift.drifted) {
+      lines.push(
+        `  ${d.name}  template ${d.templateHash.slice(0, 12)} vs live ${d.liveHash.slice(0, 12)}`,
+      );
+    }
+    lines.push(
+      "  Review the differences and copy deliberately — this is NOT synced automatically, " +
+        "because overwriting would discard local policy edits.",
+    );
+  }
+  if (drift.missingLocally.length > 0) {
+    lines.push(
+      `[workers] ${drift.missingLocally.length} shipped manifest(s) are not installed: ${drift.missingLocally.join(", ")}`,
+    );
+  }
+  return lines;
+}


### PR DESCRIPTION
`templates/workers/` and `~/.patchwork/workers/` have no sync mechanism, so
fixing a manifest in the repo has no effect on a running bridge until
someone hand-copies the file. The gate reads the LOCAL copy.

The failure is silent and it has already happened. In #1348 a worker's
manifest was missing `fs-write` from `owns`, so roughly a quarter of its
evidence classified as unowned and was dropped. The template fix merged; the
live gate kept reading the stale copy and kept dropping evidence. Nothing
errored — a valid-looking manifest simply attributed less than it should.

The symptom is the worst kind: a worker that under-attributes its own
evidence is indistinguishable from a worker that has not run.

REPORTS, does not reconcile. The issue offers either; two independent
reasons point the same way:

  Copying would clobber. The live directory legitimately holds
  operator-authored workers with no template (4 of 8 on the reference
  install), and an operator may have deliberately lowered an
  `autonomyCeiling` locally — precisely the thing you do not want restored.
  A sync that overwrites is a writer replacing a record it never checked it
  still owned: the same shape as the lock-file delete (#1359) and the config
  read-modify-write (#1361), both fixed this week.

  The dangerous direction is silence, not noise. Saying so costs nothing;
  guessing which copy is authoritative can destroy an operator's policy.

`localOnly` is therefore INFORMATION and never a warning — flagging normal
operator-authored workers would train people to ignore the report. For the
same reason the report emits nothing at all when there is nothing to say: a
startup line that always prints is one nobody reads.

Hashes CONTENT, not mtime — a copy changes mtime without changing policy and
an edit can preserve it — and normalises line endings, or a Windows checkout
would report every manifest as drifted, which is a signal that always fires.
Fail-soft throughout: a missing directory, an unreadable file or any throw
degrades to a quieter report, never a failed startup. A diagnostic that can
take the bridge down is worse than the condition it diagnoses.

Verified end to end against the real install, with a check that could fail:
quiet when the copies match, fires naming both hashes when a byte is
appended to a live manifest, quiet again once restored. Template resolution
confirmed for both layouts — `dist/../templates/workers` exists in a
checkout, and `templates` is in package.json `files[]`, so an npm install
reports too rather than silently skipping.

Full suite 9755/9755.

Closes #1358.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)