### PR TITLE
fix(connectors): resolve the OAuth redirect URI per call, not at import

### DIFF
--- a/src/connectors/__tests__/redirectUriNotFrozen.test.ts
+++ b/src/connectors/__tests__/redirectUriNotFrozen.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { connectorRedirectUri } from "../connectorRedirectUri.js";
+
+/**
+ * #1266 defect 1 — the redirect URI must track the environment at CALL time.
+ *
+ * Six connectors bound it to a module-level `const`, freezing whichever base
+ * URL existed when the module first loaded. Any later change was ignored and
+ * the connector kept building auth URLs against a stale base, with no error:
+ * the failure surfaces at the OAuth provider as a redirect_uri mismatch, far
+ * from its cause.
+ */
+const KEYS = ["PATCHWORK_DASHBOARD_URL", "PATCHWORK_BRIDGE_URL"] as const;
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+  for (const k of KEYS) delete process.env[k];
+});
+afterEach(() => {
+  for (const k of KEYS) {
+    const v = saved[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("connectorRedirectUri reflects the environment at call time", () => {
+  it("changes when the dashboard URL changes between calls", () => {
+    process.env.PATCHWORK_DASHBOARD_URL = "https://first.example.test";
+    const before = connectorRedirectUri("gmail");
+    process.env.PATCHWORK_DASHBOARD_URL = "https://second.example.test";
+    const after = connectorRedirectUri("gmail");
+
+    expect(before).toContain("first.example.test");
+    expect(after).toContain("second.example.test");
+    // The whole point: a value captured once cannot do this.
+    expect(after).not.toBe(before);
+  });
+
+  it("falls back to the bridge URL, then to a default", () => {
+    process.env.PATCHWORK_BRIDGE_URL = "https://bridge.example.test";
+    expect(connectorRedirectUri("monday")).toContain("bridge.example.test");
+
+    delete process.env.PATCHWORK_BRIDGE_URL;
+    expect(connectorRedirectUri("monday")).toMatch(/^https?:\/\//);
+  });
+
+  it("keeps the per-connector callback path", () => {
+    process.env.PATCHWORK_DASHBOARD_URL = "https://host.example.test";
+    for (const slug of [
+      "gmail",
+      "google-calendar",
+      "google-drive",
+      "google-docs",
+      "salesforce",
+      "monday",
+    ]) {
+      expect(connectorRedirectUri(slug)).toBe(
+        `https://host.example.test/connections/${slug}/callback`,
+      );
+    }
+  });
+});
+
+describe("no connector freezes the redirect URI at import (#1266)", () => {
+  it("has no module-level REDIRECT_URI constant left", async () => {
+    // A source-level assertion because the defect IS the binding site: a
+    // behavioural test of one connector would pass while another stayed
+    // frozen, and this is exactly the drift class the issue describes.
+    const { readFileSync, readdirSync } = await import("node:fs");
+    const path = await import("node:path");
+    const dir = path.join(process.cwd(), "src", "connectors");
+    const offenders: string[] = [];
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".ts")) continue;
+      const src = readFileSync(path.join(dir, f), "utf-8");
+      if (/^const\s+REDIRECT_URI\s*=/m.test(src)) offenders.push(f);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/connectors/gmail.ts
+++ b/src/connectors/gmail.ts
@@ -26,7 +26,21 @@ import {
 } from "./tokenStorage.js";
 
 const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
-const REDIRECT_URI = connectorRedirectUri("gmail");
+/**
+ * Resolved per CALL, never frozen at import (#1266).
+ *
+ * `connectorRedirectUri()` reads PATCHWORK_DASHBOARD_URL -> PATCHWORK_BRIDGE_URL
+ * -> a localhost default. Binding it to a module-level `const` captured
+ * whichever values existed when the module first loaded, so any later change
+ * was ignored and the connector kept building auth URLs against a stale base
+ * until the process restarted — with no error to explain the mismatch.
+ *
+ * The redirect URI must match what the OAuth app has registered, so a stale
+ * one fails at the provider, far from the cause.
+ */
+function redirectUri(): string {
+  return connectorRedirectUri("gmail");
+}
 function getTokenPath() {
   const dir =
     process.env.PATCHWORK_TOKEN_DIR ??
@@ -114,7 +128,7 @@ function deleteTokens(): void {
 function buildAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: clientId(),
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     response_type: "code",
     scope: SCOPES.join(" "),
     access_type: "offline",
@@ -132,7 +146,7 @@ async function exchangeCode(code: string): Promise<GmailTokens> {
       code,
       client_id: clientId(),
       client_secret: clientSecret(),
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: redirectUri(),
       grant_type: "authorization_code",
     }).toString(),
   });

--- a/src/connectors/googleCalendar.ts
+++ b/src/connectors/googleCalendar.ts
@@ -24,7 +24,21 @@ import {
 } from "./tokenStorage.js";
 
 const SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"];
-const REDIRECT_URI = connectorRedirectUri("google-calendar");
+/**
+ * Resolved per CALL, never frozen at import (#1266).
+ *
+ * `connectorRedirectUri()` reads PATCHWORK_DASHBOARD_URL -> PATCHWORK_BRIDGE_URL
+ * -> a localhost default. Binding it to a module-level `const` captured
+ * whichever values existed when the module first loaded, so any later change
+ * was ignored and the connector kept building auth URLs against a stale base
+ * until the process restarted — with no error to explain the mismatch.
+ *
+ * The redirect URI must match what the OAuth app has registered, so a stale
+ * one fails at the provider, far from the cause.
+ */
+function redirectUri(): string {
+  return connectorRedirectUri("google-calendar");
+}
 const CALENDAR_API = "https://www.googleapis.com/calendar/v3";
 function getTokenPath() {
   const dir =
@@ -150,7 +164,7 @@ export function getStatus(): ConnectorStatus {
 function buildAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: clientId(),
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     response_type: "code",
     scope: SCOPES.join(" "),
     access_type: "offline",
@@ -170,7 +184,7 @@ async function exchangeCode(
       code,
       client_id: clientId(),
       client_secret: clientSecret(),
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: redirectUri(),
       grant_type: "authorization_code",
     }).toString(),
   });

--- a/src/connectors/googleDocs.ts
+++ b/src/connectors/googleDocs.ts
@@ -12,7 +12,21 @@ import {
 } from "./tokenStorage.js";
 
 const SCOPES = ["https://www.googleapis.com/auth/documents.readonly"];
-const REDIRECT_URI = connectorRedirectUri("google-docs");
+/**
+ * Resolved per CALL, never frozen at import (#1266).
+ *
+ * `connectorRedirectUri()` reads PATCHWORK_DASHBOARD_URL -> PATCHWORK_BRIDGE_URL
+ * -> a localhost default. Binding it to a module-level `const` captured
+ * whichever values existed when the module first loaded, so any later change
+ * was ignored and the connector kept building auth URLs against a stale base
+ * until the process restarted — with no error to explain the mismatch.
+ *
+ * The redirect URI must match what the OAuth app has registered, so a stale
+ * one fails at the provider, far from the cause.
+ */
+function redirectUri(): string {
+  return connectorRedirectUri("google-docs");
+}
 const DOCS_API = "https://docs.googleapis.com";
 
 function getTokenPath() {
@@ -184,7 +198,7 @@ export function getStatus(): ConnectorStatus {
 function buildAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: clientId(),
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     response_type: "code",
     scope: SCOPES.join(" "),
     access_type: "offline",
@@ -204,7 +218,7 @@ async function exchangeCode(
       code,
       client_id: clientId(),
       client_secret: clientSecret(),
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: redirectUri(),
       grant_type: "authorization_code",
     }).toString(),
   });

--- a/src/connectors/googleDrive.ts
+++ b/src/connectors/googleDrive.ts
@@ -12,7 +12,21 @@ import {
 } from "./tokenStorage.js";
 
 const SCOPES = ["https://www.googleapis.com/auth/drive.readonly"];
-const REDIRECT_URI = connectorRedirectUri("google-drive");
+/**
+ * Resolved per CALL, never frozen at import (#1266).
+ *
+ * `connectorRedirectUri()` reads PATCHWORK_DASHBOARD_URL -> PATCHWORK_BRIDGE_URL
+ * -> a localhost default. Binding it to a module-level `const` captured
+ * whichever values existed when the module first loaded, so any later change
+ * was ignored and the connector kept building auth URLs against a stale base
+ * until the process restarted — with no error to explain the mismatch.
+ *
+ * The redirect URI must match what the OAuth app has registered, so a stale
+ * one fails at the provider, far from the cause.
+ */
+function redirectUri(): string {
+  return connectorRedirectUri("google-drive");
+}
 
 function getTokenPath() {
   const dir =
@@ -115,7 +129,7 @@ export function getStatus(): ConnectorStatus {
 function buildAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: clientId(),
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     response_type: "code",
     scope: SCOPES.join(" "),
     access_type: "offline",
@@ -135,7 +149,7 @@ async function exchangeCode(
       code,
       client_id: clientId(),
       client_secret: clientSecret(),
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: redirectUri(),
       grant_type: "authorization_code",
     }).toString(),
   });

--- a/src/connectors/monday.ts
+++ b/src/connectors/monday.ts
@@ -32,7 +32,21 @@ const SCOPES = [
   "users:read",
   "tags:read",
 ];
-const REDIRECT_URI = connectorRedirectUri("monday");
+/**
+ * Resolved per CALL, never frozen at import (#1266).
+ *
+ * `connectorRedirectUri()` reads PATCHWORK_DASHBOARD_URL -> PATCHWORK_BRIDGE_URL
+ * -> a localhost default. Binding it to a module-level `const` captured
+ * whichever values existed when the module first loaded, so any later change
+ * was ignored and the connector kept building auth URLs against a stale base
+ * until the process restarted — with no error to explain the mismatch.
+ *
+ * The redirect URI must match what the OAuth app has registered, so a stale
+ * one fails at the provider, far from the cause.
+ */
+function redirectUri(): string {
+  return connectorRedirectUri("monday");
+}
 const MONDAY_AUTH_URL = "https://auth.monday.com/oauth2/authorize";
 const MONDAY_TOKEN_URL = "https://auth.monday.com/oauth2/token";
 const MONDAY_API = "https://api.monday.com/v2";
@@ -240,7 +254,7 @@ export function getStatus(): ConnectorStatus {
 function buildAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: clientId(),
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     response_type: "code",
     scope: SCOPES.join(" "),
     state,
@@ -258,7 +272,7 @@ async function exchangeCode(
       code,
       client_id: clientId(),
       client_secret: clientSecret(),
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: redirectUri(),
       grant_type: "authorization_code",
     }).toString(),
   });

--- a/src/connectors/salesforce.ts
+++ b/src/connectors/salesforce.ts
@@ -36,7 +36,21 @@ import {
 // `refresh_token` — issue a refresh_token grant
 // `offline_access` — keep the refresh_token valid while user is offline
 const SCOPES = ["api", "refresh_token", "offline_access"];
-const REDIRECT_URI = connectorRedirectUri("salesforce");
+/**
+ * Resolved per CALL, never frozen at import (#1266).
+ *
+ * `connectorRedirectUri()` reads PATCHWORK_DASHBOARD_URL -> PATCHWORK_BRIDGE_URL
+ * -> a localhost default. Binding it to a module-level `const` captured
+ * whichever values existed when the module first loaded, so any later change
+ * was ignored and the connector kept building auth URLs against a stale base
+ * until the process restarted — with no error to explain the mismatch.
+ *
+ * The redirect URI must match what the OAuth app has registered, so a stale
+ * one fails at the provider, far from the cause.
+ */
+function redirectUri(): string {
+  return connectorRedirectUri("salesforce");
+}
 const API_VERSION = "v59.0";
 const DEFAULT_LOGIN_HOST = "login.salesforce.com";
 
@@ -291,7 +305,7 @@ export function getStatus(): ConnectorStatus {
 function buildAuthUrl(state: string): string {
   const params = new URLSearchParams({
     client_id: clientId(),
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: redirectUri(),
     response_type: "code",
     scope: SCOPES.join(" "),
     state,
@@ -319,7 +333,7 @@ async function exchangeCode(code: string): Promise<SalesforceTokens> {
       code,
       client_id: clientId(),
       client_secret: clientSecret(),
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: redirectUri(),
       grant_type: "authorization_code",
     }).toString(),
   });


### PR DESCRIPTION
Six connectors bound their redirect URI to a module-level constant:

    const REDIRECT_URI = connectorRedirectUri("gmail");

`connectorRedirectUri()` reads PATCHWORK_DASHBOARD_URL, then
PATCHWORK_BRIDGE_URL, then a localhost default. Evaluating it at import
captured whichever values existed when the module first loaded, so any
later change was ignored and the connector kept building auth URLs against
a stale base until the process restarted.

The consequence is worse than a wrong string. A redirect URI must match
what the OAuth app has registered, so a stale one fails at the PROVIDER —
an opaque redirect_uri mismatch, arbitrarily far from the cause, with
nothing locally to suggest the base URL was the problem.

Converted to a call at use site in gmail, googleCalendar, googleDrive,
googleDocs, salesforce and monday. The connectors that already resolved per
call (asana, discord, gitlab) were already correct and are untouched.

The guard is a SOURCE-level assertion — no `const REDIRECT_URI = ` may
remain anywhere in `src/connectors/` — rather than a behavioural test of one
connector. The defect is the binding site, so a behavioural test would pass
on whichever connector it exercised while another stayed frozen, which is
precisely the add-a-connector drift class the issue is about. Verified by
mutation: re-freezing a single connector fails the guard.

Full suite 9762/9762.

Refs #1266 — defect 1 only. Defect 2 (registry-driven callback dispatch, to
replace the hardcoded if-chain in connectorRoutes.ts) is a larger change and
is deliberately not attempted here, so the issue stays open.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)