### PR TITLE
feat(privacy): information-boundary decision point at executeAgent (ADR-0021)

### DIFF
--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -1,7 +1,33 @@
 # ADR-0021: The Information Boundary — What May a Model Know?
 
-**Status:** Proposed
+**Status:** Accepted — Phases 1 and 2 implemented 2026-08-14; Phase 3 partial
 **Date:** 2026-08-12
+
+> **Implementation note, 2026-08-14.** The decision point exists at
+> `executeAgent` (`src/recipes/agentExecutor.ts`), evaluated before dispatch,
+> with the pure decision in `src/privacy/dataPolicy.ts`. What is and is not
+> built, stated exactly:
+>
+> - **Phase 1 (declared labels)** — built. `parseDataPolicy` reads a step's
+>   `data_policy`; absent means `internal` and behaves as before, so existing
+>   recipes are unaffected. An UNRECOGNISED classification is refused rather
+>   than defaulted: silently reading a typo as `internal` would leave an
+>   operator believing they had labelled something when they had not.
+> - **Phase 2 (the decision)** — built, all five values, pure and model-free.
+>   `narrowest()` enforces the never-widen rule.
+> - **Phase 3 (receipts)** — the SINK is wired (`recordBoundaryDecisionFn`) and
+>   every decision including `ALLOW` emits one, but no durable store is
+>   attached yet. Enforcement deliberately does NOT depend on the sink being
+>   configured — a boundary that refuses only when its audit trail happens to
+>   be wired could be disabled by removing the sink.
+> - **`ALLOW_REDACTED` REFUSES.** Redaction is not implemented, so a step that
+>   must have a category removed is refused rather than sent unredacted.
+>   "We know something must be removed and cannot remove it" has to fail
+>   closed; the alternative sends the data and records that it should not have.
+> - **Not built, unchanged from below:** detection, purpose-based
+>   minimisation, least-data routing, policy packs. Destinations are supplied
+>   by the caller; a configuration surface for registering them is the next
+>   slice, and until one exists the boundary is inert on every install.
 **Bounded by:** [ADR-0019](0019-open-core-boundary.md) — the engine is MIT and
 lives here; organisation-wide policy is control-plane. See "Open-core boundary".
 **Related:** [ADR-0016](0016-approval-hook-fail-closed.md) (fail-closed gating),

--- a/src/privacy/__tests__/agentBoundary.test.ts
+++ b/src/privacy/__tests__/agentBoundary.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { executeAgent } from "../../recipes/agentExecutor.js";
+import type { Destination } from "../dataPolicy.js";
+
+const REMOTE: Destination = {
+  id: "remote-model",
+  type: "remote",
+  classifications: ["public", "internal"],
+};
+
+/** Minimal deps: a driver that records whether it was ever reached. */
+function depsWithSpy() {
+  const ran = vi.fn(async () => ({ text: "model output" }));
+  const receipts: Array<Record<string, unknown>> = [];
+  return {
+    ran,
+    receipts,
+    deps: {
+      localFn: ran,
+      // Enough of the real dep surface for the ALLOW path to reach dispatch.
+      // The refusal tests deliberately do NOT need these — that they pass with
+      // a bare stub is itself evidence the boundary short-circuits before any
+      // driver work happens.
+      loadPatchworkConfig: () => ({}),
+      recordBoundaryDecisionFn: (r: Record<string, unknown>) => {
+        receipts.push(r);
+      },
+    } as never,
+  };
+}
+
+describe("executeAgent enforces the information boundary (ADR-0021)", () => {
+  it("refuses to dispatch when the destination is not cleared", async () => {
+    const { ran, deps } = depsWithSpy();
+    const result = await executeAgent(
+      {
+        prompt: "synthetic prompt",
+        driver: "local",
+        boundary: {
+          dataPolicy: { classification: "restricted" },
+          destination: REMOTE,
+        },
+      },
+      deps,
+    );
+    // The invariant: no model-bound context leaves without passing the point.
+    // Asserting the DRIVER WAS NEVER CALLED, not merely that the text says so —
+    // a check on the message alone would pass even if the prompt had been sent.
+    expect(ran).not.toHaveBeenCalled();
+    expect(result.text).toContain("information boundary");
+  });
+
+  it("refuses a typo'd classification rather than defaulting it", async () => {
+    const { ran, deps } = depsWithSpy();
+    const result = await executeAgent(
+      {
+        prompt: "synthetic prompt",
+        driver: "local",
+        boundary: {
+          dataPolicy: { classification: "confidentail" },
+          destination: REMOTE,
+        },
+      },
+      deps,
+    );
+    expect(ran).not.toHaveBeenCalled();
+    expect(result.text).toMatch(/unrecognised classification/);
+  });
+
+  it("refuses ALLOW_REDACTED rather than sending unredacted", async () => {
+    // Redaction is not implemented in this phase. "We know something must be
+    // removed and cannot remove it" must fail closed — the alternative sends
+    // the data and logs that it should not have.
+    const { ran, deps } = depsWithSpy();
+    await executeAgent(
+      {
+        prompt: "synthetic prompt",
+        driver: "local",
+        boundary: {
+          dataPolicy: { classification: "internal", categories: ["beta"] },
+          destination: { ...REMOTE, forbiddenCategories: ["beta"] },
+        },
+      },
+      deps,
+    );
+    expect(ran).not.toHaveBeenCalled();
+  });
+
+  it("writes a receipt for every decision, including ALLOW", async () => {
+    const { receipts, deps } = depsWithSpy();
+    await executeAgent(
+      {
+        prompt: "synthetic prompt",
+        driver: "local",
+        boundary: {
+          dataPolicy: { classification: "internal" },
+          destination: REMOTE,
+        },
+      },
+      deps,
+    );
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0]).toMatchObject({
+      decision: "ALLOW",
+      destinationId: "remote-model",
+    });
+  });
+
+  it("is inert when no destination is registered — existing recipes unaffected", async () => {
+    const { ran, receipts, deps } = depsWithSpy();
+    await executeAgent({ prompt: "synthetic prompt", driver: "local" }, deps);
+    expect(ran).toHaveBeenCalled();
+    expect(receipts).toEqual([]);
+  });
+
+  it("does not depend on its own audit trail being wired", async () => {
+    // A boundary that refuses when no receipt sink is configured would be
+    // trivially disabled by removing the sink. Enforcement must not need it.
+    const ran = vi.fn(async () => ({ text: "out" }));
+    const result = await executeAgent(
+      {
+        prompt: "synthetic prompt",
+        driver: "local",
+        boundary: {
+          dataPolicy: { classification: "restricted" },
+          destination: REMOTE,
+        },
+      },
+      { localFn: ran } as never,
+    );
+    expect(ran).not.toHaveBeenCalled();
+    expect(result.text).toContain("information boundary");
+  });
+});

--- a/src/privacy/__tests__/dataPolicy.test.ts
+++ b/src/privacy/__tests__/dataPolicy.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_CLASSIFICATION,
+  type Destination,
+  decideBoundary,
+  narrowest,
+  parseDataPolicy,
+} from "../dataPolicy.js";
+
+// Every fixture here is synthetic. ADR-0021's own warning applies with force to
+// its tests: a privacy engine that leaks real names in its test data is the
+// sharpest possible own goal.
+const LOCAL: Destination = {
+  id: "local-model",
+  type: "local",
+  classifications: [
+    "public",
+    "internal",
+    "personal",
+    "confidential",
+    "restricted",
+  ],
+};
+const REMOTE: Destination = {
+  id: "remote-model",
+  type: "remote",
+  classifications: ["public", "internal"],
+};
+
+describe("decideBoundary — the five outcomes", () => {
+  it("ALLOWs what the destination is cleared for", () => {
+    const out = decideBoundary({ classification: "internal" }, REMOTE);
+    expect(out.decision).toBe("ALLOW");
+  });
+
+  it("routes LOCAL_ONLY when a local destination could take it", () => {
+    // Not a failure — the data may be processed, just not there. The caller is
+    // expected to retry locally rather than fail the step.
+    const out = decideBoundary({ classification: "confidential" }, REMOTE, {
+      localDestinationAccepts: true,
+    });
+    expect(out.decision).toBe("LOCAL_ONLY");
+  });
+
+  it("REQUIRE_APPROVALs when the destination is approvable and no local path exists", () => {
+    const out = decideBoundary(
+      { classification: "confidential" },
+      {
+        ...REMOTE,
+        approvable: true,
+      },
+    );
+    expect(out.decision).toBe("REQUIRE_APPROVAL");
+  });
+
+  it("DENIes when not cleared, not approvable, and no local path", () => {
+    const out = decideBoundary({ classification: "restricted" }, REMOTE);
+    expect(out.decision).toBe("DENY");
+    // DENY must mean "no approval unlocks this", exactly as the autonomy gate's
+    // `forbid` does — otherwise the two vocabularies disagree.
+    expect(out.reason).toMatch(/no approval/i);
+  });
+
+  it("ALLOW_REDACTEDs a forbidden category on an otherwise-cleared destination", () => {
+    const out = decideBoundary(
+      { classification: "internal", categories: ["alpha", "beta"] },
+      { ...REMOTE, forbiddenCategories: ["beta"] },
+    );
+    expect(out.decision).toBe("ALLOW_REDACTED");
+    expect(out.redactCategories).toEqual(["beta"]);
+  });
+
+  it("does NOT let redaction rescue an uncleared classification", () => {
+    // The ordering guarantee. Dropping a tag does not declassify what remains,
+    // so a destination must never become cleared by redacting a category.
+    const out = decideBoundary(
+      { classification: "restricted", categories: ["beta"] },
+      { ...REMOTE, forbiddenCategories: ["beta"] },
+    );
+    expect(out.decision).toBe("DENY");
+    expect(out.redactCategories).toBeUndefined();
+  });
+
+  it("clears a local destination for everything it declares", () => {
+    for (const c of [
+      "public",
+      "internal",
+      "personal",
+      "confidential",
+      "restricted",
+    ] as const) {
+      expect(decideBoundary({ classification: c }, LOCAL).decision).toBe(
+        "ALLOW",
+      );
+    }
+  });
+
+  it("never contains the payload in the reason", () => {
+    const out = decideBoundary(
+      { classification: "restricted", categories: ["secret-tag"] },
+      REMOTE,
+    );
+    // The reason is shown to humans and written to receipts; it may name the
+    // policy, never the data.
+    expect(out.reason).not.toContain("secret-tag");
+  });
+});
+
+describe("parseDataPolicy — declared, and fail closed on a typo", () => {
+  it("defaults an absent policy to internal, so existing recipes are unaffected", () => {
+    expect(parseDataPolicy(undefined)).toEqual({
+      classification: DEFAULT_CLASSIFICATION,
+    });
+    expect(DEFAULT_CLASSIFICATION).toBe("internal");
+  });
+
+  it("returns null for an unrecognised classification rather than defaulting it", () => {
+    // The failure a declared-labels scheme cannot afford: the operator believes
+    // they labelled it and the system believes they did not. `confidentail`
+    // must not sail through as ordinary internal data.
+    expect(parseDataPolicy({ classification: "confidentail" })).toBeNull();
+    expect(parseDataPolicy({ classification: 7 })).toBeNull();
+    expect(parseDataPolicy("nonsense")).toBeNull();
+  });
+
+  it("keeps declared categories and drops non-strings", () => {
+    expect(
+      parseDataPolicy({
+        classification: "confidential",
+        categories: ["alpha", 3, "beta"],
+      }),
+    ).toEqual({
+      classification: "confidential",
+      categories: ["alpha", "beta"],
+    });
+  });
+});
+
+describe("narrowest — never widen", () => {
+  it("takes the more restrictive of two decisions regardless of order", () => {
+    const allow = decideBoundary({ classification: "internal" }, REMOTE);
+    const deny = decideBoundary({ classification: "restricted" }, REMOTE);
+    expect(narrowest(allow, deny).decision).toBe("DENY");
+    expect(narrowest(deny, allow).decision).toBe("DENY");
+  });
+
+  it("orders every decision so a later stage cannot restore removed context", () => {
+    const mk = (d: string) => ({ decision: d, reason: "" }) as never;
+    const order = [
+      "ALLOW",
+      "ALLOW_REDACTED",
+      "LOCAL_ONLY",
+      "REQUIRE_APPROVAL",
+      "DENY",
+    ];
+    for (let i = 0; i < order.length - 1; i++) {
+      const looser = mk(order[i] as string);
+      const tighter = mk(order[i + 1] as string);
+      expect(narrowest(looser, tighter).decision).toBe(order[i + 1]);
+    }
+  });
+});

--- a/src/privacy/dataPolicy.ts
+++ b/src/privacy/dataPolicy.ts
@@ -1,0 +1,215 @@
+/**
+ * Information boundary — declared labels and the boundary decision (ADR-0021,
+ * Phases 1 and 2).
+ *
+ * The invariant this exists to hold:
+ *
+ *   > No model-bound context leaves Patchwork without passing the
+ *   > information-boundary decision point.
+ *
+ * Two properties are deliberate and load-bearing.
+ *
+ * **Declared, never detected.** A step says what it carries; a destination says
+ * what it may receive. Nothing is inferred. ADR-0021 rules detection out on the
+ * grounds that a detector which IS the boundary fails silently on everything it
+ * does not recognise, and its recall is unknowable. A detector may later suggest
+ * a classification; policy still decides.
+ *
+ * **Pure.** The decision is a function of (declared policy, destination policy)
+ * and nothing else — no clock, no filesystem, no model. That is what makes it
+ * testable without a model in the loop, and what stops the boundary being
+ * enforced by the thing it constrains.
+ */
+
+/**
+ * Sensitivity ladder, ordered. The order is the whole comparison: a destination
+ * cleared for `internal` is cleared for `public`, never the reverse.
+ */
+export const CLASSIFICATIONS = [
+  "public",
+  "internal",
+  "personal",
+  "confidential",
+  "restricted",
+] as const;
+
+export type Classification = (typeof CLASSIFICATIONS)[number];
+
+/**
+ * Default for a step that declares nothing.
+ *
+ * `internal` rather than `restricted`, deliberately. Every existing recipe
+ * declares nothing, so a strict default would refuse the entire installed base
+ * on upgrade to solve a problem those installs do not have — and a boundary
+ * that breaks everything on day one gets switched off, which protects nobody.
+ * Same fail-soft reasoning as the identity roster's implicit owner.
+ */
+export const DEFAULT_CLASSIFICATION: Classification = "internal";
+
+export function classificationRank(c: Classification): number {
+  return CLASSIFICATIONS.indexOf(c);
+}
+
+/** What a step declares it is carrying. */
+export interface DataPolicy {
+  classification: Classification;
+  /** Free-form tags (e.g. "financial"). Used for redaction, not for ranking. */
+  categories?: string[];
+}
+
+/** What a destination declares it may receive. */
+export interface Destination {
+  id: string;
+  /** `local` never leaves the machine; `remote` crosses a network boundary. */
+  type: "local" | "remote";
+  /** Classifications this destination is cleared for. */
+  classifications: Classification[];
+  /**
+   * Categories this destination must never receive even when it is cleared for
+   * the classification. Redaction removes them; if they cannot be removed the
+   * decision escalates rather than silently sending them.
+   */
+  forbiddenCategories?: string[];
+  /**
+   * Whether a human may authorise an otherwise-refused send. Absent means no:
+   * the refusal stands, which keeps DENY meaningful as "no approval unlocks
+   * this" exactly as the autonomy gate's `forbid` does.
+   */
+  approvable?: boolean;
+}
+
+/**
+ * The five outcomes.
+ *
+ * `LOCAL_ONLY` is distinct from `DENY` on purpose: it means the data may be
+ * processed, just not here. It is a routing instruction, and the caller is
+ * expected to retry against a local destination rather than fail the step.
+ */
+export type BoundaryDecision =
+  | "ALLOW"
+  | "ALLOW_REDACTED"
+  | "LOCAL_ONLY"
+  | "REQUIRE_APPROVAL"
+  | "DENY";
+
+export interface BoundaryOutcome {
+  decision: BoundaryDecision;
+  /** One sentence, safe to show a human. Never contains the payload. */
+  reason: string;
+  /** Categories that must be removed before dispatch (ALLOW_REDACTED only). */
+  redactCategories?: string[];
+}
+
+/**
+ * Decide whether `policy` may be sent to `destination`.
+ *
+ * The rule table, in evaluation order:
+ *
+ *   1. destination not cleared for the classification
+ *        → LOCAL_ONLY if a local destination could take it, else
+ *          REQUIRE_APPROVAL if the destination is approvable, else DENY
+ *   2. cleared, but carries a forbidden category
+ *        → ALLOW_REDACTED (the category is removable)
+ *   3. otherwise → ALLOW
+ *
+ * Rule 1 runs FIRST and is not reachable past. A destination cannot become
+ * cleared by redacting a category, because the classification is a property of
+ * the step as a whole — dropping a tag does not declassify what remains.
+ */
+export function decideBoundary(
+  policy: DataPolicy,
+  destination: Destination,
+  opts: { localDestinationAccepts?: boolean } = {},
+): BoundaryOutcome {
+  const cleared = destination.classifications.includes(policy.classification);
+
+  if (!cleared) {
+    if (destination.type === "remote" && opts.localDestinationAccepts) {
+      return {
+        decision: "LOCAL_ONLY",
+        reason: `"${policy.classification}" may not leave the machine; a local destination accepts it`,
+      };
+    }
+    if (destination.approvable) {
+      return {
+        decision: "REQUIRE_APPROVAL",
+        reason: `"${destination.id}" is not cleared for "${policy.classification}"; a human may authorise this send`,
+      };
+    }
+    return {
+      decision: "DENY",
+      reason: `"${destination.id}" is not cleared for "${policy.classification}" and no approval can unlock it`,
+    };
+  }
+
+  const forbidden = destination.forbiddenCategories ?? [];
+  const carried = policy.categories ?? [];
+  const hits = carried.filter((c) => forbidden.includes(c));
+  if (hits.length > 0) {
+    return {
+      decision: "ALLOW_REDACTED",
+      reason: `"${destination.id}" is cleared for "${policy.classification}" but must not receive: ${hits.join(", ")}`,
+      redactCategories: hits,
+    };
+  }
+
+  return {
+    decision: "ALLOW",
+    reason: `"${destination.id}" is cleared for "${policy.classification}"`,
+  };
+}
+
+/**
+ * Parse a step's declared `data_policy`, falling back to the default.
+ *
+ * An UNRECOGNISED classification is not silently defaulted — it returns null so
+ * the caller can fail closed. Defaulting a typo to `internal` would let
+ * `classification: confidentail` sail through as ordinary internal data, which
+ * is precisely the failure a declared-labels scheme cannot afford: the operator
+ * believes they labelled it and the system believes they did not.
+ */
+export function parseDataPolicy(raw: unknown): DataPolicy | null {
+  if (raw === undefined || raw === null) {
+    return { classification: DEFAULT_CLASSIFICATION };
+  }
+  if (typeof raw !== "object") return null;
+  const obj = raw as { classification?: unknown; categories?: unknown };
+  const c = obj.classification;
+  let classification: Classification;
+  if (c === undefined) {
+    classification = DEFAULT_CLASSIFICATION;
+  } else if (
+    typeof c === "string" &&
+    (CLASSIFICATIONS as readonly string[]).includes(c)
+  ) {
+    classification = c as Classification;
+  } else {
+    return null;
+  }
+  const categories = Array.isArray(obj.categories)
+    ? obj.categories.filter((x): x is string => typeof x === "string")
+    : undefined;
+  return categories ? { classification, categories } : { classification };
+}
+
+/**
+ * NEVER-WIDEN composition, mirroring the autonomy gate's rule.
+ *
+ * A later stage may restrict further; it may never restore what an earlier one
+ * removed. Applied by taking the MORE restrictive of two decisions, so ordering
+ * the stages wrongly cannot loosen the result.
+ */
+const RESTRICTIVENESS: Record<BoundaryDecision, number> = {
+  ALLOW: 0,
+  ALLOW_REDACTED: 1,
+  LOCAL_ONLY: 2,
+  REQUIRE_APPROVAL: 3,
+  DENY: 4,
+};
+
+export function narrowest(
+  a: BoundaryOutcome,
+  b: BoundaryOutcome,
+): BoundaryOutcome {
+  return RESTRICTIVENESS[b.decision] > RESTRICTIVENESS[a.decision] ? b : a;
+}

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -8,6 +8,12 @@
  * localFn (Ollama/LM Studio) instead of Anthropic API — opt-in behaviour change.
  */
 
+import {
+  type BoundaryOutcome,
+  type Destination,
+  decideBoundary,
+  parseDataPolicy,
+} from "../privacy/dataPolicy.js";
 import { resolveLocalModel } from "./localSettings.js";
 
 /**
@@ -44,6 +50,17 @@ export interface AgentResult {
 }
 
 export interface AgentExecutorDeps {
+  /**
+   * Receipt sink for information-boundary decisions (ADR-0021 Phase 3).
+   * Optional: an unwired sink means no receipt, never a refusal — the
+   * boundary must not depend on its own audit trail being configured.
+   */
+  recordBoundaryDecisionFn?: (r: {
+    decision: string;
+    reason: string;
+    destinationId?: string;
+    redactCategories?: string[];
+  }) => void;
   anthropicFn: (prompt: string, model: string) => Promise<AgentResult>;
   /** Handles openai, grok, gemini, gemini-api, codex — passes driver name through. */
   providerDriverFn: (
@@ -92,6 +109,19 @@ export interface AgentExecutorInput {
   allowedTools?: string[];
   /** Deny rules via --disallowed-tools (any mode). */
   disallowedTools?: string[];
+  /**
+   * Information-boundary context (ADR-0021). Absent means the step declared no
+   * `data_policy` and no destination is registered, which is byte-identical to
+   * pre-boundary behaviour — the overwhelmingly common case on upgrade.
+   */
+  boundary?: {
+    /** Raw `data_policy` as declared on the step. Parsed here, not by callers. */
+    dataPolicy?: unknown;
+    /** Where this prompt is about to go. */
+    destination?: Destination;
+    /** Whether ANY registered local destination accepts the classification. */
+    localDestinationAccepts?: boolean;
+  };
   /**
    * Worker-autonomy hard requirement. When true, this agent step carries a
    * worker-mandated tool sandbox (see disallowedToolsForAgentStep) that ONLY the
@@ -172,6 +202,36 @@ const CODEX_WORKER_SANDBOX_LOCKDOWN: Record<string, unknown> = {
   webSearch: false,
 };
 
+/**
+ * Evaluate the information boundary for one agent step.
+ *
+ * Returns null when the step declares nothing AND no destination is registered
+ * — byte-identical to pre-boundary behaviour, which is the state of every
+ * existing install.
+ *
+ * A MALFORMED `data_policy` fails closed with DENY rather than defaulting. The
+ * operator wrote a label; silently reading it as `internal` because of a typo
+ * would leave them believing data was protected when it was not.
+ */
+function evaluateBoundary(
+  ctx: AgentExecutorInput["boundary"],
+): BoundaryOutcome | null {
+  if (!ctx?.destination) return null;
+  const policy = parseDataPolicy(ctx.dataPolicy);
+  if (policy === null) {
+    return {
+      decision: "DENY",
+      reason:
+        "data_policy declares an unrecognised classification — refusing rather than defaulting a typo to `internal`",
+    };
+  }
+  return decideBoundary(policy, ctx.destination, {
+    ...(ctx.localDestinationAccepts !== undefined && {
+      localDestinationAccepts: ctx.localDestinationAccepts,
+    }),
+  });
+}
+
 export async function executeAgent(
   input: AgentExecutorInput,
   deps: AgentExecutorDeps,
@@ -202,6 +262,43 @@ export async function executeAgent(
       servedBy: { driver: driver ?? "auto" },
     };
   }
+  // ── INFORMATION BOUNDARY (ADR-0021) ─────────────────────────────────────
+  // Evaluated BEFORE dispatch, and here rather than in `costRouter`, which is
+  // the tempting seam and the wrong one: costRouter short-circuits with no
+  // downshift list and no USD cap, so binding privacy there would cover only
+  // budgeted steps while presenting as total enforcement. This function is on
+  // the unconditional path for both runners.
+  //
+  // Precedence is privacy -> capability -> cost, and it is not negotiable by
+  // the later stages: a cheaper or more capable model that is not authorised
+  // for the data does not become authorised by being cheaper or more capable.
+  const boundary = evaluateBoundary(input.boundary);
+  if (boundary && boundary.decision !== "ALLOW") {
+    deps.recordBoundaryDecisionFn?.({
+      decision: boundary.decision,
+      reason: boundary.reason,
+      destinationId: input.boundary?.destination?.id,
+      ...(boundary.redactCategories && {
+        redactCategories: boundary.redactCategories,
+      }),
+    });
+    // ALLOW_REDACTED is not implemented as a transform in this phase, and is
+    // therefore REFUSED rather than silently sent unredacted. Failing closed on
+    // "we know something must be removed and cannot remove it" is the whole
+    // point; the alternative sends the data and logs that it should not have.
+    return {
+      text: `[agent step failed: information boundary — ${boundary.reason}]`,
+      servedBy: { driver: driver ?? "auto" },
+    };
+  }
+  if (boundary) {
+    deps.recordBoundaryDecisionFn?.({
+      decision: boundary.decision,
+      reason: boundary.reason,
+      destinationId: input.boundary?.destination?.id,
+    });
+  }
+
   const cliOpts =
     mcpAccess !== undefined ||
     sandbox !== undefined ||


### PR DESCRIPTION
Phases 1 and 2, plus the receipt sink. The invariant the ADR states:

  > No model-bound context leaves Patchwork without passing the
  > information-boundary decision point.

ENFORCED AT `executeAgent`, NOT `costRouter`. costRouter is the tempting
seam and the wrong one: it short-circuits with no downshift list and no USD
cap, so binding privacy there would cover only budgeted steps while
presenting as total enforcement — partial protection that reads as complete
is worse than none, because it is trusted. `executeAgent` is on the
unconditional path for both runners and is already fail-closed.

Precedence privacy -> capability -> cost, not negotiable by the later
stages: a cheaper or more capable model that is not authorised for the data
does not become authorised by being cheaper or more capable.

Phase 1, declared labels. `parseDataPolicy` reads a step's `data_policy`.
Absent means `internal` and behaves exactly as today — the same fail-soft
choice `members.json` makes, because a boundary that breaks every existing
install to solve a problem those installs do not have gets switched off. An
UNRECOGNISED classification is REFUSED rather than defaulted: reading
`confidentail` as ordinary internal data is the one failure a declared-labels
scheme cannot afford, since the operator believes they labelled it and the
system believes they did not.

Phase 2, the decision. All five values, a pure function of (declared policy,
destination policy) — no clock, no filesystem, no model. That is what makes
it testable without a model in the loop and what stops the boundary being
enforced by the thing it constrains. `LOCAL_ONLY` is deliberately distinct
from `DENY`: the data may be processed, just not there. `DENY` means no
approval unlocks it, matching the autonomy gate's `forbid` so the two
vocabularies agree. Redaction cannot rescue an uncleared classification —
rule order is pinned by a test, because dropping a tag does not declassify
what remains.

`narrowest()` implements never-widen, mirroring the gate: a later stage may
restrict further, never restore what an earlier one removed.

Phase 3, receipts: the sink is wired and every decision including ALLOW emits
one; no durable store yet. Enforcement does NOT depend on the sink being
configured, and a test pins that — a boundary that refuses only when its
audit trail happens to be wired could be disabled by removing the sink.

`ALLOW_REDACTED` REFUSES. Redaction is not implemented, so a step that must
have a category removed is refused rather than sent unredacted.

The tests assert the DRIVER WAS NEVER CALLED, not merely that the refusal
message says so — asserting on the message alone would pass even if the
prompt had already been sent, which is the only failure that actually
matters here. Verified by mutation: disabling the enforcement branch while
leaving receipts intact fails four tests.

Every fixture is synthetic. ADR-0021's own warning applies hardest to its
tests: a privacy engine that leaks real names in its test data is the
sharpest possible own goal.

NOT BUILT, and the ADR now says so in an implementation note rather than
still reading "Proposed": detection, purpose-based minimisation, least-data
routing, policy packs (regulatory content carrying liability software does
not — if a pack is wrong, the customer's defence is that they bought our
rules). Destinations are caller-supplied; a configuration surface for
registering them is the next slice, and until one exists the boundary is
inert on every install.

Suite: 9774 passing, 3 pre-existing tokenEfficiency failures that reproduce
identically on main.

Refs ADR-0021.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)