### PR TITLE
feat(privacy): destination registry, so the boundary can actually engage

### DIFF
--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -26,8 +26,15 @@
 >   closed; the alternative sends the data and records that it should not have.
 > - **Not built, unchanged from below:** detection, purpose-based
 >   minimisation, least-data routing, policy packs. Destinations are supplied
->   by the caller; a configuration surface for registering them is the next
->   slice, and until one exists the boundary is inert on every install.
+>   by config (`privacy.destinations`) since 2026-08-14 — see
+>   `src/privacy/destinationRegistry.ts`. `executeAgent` resolves its own
+>   destination rather than requiring each of the four dispatch sites to
+>   pass one, because a boundary that depends on every call site
+>   remembering has one bypass per call site. With no `privacy` block the
+>   boundary stays inert; registering a destination is how an operator
+>   OPTS IN. Once opted in it fails CLOSED — an unrecognised driver
+>   resolves to the strictest registered remote, never to "no
+>   destination".
 **Bounded by:** [ADR-0019](0019-open-core-boundary.md) — the engine is MIT and
 lives here; organisation-wide policy is control-plane. See "Open-core boundary".
 **Related:** [ADR-0016](0016-approval-hook-fail-closed.md) (fail-closed gating),

--- a/src/privacy/__tests__/agentBoundary.test.ts
+++ b/src/privacy/__tests__/agentBoundary.test.ts
@@ -133,3 +133,55 @@ describe("executeAgent enforces the information boundary (ADR-0021)", () => {
     expect(result.text).toContain("information boundary");
   });
 });
+
+describe("executeAgent resolves its own destination from config", () => {
+  const CFG = {
+    destinations: {
+      "remote-narrow": {
+        type: "remote",
+        classifications: ["public"],
+        drivers: ["anthropic"],
+      },
+    },
+  };
+
+  it("enforces without the caller passing a destination", async () => {
+    // The property that makes the boundary unconditional: four dispatch sites
+    // exist in the flat runner alone, and a boundary depending on each of them
+    // remembering to pass a destination is a boundary with four bypasses.
+    const ran = vi.fn(async () => ({ text: "out" }));
+    const result = await executeAgent(
+      {
+        prompt: "synthetic prompt",
+        driver: "anthropic",
+        boundary: { dataPolicy: { classification: "confidential" } },
+      },
+      { localFn: ran, loadPrivacyConfigFn: () => CFG } as never,
+    );
+    expect(ran).not.toHaveBeenCalled();
+    expect(result.text).toContain("information boundary");
+  });
+
+  it("enforces even when the step declares NO policy at all", async () => {
+    // Default `internal` against a destination cleared only for `public`.
+    // A step that declares nothing is still governed once the operator has
+    // opted in by registering destinations.
+    const ran = vi.fn(async () => ({ text: "out" }));
+    const result = await executeAgent(
+      { prompt: "synthetic prompt", driver: "anthropic" },
+      { localFn: ran, loadPrivacyConfigFn: () => CFG } as never,
+    );
+    expect(ran).not.toHaveBeenCalled();
+    expect(result.text).toContain("information boundary");
+  });
+
+  it("stays inert when no destinations are configured", async () => {
+    const ran = vi.fn(async () => ({ text: "out" }));
+    await executeAgent({ prompt: "synthetic prompt", driver: "local" }, {
+      localFn: ran,
+      loadPatchworkConfig: () => ({}),
+      loadPrivacyConfigFn: () => undefined,
+    } as never);
+    expect(ran).toHaveBeenCalled();
+  });
+});

--- a/src/privacy/__tests__/destinationRegistry.test.ts
+++ b/src/privacy/__tests__/destinationRegistry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRegistry, resolveDestination } from "../destinationRegistry.js";
+
+// Synthetic throughout — see the note in dataPolicy.test.ts.
+const CFG = {
+  destinations: {
+    "local-profile": {
+      type: "local",
+      classifications: [
+        "public",
+        "internal",
+        "personal",
+        "confidential",
+        "restricted",
+      ],
+      drivers: ["local", "ollama"],
+    },
+    "remote-wide": {
+      type: "remote",
+      classifications: ["public", "internal", "personal"],
+      drivers: ["anthropic"],
+    },
+    "remote-narrow": {
+      type: "remote",
+      classifications: ["public"],
+      drivers: ["thirdparty"],
+    },
+  },
+};
+
+describe("parseRegistry", () => {
+  it("parses valid destinations", () => {
+    const r = parseRegistry(CFG);
+    expect(r.destinations.map((d) => d.id).sort()).toEqual([
+      "local-profile",
+      "remote-narrow",
+      "remote-wide",
+    ]);
+    expect(r.invalid).toEqual([]);
+  });
+
+  it("REPORTS a malformed destination instead of dropping it", () => {
+    // A destination that silently vanishes downgrades enforcement to "no
+    // destination" — the one direction this must never fail in.
+    const r = parseRegistry({
+      destinations: {
+        broken: { type: "sideways", classifications: ["public"] },
+        alsoBroken: { type: "remote", classifications: ["nonsense"] },
+        missing: { type: "remote" },
+      },
+    });
+    expect(r.destinations).toEqual([]);
+    expect(r.invalid.map((i) => i.id).sort()).toEqual([
+      "alsoBroken",
+      "broken",
+      "missing",
+    ]);
+  });
+});
+
+describe("resolveDestination", () => {
+  const reg = parseRegistry(CFG);
+
+  it("is INERT when nothing is registered", () => {
+    // Absence must be byte-identical to pre-boundary behaviour, or every
+    // install that has not configured this starts refusing work.
+    expect(
+      resolveDestination(parseRegistry(undefined), "anthropic", "internal"),
+    ).toBeNull();
+  });
+
+  it("uses an explicit driver mapping", () => {
+    expect(
+      resolveDestination(reg, "anthropic", "internal")?.destination.id,
+    ).toBe("remote-wide");
+    expect(resolveDestination(reg, "ollama", "internal")?.destination.id).toBe(
+      "local-profile",
+    );
+  });
+
+  it("falls back to the STRICTEST remote for an unknown driver", () => {
+    // Fail closed. "We do not recognise where this is going" must never read
+    // as "it is fine to send", and picking the widest remote would do exactly
+    // that for every driver nobody anticipated.
+    const r = resolveDestination(reg, "some-new-driver", "internal");
+    expect(r?.destination.id).toBe("remote-narrow");
+  });
+
+  it("treats an absent driver as unknown, not as local", () => {
+    expect(resolveDestination(reg, undefined, "internal")?.destination.id).toBe(
+      "remote-narrow",
+    );
+  });
+
+  it("reports whether a local destination could take the classification", () => {
+    // Drives LOCAL_ONLY rather than DENY: the data may be processed, just not
+    // at the remote destination.
+    expect(
+      resolveDestination(reg, "anthropic", "restricted")
+        ?.localDestinationAccepts,
+    ).toBe(true);
+
+    const noLocal = parseRegistry({
+      destinations: {
+        "remote-only": {
+          type: "remote",
+          classifications: ["public"],
+          drivers: ["x"],
+        },
+      },
+    });
+    expect(
+      resolveDestination(noLocal, "x", "restricted")?.localDestinationAccepts,
+    ).toBe(false);
+  });
+
+  it("never returns null once anything is registered", () => {
+    // The property that keeps the boundary reachable: any dispatch, any
+    // driver string, still gets a destination to be judged against.
+    for (const drv of ["", "weird", "ANTHROPIC", undefined]) {
+      expect(resolveDestination(reg, drv, "internal")).not.toBeNull();
+    }
+  });
+});

--- a/src/privacy/destinationRegistry.ts
+++ b/src/privacy/destinationRegistry.ts
@@ -1,0 +1,181 @@
+/**
+ * Destination registry (ADR-0021).
+ *
+ * The decision in `dataPolicy.ts` is pure and complete, and until this module
+ * existed it was also unreachable: `executeAgent` only evaluates the boundary
+ * when a destination is supplied, and nothing supplied one. The engine was
+ * built and inert.
+ *
+ * A destination is *where a prompt is about to go*. Patchwork resolves that
+ * from the driver, because that is what actually determines whether bytes
+ * cross a network boundary:
+ *
+ *   local   — a model on this machine (`local`, `ollama`, an OpenAI-compatible
+ *             endpoint pointed at localhost)
+ *   remote  — anything that sends the prompt to a third party
+ *
+ * ## Configuration is opt-in, and absence means inert
+ *
+ * With no `privacy.destinations` block, `resolveDestination` returns null and
+ * `executeAgent` skips the boundary entirely — byte-identical to before. That
+ * is the same fail-soft posture as the default classification, and for the same
+ * reason: a boundary that refuses work on every install that has not configured
+ * it would be switched off before it ever protected anyone.
+ *
+ * The asymmetry is deliberate and worth stating. Configuring a destination is
+ * how an operator OPTS IN to enforcement. Once opted in, the decision is
+ * fail-CLOSED — an unknown driver resolves to the strictest registered remote
+ * profile rather than to "no destination", because "we do not recognise where
+ * this is going" must never read as "it is fine to send".
+ */
+
+import {
+  CLASSIFICATIONS,
+  type Classification,
+  type Destination,
+} from "./dataPolicy.js";
+
+/** Drivers that keep the prompt on this machine. */
+const LOCAL_DRIVERS = new Set(["local", "ollama", "lmstudio", "llamacpp"]);
+
+export interface DestinationConfig {
+  type?: string;
+  classifications?: unknown;
+  forbiddenCategories?: unknown;
+  approvable?: unknown;
+  /** Driver names this destination covers. */
+  drivers?: unknown;
+}
+
+export interface PrivacyConfig {
+  destinations?: Record<string, DestinationConfig>;
+}
+
+function parseClassifications(raw: unknown): Classification[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out: Classification[] = [];
+  for (const v of raw) {
+    if (typeof v !== "string") return null;
+    if (!(CLASSIFICATIONS as readonly string[]).includes(v)) return null;
+    out.push(v as Classification);
+  }
+  return out;
+}
+
+export interface ParsedRegistry {
+  destinations: Destination[];
+  /** Destination id → driver names it covers. */
+  driversFor: Map<string, string[]>;
+  /**
+   * Entries that could not be parsed, with a reason. REPORTED rather than
+   * dropped: a destination that silently vanishes from the registry downgrades
+   * enforcement to "no destination", which is exactly the direction this must
+   * never fail in.
+   */
+  invalid: Array<{ id: string; reason: string }>;
+}
+
+export function parseRegistry(cfg: PrivacyConfig | undefined): ParsedRegistry {
+  const destinations: Destination[] = [];
+  const driversFor = new Map<string, string[]>();
+  const invalid: Array<{ id: string; reason: string }> = [];
+
+  for (const [id, raw] of Object.entries(cfg?.destinations ?? {})) {
+    if (!raw || typeof raw !== "object") {
+      invalid.push({ id, reason: "not an object" });
+      continue;
+    }
+    const type =
+      raw.type === "local" ? "local" : raw.type === "remote" ? "remote" : null;
+    if (!type) {
+      invalid.push({ id, reason: `type must be "local" or "remote"` });
+      continue;
+    }
+    const classifications = parseClassifications(raw.classifications);
+    if (!classifications) {
+      invalid.push({
+        id,
+        reason: "classifications must be an array of known classifications",
+      });
+      continue;
+    }
+    const dest: Destination = { id, type, classifications };
+    if (Array.isArray(raw.forbiddenCategories)) {
+      dest.forbiddenCategories = raw.forbiddenCategories.filter(
+        (c): c is string => typeof c === "string",
+      );
+    }
+    if (raw.approvable === true) dest.approvable = true;
+    destinations.push(dest);
+    driversFor.set(
+      id,
+      Array.isArray(raw.drivers)
+        ? raw.drivers.filter((d): d is string => typeof d === "string")
+        : [],
+    );
+  }
+  return { destinations, driversFor, invalid };
+}
+
+/** The strictest remote destination — fewest classifications wins. */
+function strictestRemote(destinations: Destination[]): Destination | null {
+  const remotes = destinations.filter((d) => d.type === "remote");
+  if (remotes.length === 0) return null;
+  return remotes.reduce((a, b) =>
+    b.classifications.length < a.classifications.length ? b : a,
+  );
+}
+
+export interface ResolvedDestination {
+  destination: Destination;
+  /** True when some registered LOCAL destination is cleared for `forClass`. */
+  localDestinationAccepts: boolean;
+}
+
+/**
+ * Resolve the destination for a dispatch.
+ *
+ * Returns null ONLY when nothing is registered — the inert case. Once anything
+ * is registered, this always yields a destination, because falling back to null
+ * on an unrecognised driver would silently disable the boundary for exactly the
+ * dispatches nobody anticipated.
+ */
+export function resolveDestination(
+  registry: ParsedRegistry,
+  driver: string | undefined,
+  forClass: Classification,
+): ResolvedDestination | null {
+  if (registry.destinations.length === 0) return null;
+
+  const d = (driver ?? "").toLowerCase();
+  const localAccepts = registry.destinations.some(
+    (dest) => dest.type === "local" && dest.classifications.includes(forClass),
+  );
+
+  // Explicit driver mapping wins.
+  for (const dest of registry.destinations) {
+    if ((registry.driversFor.get(dest.id) ?? []).includes(d)) {
+      return { destination: dest, localDestinationAccepts: localAccepts };
+    }
+  }
+
+  // Otherwise infer by driver family.
+  if (LOCAL_DRIVERS.has(d)) {
+    const local = registry.destinations.find((x) => x.type === "local");
+    if (local) {
+      return { destination: local, localDestinationAccepts: localAccepts };
+    }
+  }
+
+  // Unknown or remote driver → strictest remote. Fail closed: "we do not
+  // recognise where this is going" must never read as "it is fine to send".
+  const remote = strictestRemote(registry.destinations);
+  if (remote) {
+    return { destination: remote, localDestinationAccepts: localAccepts };
+  }
+  // Only local destinations are registered but the driver is not local. The
+  // strictest available answer is the local profile, which will refuse
+  // anything it is not cleared for.
+  const first = registry.destinations[0] as Destination;
+  return { destination: first, localDestinationAccepts: localAccepts };
+}

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -10,10 +10,16 @@
 
 import {
   type BoundaryOutcome,
+  DEFAULT_CLASSIFICATION,
   type Destination,
   decideBoundary,
   parseDataPolicy,
 } from "../privacy/dataPolicy.js";
+import {
+  type PrivacyConfig,
+  parseRegistry,
+  resolveDestination,
+} from "../privacy/destinationRegistry.js";
 import { resolveLocalModel } from "./localSettings.js";
 
 /**
@@ -55,6 +61,12 @@ export interface AgentExecutorDeps {
    * Optional: an unwired sink means no receipt, never a refusal — the
    * boundary must not depend on its own audit trail being configured.
    */
+  /**
+   * Supplies `privacy.destinations` from operator config. Absent means the
+   * boundary stays inert unless a caller passes an explicit destination —
+   * the opt-in posture ADR-0021 requires.
+   */
+  loadPrivacyConfigFn?: () => PrivacyConfig | undefined;
   recordBoundaryDecisionFn?: (r: {
     decision: string;
     reason: string;
@@ -215,9 +227,37 @@ const CODEX_WORKER_SANDBOX_LOCKDOWN: Record<string, unknown> = {
  */
 function evaluateBoundary(
   ctx: AgentExecutorInput["boundary"],
+  driver: string | undefined,
+  loadPrivacyConfig: (() => PrivacyConfig | undefined) | undefined,
 ): BoundaryOutcome | null {
-  if (!ctx?.destination) return null;
-  const policy = parseDataPolicy(ctx.dataPolicy);
+  const policy0 = parseDataPolicy(ctx?.dataPolicy);
+
+  // Resolve the destination HERE rather than requiring every call site to pass
+  // one. There are four dispatch sites in the flat runner alone; a boundary
+  // that depends on each of them remembering is a boundary with four ways to
+  // be bypassed, and the fifth call site added later inherits none of them.
+  let destination = ctx?.destination;
+  let localAccepts = ctx?.localDestinationAccepts;
+  if (!destination && loadPrivacyConfig) {
+    const registry = parseRegistry(loadPrivacyConfig());
+    const forClass = policy0?.classification ?? DEFAULT_CLASSIFICATION;
+    const resolved = resolveDestination(registry, driver, forClass);
+    if (resolved) {
+      destination = resolved.destination;
+      localAccepts = resolved.localDestinationAccepts;
+    }
+  }
+  if (!destination) return null;
+  const ctx2 = { ...ctx, destination, localDestinationAccepts: localAccepts };
+  return evaluateAgainst(policy0, ctx2);
+}
+
+function evaluateAgainst(
+  policy: ReturnType<typeof parseDataPolicy>,
+  ctx: NonNullable<AgentExecutorInput["boundary"]> & {
+    destination: Destination;
+  },
+): BoundaryOutcome {
   if (policy === null) {
     return {
       decision: "DENY",
@@ -272,7 +312,11 @@ export async function executeAgent(
   // Precedence is privacy -> capability -> cost, and it is not negotiable by
   // the later stages: a cheaper or more capable model that is not authorised
   // for the data does not become authorised by being cheaper or more capable.
-  const boundary = evaluateBoundary(input.boundary);
+  const boundary = evaluateBoundary(
+    input.boundary,
+    driver,
+    deps.loadPrivacyConfigFn,
+  );
   if (boundary && boundary.decision !== "ALLOW") {
     deps.recordBoundaryDecisionFn?.({
       decision: boundary.decision,


### PR DESCRIPTION
ADR-0021's decision function was built and UNREACHABLE. `executeAgent` only
evaluates the boundary when a destination is supplied, and nothing supplied
one — the engine existed and no dispatch ever passed through it.

`privacy.destinations` in operator config now registers them:

    privacy:
      destinations:
        local-profile:
          type: local
          classifications: [public, internal, personal, confidential, restricted]
          drivers: [local, ollama]
        remote-primary:
          type: remote
          classifications: [public, internal]
          drivers: [anthropic]

RESOLVED INSIDE `executeAgent`, not passed by callers. The flat runner alone
has four dispatch sites; a boundary that depends on each of them remembering
to pass a destination is a boundary with four bypasses, and the fifth call
site added next year inherits none of the care that went into the first four.
Resolving it at the single chokepoint makes enforcement unconditional by
construction rather than by discipline.

Two postures, deliberately opposite, and the asymmetry is the design:

  OPT-IN. No `privacy` block means no destinations means the boundary is
  skipped entirely — byte-identical to before. Same reasoning as the default
  classification: a boundary that refuses work on every install that has not
  configured it gets switched off before it protects anyone.

  FAIL-CLOSED once opted in. An unrecognised driver resolves to the STRICTEST
  registered remote, never to "no destination". "We do not recognise where
  this is going" must never read as "it is fine to send" — and picking the
  widest remote would do exactly that for every driver nobody anticipated.
  Three tests pin this; the mutation that returns null instead fails all
  three.

A malformed destination is REPORTED, not dropped. A destination that silently
vanishes from the registry downgrades enforcement to "no destination", which
is the one direction this must never fail in.

Also proves the boundary governs a step that declares NOTHING: default
`internal` against a destination cleared only for `public` is refused. Opting
in governs everything, not only the steps someone remembered to label.

Suite: 9785 passing, 3 pre-existing tokenEfficiency failures that reproduce
identically on main. Every fixture synthetic.

Refs ADR-0021.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)