### PR TITLE
fix(paths): route CLI, bridge and roster paths through patchworkHome() (#1265)

### DIFF
--- a/scripts/audit-patchwork-home-allowlist.json
+++ b/scripts/audit-patchwork-home-allowlist.json
@@ -14,18 +14,8 @@
     "four audit ledgers, where evidence silently landing elsewhere is the worst",
     "shape of this bug.",
     "2026-08-14 batch 2 (#1265): recipes/orchestration paths converted (31 -> 25). inboxRoutes.ts and recipes/yamlRunner.ts were converted and then DELIBERATELY REVERTED: the inbox is written via `~` expansion / os.homedir() in bridge.ts and yamlRunner.ts, so converting only the reader (or only the containment check) makes reader and writer resolve to different directories whenever PATCHWORK_HOME is set \u2014 the exact split this issue is about, moved rather than fixed. Converting them needs `~` expansion to route through the same helper, which changes where recipe file writes LAND, and that belongs in its own change.",
-    "2026-08-14 batch 3 (#1265): all 15 connector files converted (25 -> 10). Three already read PATCHWORK_HOME by hand; the other twelve ignored it entirely, so token reads and writes ALREADY split whenever the override was set \u2014 tokenStorage honoured it while gmail/notion/obsidian and the rest resolved under $HOME. Converging them closes that split rather than creating one. PATCHWORK_TOKEN_DIR precedence is unchanged."
+    "2026-08-14 batch 3 (#1265): all 15 connector files converted (25 -> 10). Three already read PATCHWORK_HOME by hand; the other twelve ignored it entirely, so token reads and writes ALREADY split whenever the override was set \u2014 tokenStorage honoured it while gmail/notion/obsidian and the rest resolved under $HOME. Converging them closes that split rather than creating one. PATCHWORK_TOKEN_DIR precedence is unchanged.",
+    "2026-08-14 batch 4 (#1265): CLI verbs, index.ts, featureFlags, roster and the non-inbox half of bridge.ts converted (10 -> 3). The three that remain are the INBOX COUPLING: bridge.ts and yamlRunner.ts write the inbox through  expansion / os.homedir(), and inboxRoutes.ts reads it, so all three must move together or reader and writer land in different trees. Converting them requires  expansion to route through the same helper, which changes where recipe file writes LAND."
   ],
-  "allow": [
-    "src/bridge.ts",
-    "src/commands/dashboard.ts",
-    "src/commands/recipe.ts",
-    "src/commands/tracesExport.ts",
-    "src/commands/tracesImport.ts",
-    "src/featureFlags.ts",
-    "src/identity/roster.ts",
-    "src/inboxRoutes.ts",
-    "src/index.ts",
-    "src/recipes/yamlRunner.ts"
-  ]
+  "allow": ["src/bridge.ts", "src/inboxRoutes.ts", "src/recipes/yamlRunner.ts"]
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1123,7 +1123,7 @@ export class Bridge {
   private registerRecipeTriggerPrograms(): void {
     if (!this.automationHooks) return;
     try {
-      const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       const collected = collectEventTriggerPrograms(recipesDir, {
         logger: this.logger,
       });
@@ -1333,7 +1333,7 @@ export class Bridge {
           workdir: this.config.workspace,
         });
         // Patchwork: wire recipe server fns + build cron scheduler.
-        const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+        const recipesDir = patchworkPath("recipes");
         // One-shot scan for legacy `<name>.permissions.json` sidecars (alpha.36+
         // no longer generates them). Skipped under NODE_ENV=test.
         warnAboutLegacyPermissionsSidecars(recipesDir);
@@ -1402,12 +1402,7 @@ export class Bridge {
           ? (opts) =>
               // biome-ignore lint/style/noNonNullAssertion: guarded by outer ternary
               this.recipeOrchestration!.fireYamlRecipe({
-                filePath: path.join(
-                  os.homedir(),
-                  ".patchwork",
-                  "recipes",
-                  `${opts.recipeName}.yaml`,
-                ),
+                filePath: patchworkPath("recipes", `${opts.recipeName}.yaml`),
                 name: opts.recipeName,
                 taskIdPrefix: `automation-recipe-${opts.recipeName}`,
                 triggerSourceSuffix: `automation:${opts.triggerSource}`,
@@ -1433,7 +1428,7 @@ export class Bridge {
       // guard is the safety floor — we never spawn tasks unless the operator
       // already enabled a driver. Pass --automation --automation-policy to add
       // policy-file hooks on top of the recipe triggers.
-      const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+      const recipesDir = patchworkPath("recipes");
       const collected = collectEventTriggerPrograms(recipesDir, {
         logger: this.logger,
       });
@@ -1455,12 +1450,7 @@ export class Bridge {
             ? (opts) =>
                 // biome-ignore lint/style/noNonNullAssertion: guarded by outer ternary
                 this.recipeOrchestration!.fireYamlRecipe({
-                  filePath: path.join(
-                    os.homedir(),
-                    ".patchwork",
-                    "recipes",
-                    `${opts.recipeName}.yaml`,
-                  ),
+                  filePath: patchworkPath("recipes", `${opts.recipeName}.yaml`),
                   name: opts.recipeName,
                   taskIdPrefix: `automation-recipe-${opts.recipeName}`,
                   triggerSourceSuffix: `automation:${opts.triggerSource}`,

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -20,9 +20,9 @@ import {
   renameSync,
   statSync,
 } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
+import { patchworkHome } from "../patchworkHome.js";
 import { ensureCmdShimIfKnown } from "../winShim.js";
 
 export interface RunEntry {
@@ -263,8 +263,7 @@ function openInEditor(item: InboxItem): void {
 // ── Main loop ─────────────────────────────────────────────────────────────────
 
 export async function runDashboard(deps: DashboardDeps = {}): Promise<void> {
-  const patchworkDir =
-    deps.patchworkDir ?? path.join(os.homedir(), ".patchwork");
+  const patchworkDir = deps.patchworkDir ?? patchworkHome();
   const out = deps.stdout ?? process.stdout;
   const isTTY = !deps.noTTY && out.isTTY === true;
   const getNow = deps.now ?? (() => new Date());

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -12,13 +12,13 @@ import {
   watch,
   writeFileSync,
 } from "node:fs";
-import os from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import "../recipes/tools/index.js";
 import { loadFixtureLibrary } from "../connectors/fixtureLibrary.js";
 import { MockConnector } from "../connectors/mockConnector.js";
+import { patchworkPath } from "../patchworkHome.js";
 import { applyTriggerInputDefaults } from "../recipeOrchestration.js";
 import {
   detectRequiredConnectors,
@@ -73,8 +73,25 @@ import { findYamlRecipePath } from "../recipesHttp.js";
 import type { RecipeRunLog } from "../runLog.js";
 import { findInstalledRecipeEntrypoint } from "./recipeInstall.js";
 
-const RECIPES_DIR = join(os.homedir(), ".patchwork", "recipes");
-const FIXTURES_DIR = join(os.homedir(), ".patchwork", "fixtures");
+/**
+ * Resolved per CALL, not bound at import (#1265/#1266).
+ *
+ * These were module-level constants. That was harmless while they read
+ * `os.homedir()`, which does not change during a process. Routing them
+ * through `patchworkPath()` makes them depend on PATCHWORK_HOME, which
+ * CAN change after import — so binding at import silently pins whichever
+ * value existed when this module first loaded.
+ *
+ * Same defect as the frozen OAuth redirect URI: the conversion is what
+ * turns a safe constant into a stale one, so the binding site has to move
+ * with it.
+ */
+function recipesDir(): string {
+  return patchworkPath("recipes");
+}
+function fixturesDir(): string {
+  return patchworkPath("fixtures");
+}
 const RECIPE_SCHEMA_HEADER =
   "# yaml-language-server: $schema=https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json";
 const RECIPE_API_VERSION = "patchwork.sh/v1";
@@ -179,7 +196,7 @@ export function runNew(options: NewOptions): { path: string; content: string } {
     .replace(/\{\{date\}\}/g, today);
   const content = `${RECIPE_SCHEMA_HEADER}\n${body}`;
 
-  const outputDir = options.outputDir ?? RECIPES_DIR;
+  const outputDir = options.outputDir ?? recipesDir();
   if (!existsSync(outputDir)) {
     mkdirSync(outputDir, { recursive: true });
   }
@@ -423,7 +440,7 @@ async function runNewAiSuggest(
     throw new Error("Cancelled by user");
   }
 
-  const outputDir = options.outputDir ?? RECIPES_DIR;
+  const outputDir = options.outputDir ?? recipesDir();
   if (!existsSync(outputDir)) {
     mkdirSync(outputDir, { recursive: true });
   }
@@ -674,7 +691,7 @@ export async function runNewInteractive(
     throw new Error("Cancelled by user");
   }
 
-  const outputDir = options.outputDir ?? RECIPES_DIR;
+  const outputDir = options.outputDir ?? recipesDir();
   if (!existsSync(outputDir)) {
     mkdirSync(outputDir, { recursive: true });
   }
@@ -893,12 +910,12 @@ function lintStep(
   // Named ref (no extension, no separator) → check ~/.patchwork/recipes/.
   // Emit a warning rather than error: the recipe may be installed on the
   // deploy target but not the author's machine.
-  if (existsSync(RECIPES_DIR)) {
+  if (existsSync(recipesDir())) {
     let found: string | null = null;
     try {
       found =
-        findYamlRecipePath(RECIPES_DIR, ref) ??
-        (existsSync(join(RECIPES_DIR, ref)) ? join(RECIPES_DIR, ref) : null);
+        findYamlRecipePath(recipesDir(), ref) ??
+        (existsSync(join(recipesDir(), ref)) ? join(recipesDir(), ref) : null);
     } catch (err) {
       issues.push({
         level: "error",
@@ -909,7 +926,7 @@ function lintStep(
     if (!found) {
       issues.push({
         level: "warning",
-        message: `Step ${stepLabel}: '${field}: ${ref}' — recipe not found in ${RECIPES_DIR}`,
+        message: `Step ${stepLabel}: '${field}: ${ref}' — recipe not found in ${recipesDir()}`,
       });
     } else {
       issues.push(...lintChildRecipe(found, field, ref, stepLabel, visited));
@@ -1469,7 +1486,7 @@ function resolveNestedRecipeForDryPlan(
   // — TS resolves this through the same package that `import os from "node:os"`
   // uses. No dynamic require: this stays synchronous and ESM-friendly.
   const parentDir = dirname(parentRecipePath);
-  const userRecipesDir = join(os.homedir(), ".patchwork", "recipes");
+  const userRecipesDir = patchworkPath("recipes");
 
   const pathLike =
     /^([./]|\.\.[/\\]|[A-Za-z]:[/\\])/.test(ref) ||
@@ -1868,9 +1885,11 @@ export async function runPreflight(
   }
 
   if (options.requireFixtures && plan.connectorNamespaces) {
-    const fixturesDir = options.fixturesDir ?? FIXTURES_DIR;
+    const resolvedFixturesDir = options.fixturesDir ?? fixturesDir();
     for (const ns of plan.connectorNamespaces) {
-      const library = loadFixtureLibrary(join(fixturesDir, `${ns}.json`));
+      const library = loadFixtureLibrary(
+        join(resolvedFixturesDir, `${ns}.json`),
+      );
       if (!library) {
         issues.push({
           level: "error",
@@ -2325,9 +2344,9 @@ function resolveRecipePath(recipeRef: string): string {
   );
   const normalizedRef = recipeRef.replace(/\.(yaml|yml|json)$/i, "");
   const candidates = [
-    join(RECIPES_DIR, `${normalizedRef}.yaml`),
-    join(RECIPES_DIR, `${normalizedRef}.yml`),
-    join(RECIPES_DIR, `${normalizedRef}.json`),
+    join(recipesDir(), `${normalizedRef}.yaml`),
+    join(recipesDir(), `${normalizedRef}.yml`),
+    join(recipesDir(), `${normalizedRef}.json`),
     join(bundledDir, `${normalizedRef}.yaml`),
     join(bundledDir, `${normalizedRef}.yml`),
   ];
@@ -2339,7 +2358,7 @@ function resolveRecipePath(recipeRef: string): string {
   }
 
   // Install-dir resolution (DB-4): `recipe install` puts each recipe in
-  // its own subdir at `<RECIPES_DIR>/<install-name>/<entrypoint>.yaml`.
+  // its own subdir at `<recipesDir()>/<install-name>/<entrypoint>.yaml`.
   // Without this fallback, `recipe run <install-name>` errors with
   // "not found" even though `recipe list` displays the recipe — observed
   // in the 2026-04-29 dogfood pass.
@@ -2354,7 +2373,7 @@ function resolveRecipePath(recipeRef: string): string {
   }
 
   throw new Error(
-    `recipe "${basename(recipeRef)}" not found in ${RECIPES_DIR}`,
+    `recipe "${basename(recipeRef)}" not found in ${recipesDir()}`,
   );
 }
 
@@ -2533,7 +2552,7 @@ export async function runRecord(
 ): Promise<RecipeRecordResult> {
   const lint = runLint(recipePath);
   const issues = [...lint.issues];
-  const fixturesDir = options.fixturesDir ?? FIXTURES_DIR;
+  const resolvedFixturesDir = options.fixturesDir ?? fixturesDir();
   let recordedFixtures: string[] = [];
   let stepsRun = 0;
   let outputs: string[] = [];
@@ -2546,7 +2565,7 @@ export async function runRecord(
       );
       const run = await runYamlRecipe(recipe, {
         ...options.deps,
-        recordFixturesDir: fixturesDir,
+        recordFixturesDir: resolvedFixturesDir,
       });
       stepsRun = run.stepsRun;
       outputs = run.outputs;
@@ -2641,7 +2660,7 @@ export async function runTest(
   options: { fixturesDir?: string } = {},
 ): Promise<RecipeTestResult> {
   const lint = runLint(recipePath);
-  const fixturesDir = options.fixturesDir ?? FIXTURES_DIR;
+  const resolvedFixturesDir = options.fixturesDir ?? fixturesDir();
   const issues = [...lint.issues];
   let requiredFixtures: string[] = [];
   let stepsRun = 0;
@@ -2661,13 +2680,13 @@ export async function runTest(
   }
 
   const missingFixtures = requiredFixtures.filter(
-    (provider) => !existsSync(join(fixturesDir, `${provider}.json`)),
+    (provider) => !existsSync(join(resolvedFixturesDir, `${provider}.json`)),
   );
 
   for (const provider of missingFixtures) {
     issues.push({
       level: "error",
-      message: `Missing fixture library for connector '${provider}' at ${join(fixturesDir, `${provider}.json`)}`,
+      message: `Missing fixture library for connector '${provider}' at ${join(resolvedFixturesDir, `${provider}.json`)}`,
     });
   }
 
@@ -2729,7 +2748,7 @@ export async function runTest(
       } else {
         const mockConnectors = createMockToolConnectors(
           recipe.steps,
-          fixturesDir,
+          resolvedFixturesDir,
         );
         const run = await runYamlRecipe(recipe, {
           testMode: true,

--- a/src/commands/tracesExport.ts
+++ b/src/commands/tracesExport.ts
@@ -41,6 +41,7 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { pipeline } from "node:stream/promises";
 import { createGzip } from "node:zlib";
+import { patchworkHome } from "../patchworkHome.js";
 
 export const TRACES_EXPORT_VERSION = 1;
 
@@ -133,7 +134,7 @@ interface RowEnvelope {
 }
 
 function defaultPatchworkDir(): string {
-  return path.join(os.homedir(), ".patchwork");
+  return patchworkHome();
 }
 
 function defaultActivityDir(): string {

--- a/src/commands/tracesImport.ts
+++ b/src/commands/tracesImport.ts
@@ -36,6 +36,7 @@ import os from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { createGunzip } from "node:zlib";
+import { patchworkHome } from "../patchworkHome.js";
 import { TRACES_EXPORT_VERSION, type TraceSource } from "./tracesExport.js";
 
 export type ImportMode = "append" | "overwrite";
@@ -90,7 +91,7 @@ const SINGLE_FILE_TARGETS: Record<Exclude<TraceSource, "activity">, string> = {
 };
 
 function defaultPatchworkDir(): string {
-  return path.join(os.homedir(), ".patchwork");
+  return patchworkHome();
 }
 
 function defaultActivityDir(): string {

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -9,9 +9,9 @@
  */
 
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import os from "node:os";
 import { join } from "node:path";
 import { watchDirectoryWithFallback } from "./fsWatchWithFallback.js";
+import { patchworkHome } from "./patchworkHome.js";
 import { writeFileAtomicSync } from "./writeFileAtomic.js";
 
 /** Flag definition */
@@ -38,11 +38,7 @@ const FLAG_VALUES: Map<string, boolean> = new Map();
 
 /** Flag storage path */
 function getFlagsPath(): string {
-  return join(
-    process.env.PATCHWORK_HOME ?? join(os.homedir(), ".patchwork"),
-    "config",
-    "flags.json",
-  );
+  return join(patchworkHome(), "config", "flags.json");
 }
 
 /**

--- a/src/identity/roster.ts
+++ b/src/identity/roster.ts
@@ -30,9 +30,8 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
-
+import { patchworkHome } from "../patchworkHome.js";
 import { type Member, memberCan, parseMember } from "./members.js";
 import type { Capability } from "./roles.js";
 
@@ -70,10 +69,7 @@ function implicitRoster(): Roster {
 /** Default location: `~/.patchwork/members.json`, honouring `PATCHWORK_HOME`. */
 export function defaultRosterPath(): string {
   const home = process.env.PATCHWORK_HOME?.trim();
-  return join(
-    home && home !== "" ? home : join(homedir(), ".patchwork"),
-    "members.json",
-  );
+  return join(home && home !== "" ? home : patchworkHome(), "members.json");
 }
 
 /**
@@ -176,7 +172,7 @@ export function resolvePrincipal(
     return roster.implicit ? (roster.members[0] ?? null) : null;
   }
   const m = findMember(roster, memberId);
-  if (!m || !m.active) return null;
+  if (!m?.active) return null;
   return m;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ import {
   PATCHWORK_PACKAGE_NAME,
   SYMLINK_INSTALL_FIX,
 } from "./installGuard.js";
+import { patchworkHome, patchworkPath } from "./patchworkHome.js";
 import { treeKill } from "./processTree.js";
 import { PACKAGE_VERSION, semverGt } from "./version.js";
 import { ensureCmdShim } from "./winShim.js";
@@ -1630,7 +1631,7 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
           );
           process.exit(1);
         }
-        resolvedLedgerDir = ledgerDir ?? path.join(os.homedir(), ".patchwork");
+        resolvedLedgerDir = ledgerDir ?? patchworkHome();
         process.stdout.write(
           `  Attempt id: ${resolvedAttempt} (ledger: ${resolvedLedgerDir})\n`,
         );
@@ -1659,7 +1660,7 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
           "./runStore/createRunLog.js"
         );
         const runLog = createRecipeRunLog({
-          dir: path.join(os.homedir(), ".patchwork"),
+          dir: patchworkHome(),
         });
         const startedAt = Date.now();
         const stepResultsForLog = extractRunLogStepResults(run.result);
@@ -1719,7 +1720,7 @@ if (process.argv[2] === "recipe" && process.argv[3] === "install") {
         const { installRecipeFromFile } = await import(
           "./recipes/installer.js"
         );
-        const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+        const recipesDir = patchworkPath("recipes");
         const result = installRecipeFromFile(path.resolve(source), {
           recipesDir,
         });
@@ -1797,7 +1798,7 @@ if (process.argv[2] === "suggest") {
 
       // Wire up the bridge's standard log paths. The CLI reads from
       // disk; it doesn't need a running bridge.
-      const patchworkDir = path.join(os.homedir(), ".patchwork");
+      const patchworkDir = patchworkHome();
       const activityLog = new ActivityLog();
       // Find the most recent activity log file (any port). For the
       // suggest CLI we union all of them.
@@ -2144,14 +2145,10 @@ if (process.argv[2] === "kill-switch") {
           setFlag(KILL_SWITCH_WRITES, engage, true);
           // Audit in a sibling CLI-only JSONL (v2-I10: bridge-only writes
           // go to decision_traces.jsonl; CLI fallback is distinct).
-          const os = await import("node:os");
           const path = await import("node:path");
           const fs = await import("node:fs");
-          const cliTraceFile = path.join(
-            process.env.PATCHWORK_HOME ??
-              path.join(os.default.homedir(), ".patchwork"),
-            "decision_traces.cli.jsonl",
-          );
+          const { patchworkPath } = await import("./patchworkHome.js");
+          const cliTraceFile = patchworkPath("decision_traces.cli.jsonl");
           const dir = path.dirname(cliTraceFile);
           if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
           const entry = JSON.stringify({
@@ -2376,7 +2373,6 @@ if (process.argv[2] === "runstore") {
     process.exit(1);
   }
   void (async () => {
-    const os = await import("node:os");
     const pathMod = await import("node:path");
     const { SqliteRunRepository } = await import(
       "./runStore/sqliteRunRepository.js"
@@ -2384,9 +2380,7 @@ if (process.argv[2] === "runstore") {
     const { backfillMirror, compareStores, formatCompare } = await import(
       "./runStore/backfillMirror.js"
     );
-    const dir = process.env.PATCHWORK_HOME
-      ? process.env.PATCHWORK_HOME
-      : pathMod.join(os.homedir(), ".patchwork");
+    const dir = patchworkHome();
     const mirror = new SqliteRunRepository({
       dir: pathMod.join(dir, "runstore-mirror"),
     });
@@ -3806,7 +3800,7 @@ if (process.argv[2] === "recipe" && process.argv[3] === "watch") {
               "./runStore/createRunLog.js"
             );
             const runLog = createRecipeRunLog({
-              dir: path.join(os.homedir(), ".patchwork"),
+              dir: patchworkHome(),
             });
             const now = Date.now();
             const stepResultsForLog = extractRunLogStepResults(
@@ -5082,8 +5076,7 @@ if (process.argv[2] === "gate") {
         formatGateDecisionHistory,
         formatGateDecisionDiff,
       } = await import("./workerGateDecisionLog.js");
-      const patchworkDir =
-        process.env.PATCHWORK_HOME ?? path.join(os.homedir(), ".patchwork");
+      const patchworkDir = patchworkHome();
       const log = new WorkerGateDecisionLog({ dir: patchworkDir });
       const decisions = log.query({ workerId, classKey, limit });
 
@@ -5189,7 +5182,7 @@ if (process.argv[2] === "launchd") {
     // First-run guard: if the user hasn't run `patchwork init` yet, launching
     // the dashboard renders an empty panel with no signpost. Print an
     // actionable pointer instead and exit cleanly.
-    const cfgPath = path.join(os.homedir(), ".patchwork", "config.json");
+    const cfgPath = patchworkPath("config.json");
     if (!existsSync(cfgPath) && !process.argv[2]) {
       process.stdout.write(
         `No Patchwork config found at ${cfgPath}.\n\n` +

--- a/src/recipes/simulation/__tests__/mockedSandbox.test.ts
+++ b/src/recipes/simulation/__tests__/mockedSandbox.test.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import { Ajv } from "ajv";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RecipeDryRunPlan } from "../../../commands/recipe.js";
+import { patchworkPath } from "../../../patchworkHome.js";
 import { type RecipeRun, RecipeRunLog } from "../../../runLog.js";
 import type { ChainedRecipe } from "../../chainedRunner.js";
 import { generateSimulationSchema } from "../../schemaGenerator.js";
@@ -377,8 +378,14 @@ describe("branch resolution (mocked overlay)", () => {
 // ── Routing (runRecipeSimulate hard guards) ────────────────────────────────
 
 describe("runRecipeSimulate routing", () => {
+  // Writes where the CLI READS. Previously this joined `os.homedir()`
+  // directly, which meant two things at once: the test wrote into the
+  // operator's REAL ~/.patchwork/recipes (leaving files behind on every run),
+  // and once the resolver started honouring PATCHWORK_HOME (#1265) the write
+  // and the read landed in different trees. Both are fixed by resolving the
+  // same way the code under test does.
   function writeRecipe(name: string, body: string): void {
-    const recipesDir = path.join(os.homedir(), ".patchwork", "recipes");
+    const recipesDir = patchworkPath("recipes");
     mkdirSync(recipesDir, { recursive: true });
     writeFileSync(path.join(recipesDir, `${name}.yaml`), body);
   }


### PR DESCRIPTION
Fourth and final conversion batch: ratchet 10 -> 3. CLI verbs, index.ts,
featureFlags, the identity roster, and the non-inbox half of bridge.ts.

Only `.patchwork` paths moved. The `.claude` ones (CLAUDE_CONFIG_DIR,
~/.claude/ide, ~/.claude.json) belong to a different tool and are
deliberately untouched.

Three things this batch surfaced that a mechanical sweep would have shipped:

CONVERSION CAN FREEZE A CONSTANT. `commands/recipe.ts` bound RECIPES_DIR and
FIXTURES_DIR at module level. Harmless while they read `os.homedir()`, which
cannot change during a process — but routing them through `patchworkPath()`
makes them depend on PATCHWORK_HOME, which CAN change after import. The
conversion is what turns a safe constant into a stale one. Both are now
functions, the same fix as the frozen OAuth redirect URI.

A REGEX ARTIFACT. The optional `path.` in my substitution also matched the
bare `join(` inside `pathMod.join(...)`, producing `pathMod.patchworkHome()`.
Typecheck caught the one instance; I then grepped every converted file for
that shape rather than assuming it was unique.

A TEST WRITING TO THE REAL HOME. `mockedSandbox.test.ts` created its fixture
in `path.join(os.homedir(), ".patchwork", "recipes")` — the operator's actual
recipes directory, on every run. Once the resolver honoured the override, the
write and the read landed in different trees. Resolving the test the same way
the code does repairs both at once.

The three files still on the ratchet are the INBOX COUPLING, listed together
on purpose: bridge.ts and yamlRunner.ts WRITE the inbox via `~` expansion,
inboxRoutes.ts READS it. They must move together or reader and writer resolve
to different directories — the split this issue exists to close. That needs
`~` expansion routed through the same helper, which changes where recipe file
writes LAND, and belongs in its own change.

Also applies one unrelated lint fix the pre-commit hook demanded on a file
this batch touches (`!m || !m.active` -> `!m?.active` in roster.ts);
identity tests unchanged at 45 passing.

31 -> 3 across four batches. Suite: 9755 passing, 3 pre-existing failures in
tokenEfficiency.test.ts that reproduce identically on main (they read the
real ~/.claude/ide lock dir, so a live local bridge breaks them; CI has none).

Refs #1265.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)