### PR TITLE
fix(paths): route recipe + orchestration paths through patchworkHome() (#1265)

### DIFF
--- a/scripts/audit-patchwork-home-allowlist.json
+++ b/scripts/audit-patchwork-home-allowlist.json
@@ -12,7 +12,8 @@
     "",
     "Converted 2026-08-10: src/bridge.ts and src/tools/index.ts ledger roots \u2014 the",
     "four audit ledgers, where evidence silently landing elsewhere is the worst",
-    "shape of this bug."
+    "shape of this bug.",
+    "2026-08-14 batch 2 (#1265): recipes/orchestration paths converted (31 -> 25). inboxRoutes.ts and recipes/yamlRunner.ts were converted and then DELIBERATELY REVERTED: the inbox is written via `~` expansion / os.homedir() in bridge.ts and yamlRunner.ts, so converting only the reader (or only the containment check) makes reader and writer resolve to different directories whenever PATCHWORK_HOME is set \u2014 the exact split this issue is about, moved rather than fixed. Converting them needs `~` expansion to route through the same helper, which changes where recipe file writes LAND, and that belongs in its own change."
   ],
   "allow": [
     "src/bridge.ts",
@@ -39,9 +40,6 @@
     "src/identity/roster.ts",
     "src/inboxRoutes.ts",
     "src/index.ts",
-    "src/recipeOrchestration.ts",
-    "src/recipeRoutes.ts",
-    "src/recipes/yamlRunner.ts",
-    "src/recipesHttp.ts"
+    "src/recipes/yamlRunner.ts"
   ]
 }

--- a/src/__tests__/recipeOrchestration.test.ts
+++ b/src/__tests__/recipeOrchestration.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { patchworkPath } from "../patchworkHome.js";
 
 // These imports will fail until src/recipeOrchestration.ts exists.
 let RecipeOrchestration: any;
@@ -515,9 +516,11 @@ describe("RecipeOrchestration", () => {
       ledgerDir?: string;
     };
     expect(passedDeps.manualRunId).toBe("deadbeefdeadbeefdeadbeefdeadbeef");
-    expect(passedDeps.ledgerDir).toMatch(
-      /[/\\]\.patchwork[/\\]webhook-effect-ledger$/,
-    );
+    // Compared against `patchworkPath`, not a literal `.patchwork` segment:
+    // the ledger dir now honours PATCHWORK_HOME (#1265), and under an override
+    // there is no `.patchwork` component at all. Asserting the old shape would
+    // fail precisely when the override works.
+    expect(passedDeps.ledgerDir).toBe(patchworkPath("webhook-effect-ledger"));
   });
 
   it("fireYamlRecipe() — omits manualRunId/ledgerDir when no deliveryId is given (scheduler/dashboard-fired runs)", async () => {

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -4,7 +4,6 @@
  */
 
 import { mkdirSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { basename, dirname, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,6 +12,7 @@ import { recordRecipeRun } from "./activationMetrics.js";
 import type { ClaudeOrchestrator } from "./claudeOrchestrator.js";
 import { truncateUtf8Bytes } from "./drivers/outputCap.js";
 import { loadConfig } from "./patchworkConfig.js";
+import { patchworkPath } from "./patchworkHome.js";
 import { getConfigDisabledNames } from "./recipes/disabledMarkers.js";
 import {
   elicitMissingVars,
@@ -460,10 +460,8 @@ export async function resolveWorkerIdForRecipe(
   workersDir?: string,
 ): Promise<string | undefined> {
   try {
-    const os = await import("node:os");
-    const path = await import("node:path");
     const { loadWorkersFromDir } = await import("./workers/workerLoader.js");
-    const dir = workersDir ?? path.join(os.homedir(), ".patchwork", "workers");
+    const dir = workersDir ?? patchworkPath("workers");
     const workers = loadWorkersFromDir(dir);
     // Ambiguous → undefined, never guess. Two worker manifests declaring
     // the same `recipe:` previously resolved to whichever sorted first
@@ -562,7 +560,7 @@ export class RecipeOrchestration {
       );
       const drift = detectWorkerManifestDrift({
         templatesDir,
-        liveDir: join(homedir(), ".patchwork", "workers"),
+        liveDir: patchworkPath("workers"),
       });
       for (const line of formatWorkerManifestDrift(drift)) {
         this.deps.logger?.warn?.(line);
@@ -576,7 +574,7 @@ export class RecipeOrchestration {
     const { server } = this.deps;
 
     server.recipesFn = () => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return listInstalledRecipes(recipesDir) as unknown as Record<
         string,
         unknown
@@ -584,22 +582,22 @@ export class RecipeOrchestration {
     };
 
     server.loadRecipeContentFn = (name: string) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return loadRecipeContent(recipesDir, name);
     };
 
     server.saveRecipeContentFn = (name: string, content: string) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return saveRecipeContent(recipesDir, name, content);
     };
 
     server.deleteRecipeContentFn = (name: string) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return deleteRecipeContent(recipesDir, name);
     };
 
     server.listWorkersFn = () => {
-      const workersDir = join(homedir(), ".patchwork", "workers");
+      const workersDir = patchworkPath("workers");
       return listWorkers(workersDir);
     };
 
@@ -612,28 +610,28 @@ export class RecipeOrchestration {
     this.reportWorkerManifestDrift();
 
     server.loadWorkerContentFn = (id: string) => {
-      const workersDir = join(homedir(), ".patchwork", "workers");
+      const workersDir = patchworkPath("workers");
       return loadWorkerContent(workersDir, id);
     };
 
     server.saveWorkerContentFn = (id: string, content: string) => {
-      const workersDir = join(homedir(), ".patchwork", "workers");
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const workersDir = patchworkPath("workers");
+      const recipesDir = patchworkPath("recipes");
       return saveWorkerContent(workersDir, recipesDir, id, content);
     };
 
     server.lintWorkerContentFn = (content: string) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return lintWorkerContent(content, recipesDir);
     };
 
     server.archiveRecipeFn = (name: string) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return archiveRecipe(recipesDir, name);
     };
 
     server.duplicateRecipeFn = (name: string) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return duplicateRecipe(recipesDir, name);
     };
 
@@ -642,7 +640,7 @@ export class RecipeOrchestration {
       targetName: string,
       options?: { force?: boolean },
     ) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return promoteRecipeVariant(recipesDir, variantName, targetName, options);
     };
 
@@ -650,7 +648,7 @@ export class RecipeOrchestration {
       lintRecipeContent(content);
 
     server.setRecipeTrustFn = (name: string, level: string) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return setTrustLevel(
         recipesDir,
         name,
@@ -660,7 +658,7 @@ export class RecipeOrchestration {
 
     // biome-ignore lint/suspicious/noExplicitAny: matches Server type
     server.saveRecipeFn = (draft: any) => {
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       return saveRecipe(recipesDir, draft);
     };
 
@@ -834,7 +832,7 @@ export class RecipeOrchestration {
 
       try {
         const { findYamlRecipePath } = await import("./recipesHttp.js");
-        const recipesDir = join(homedir(), ".patchwork", "recipes");
+        const recipesDir = patchworkPath("recipes");
         const recipePath = findYamlRecipePath(recipesDir, recipeName);
         if (!recipePath) {
           return { ok: false, error: "recipe_file_missing" };
@@ -981,7 +979,7 @@ export class RecipeOrchestration {
       const orchestrator = this.deps.getOrchestrator();
       if (!orchestrator)
         return { ok: false, error: "orchestrator_unavailable" };
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       const match = findWebhookRecipe(recipesDir, hookPath);
       if (!match) {
         return { ok: false, error: "not_found" };
@@ -1086,7 +1084,7 @@ export class RecipeOrchestration {
       const orchestrator = this.deps.getOrchestrator();
       if (!orchestrator)
         return { ok: false, error: "orchestrator_unavailable" };
-      const recipesDir = join(homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
 
       // Try JSON recipe first (legacy path: enqueue prompt as a task).
       const loaded = loadRecipePrompt(recipesDir, name);
@@ -1643,7 +1641,7 @@ export class RecipeOrchestration {
       // delivery already made.
       ...(opts.deliveryId && {
         manualRunId: opts.deliveryId,
-        ledgerDir: join(homedir(), ".patchwork", "webhook-effect-ledger"),
+        ledgerDir: patchworkPath("webhook-effect-ledger"),
       }),
     };
     // Pass the bridge's long-lived RecipeRunLog so chainedRunner can flip the

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -48,6 +48,7 @@ import {
 } from "./fp/tokenBucket.js";
 import { respondIfUnknownBodyKeys } from "./httpBodyValidation.js";
 import { respond500 } from "./httpErrorResponse.js";
+import { patchworkPath } from "./patchworkHome.js";
 import { cancelRun } from "./recipes/runRegistry.js";
 import type { LintIssue } from "./recipes/validation.js";
 import type { RecipeDraft } from "./recipesHttp.js";
@@ -2804,7 +2805,7 @@ export function tryHandleRecipeRoute(
           const { installRecipeFromFile } = await import(
             "./recipes/installer.js"
           );
-          const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+          const recipesDir = patchworkPath("recipes");
           mkdirSync(recipesDir, { recursive: true });
 
           for (const r of manifest.recipes as string[]) {
@@ -3313,7 +3314,7 @@ export function tryHandleRecipeRoute(
         // the try, orphaning the temp file on any write error.
         try {
           writeFileSync(tmpFile, yamlText, "utf-8");
-          const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+          const recipesDir = patchworkPath("recipes");
           mkdirSync(recipesDir, { recursive: true });
           const { installRecipeFromFile } = await import(
             "./recipes/installer.js"

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -117,6 +117,7 @@ import {
 import { evaluateWhen } from "./whenGuard.js";
 import { resolveWorkspaceRoot } from "./workspaceRoot.js";
 import "./tools/index.js";
+import { patchworkPath } from "../patchworkHome.js";
 
 /**
  * Bundled-templates directory used as a third allowed root for nested-recipe
@@ -1300,6 +1301,18 @@ export async function runYamlRecipe(
   // `C:\Users\...`. Now we resolve both sides through `path.resolve()`
   // and use `path.relative()` to detect containment so the comparison is
   // separator-agnostic. Also case-insensitive on Win32 (NTFS).
+  // NOT converted to `patchworkPath()` (#1265), deliberately. A recipe
+  // writes to a literal `~/.patchwork/inbox/...` path, and `~` is expanded
+  // via `os.homedir()` elsewhere in the write path. Resolving only THIS
+  // side through PATCHWORK_HOME makes the two disagree whenever the
+  // override is set: the file lands under $HOME while the containment
+  // check looks under the override, so provenance is silently skipped and
+  // `inboxOutputs` stays empty. Caught by the suite, not by review.
+  //
+  // Converting this needs `~` expansion to route through the same helper,
+  // which changes where recipe file writes LAND. That is a real blast
+  // radius and belongs in its own change, so yamlRunner.ts stays on the
+  // ratchet.
   const inboxDirAbs = path.resolve(
     path.join(os.homedir(), ".patchwork", "inbox"),
   );
@@ -2858,9 +2871,7 @@ export async function runYamlRecipe(
         const { createRecipeRunLog } = await import(
           "../runStore/createRunLog.js"
         );
-        const { homedir } = await import("node:os");
-        const resolvedLogDir =
-          deps.logDir ?? path.join(homedir(), ".patchwork");
+        const resolvedLogDir = deps.logDir ?? patchworkPath();
         const log = createRecipeRunLog({ dir: resolvedLogDir });
         log.appendDirect({
           taskId: `yaml:${recipe.name}:${recipeStartedAt}`,
@@ -2895,7 +2906,7 @@ export async function runYamlRecipe(
         // Read notification channel from ~/.patchwork/config.json
         let notifyChannel = "";
         try {
-          const cfgPath = path.join(os.homedir(), ".patchwork", "config.json");
+          const cfgPath = patchworkPath("config.json");
           const cfg = JSON.parse(readFileSync(cfgPath, "utf-8")) as Record<
             string,
             unknown

--- a/src/recipesHttp.ts
+++ b/src/recipesHttp.ts
@@ -9,7 +9,6 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
 import * as path from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import {
@@ -17,6 +16,7 @@ import {
   type PatchworkConfig,
   saveConfig as savePatchworkConfig,
 } from "./patchworkConfig.js";
+import { patchworkPath } from "./patchworkHome.js";
 import {
   disabledMarkerPath,
   getConfigDisabledNames,
@@ -196,8 +196,7 @@ export function setRecipeEnabled(
     saveConfigFn?: (cfg: unknown) => void;
   } = {},
 ): { ok: boolean; error?: string } {
-  const recipesDir =
-    options.recipesDir ?? path.join(homedir(), ".patchwork", "recipes");
+  const recipesDir = options.recipesDir ?? patchworkPath("recipes");
 
   try {
     const installDir = findInstallDirByRecipeName(recipesDir, name);


### PR DESCRIPTION
Second conversion batch: ratchet 28 -> 25. Converts the recipes/orchestration
group — recipeOrchestration.ts (20 sites), recipeRoutes.ts, recipesHttp.ts,
and two internal sites in yamlRunner.ts.

The interesting part is what came back OUT, and why.

`inboxRoutes.ts` and yamlRunner's inbox containment check were converted and
then DELIBERATELY REVERTED. The inbox is written through `~` expansion via
`os.homedir()` in bridge.ts and yamlRunner.ts. Converting only the READER
(the /inbox route) or only the containment CHECK makes reader and writer
resolve to different directories the moment PATCHWORK_HOME is set: the file
lands under $HOME while the check looks under the override, so inbox
provenance is silently skipped and `inboxOutputs` stays empty.

That is the split installation this issue exists to close, relocated rather
than repaired — and relocated into a quieter place, since a missing
frontmatter block looks like a recipe that simply did not write one.

Converting them properly requires `~` expansion to route through the same
helper, which changes where recipe file writes LAND. That is a real blast
radius and belongs in its own change, so both files stay on the ratchet with
the reason recorded in the code and in the allowlist.

Caught by the suite, not by review. The conversion looked purely mechanical
and the diff read as semantically identical; three tests disagreed. Worth
stating plainly because the same reasoning ("this is just a rename") is what
would justify skipping the full run next time.

One test updated rather than reverted: the webhook-effect-ledger dir has a
single write site, so converting it is self-consistent, and the test asserted
a literal `.patchwork` path segment — which fails precisely WHEN the override
works. It now compares against `patchworkPath()`.

Full suite 9762/9762; ratchet audit reports 25 files with 25 listed.

Refs #1265.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)