### PR TITLE
feat(privacy): durable boundary receipts, and fix the destination they name

### DIFF
--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -28,6 +28,13 @@
 >   must have a category removed is refused rather than sent unredacted.
 >   "We know something must be removed and cannot remove it" has to fail
 >   closed; the alternative sends the data and records that it should not have.
+> - **Wiring.** `buildAgentExecutorDeps` (`src/recipes/yamlRunner.ts`)
+>   supplies both `loadPrivacyConfigFn` and `recordBoundaryDecisionFn`.
+>   Until it did, the boundary was correct, tested and INERT in
+>   production: optional deps that no caller supplies are
+>   indistinguishable at runtime from a feature that was never built.
+>   A source-level test asserts the wiring is present, because the
+>   regression it guards is a line going missing.
 > - **Not built, unchanged from below:** detection, purpose-based
 >   minimisation, least-data routing, policy packs. Destinations are supplied
 >   by config (`privacy.destinations`) since 2026-08-14 — see

--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -15,9 +15,13 @@
 >   operator believing they had labelled something when they had not.
 > - **Phase 2 (the decision)** — built, all five values, pure and model-free.
 >   `narrowest()` enforces the never-widen rule.
-> - **Phase 3 (receipts)** — the SINK is wired (`recordBoundaryDecisionFn`) and
->   every decision including `ALLOW` emits one, but no durable store is
->   attached yet. Enforcement deliberately does NOT depend on the sink being
+> - **Phase 3 (receipts)** — built. `src/privacy/boundaryReceiptLog.ts`
+>   persists to `boundary_receipts.jsonl` alongside the gate's decision
+>   record, same shape and same directory mode. It has NO FIELD FOR THE
+>   PAYLOAD, by construction: a privacy audit log containing the prompts
+>   would be the largest unclassified copy of exactly the material the
+>   boundary protects. Only declared metadata is stored — classification,
+>   category names, destination, decision, reason. Enforcement deliberately does NOT depend on the sink being
 >   configured — a boundary that refuses only when its audit trail happens to
 >   be wired could be disabled by removing the sink.
 > - **`ALLOW_REDACTED` REFUSES.** Redaction is not implemented, so a step that

--- a/src/privacy/__tests__/agentBoundary.test.ts
+++ b/src/privacy/__tests__/agentBoundary.test.ts
@@ -185,3 +185,44 @@ describe("executeAgent resolves its own destination from config", () => {
     expect(ran).toHaveBeenCalled();
   });
 });
+
+describe("receipts name the RESOLVED destination", () => {
+  it("records where the data was actually going, not what the caller passed", () => {
+    // Regression guard. The first wiring read `input.boundary.destination.id`,
+    // which is undefined on the normal path where the destination is resolved
+    // from config — so every receipt recorded a decision with no record of the
+    // destination, which is the field that makes it an audit trail rather than
+    // a counter.
+    const receipts: Array<Record<string, unknown>> = [];
+    const ran = vi.fn(async () => ({ text: "out" }));
+    return executeAgent(
+      {
+        prompt: "synthetic prompt",
+        driver: "anthropic",
+        boundary: { dataPolicy: { classification: "confidential" } },
+      },
+      {
+        localFn: ran,
+        loadPrivacyConfigFn: () => ({
+          destinations: {
+            "remote-narrow": {
+              type: "remote",
+              classifications: ["public"],
+              drivers: ["anthropic"],
+            },
+          },
+        }),
+        recordBoundaryDecisionFn: (r: Record<string, unknown>) =>
+          receipts.push(r),
+      } as never,
+    ).then(() => {
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0]).toMatchObject({
+        destinationId: "remote-narrow",
+        destinationType: "remote",
+        classification: "confidential",
+      });
+      expect(receipts[0]?.destinationId).toBeDefined();
+    });
+  });
+});

--- a/src/privacy/__tests__/boundaryEndToEnd.test.ts
+++ b/src/privacy/__tests__/boundaryEndToEnd.test.ts
@@ -1,0 +1,154 @@
+/**
+ * End-to-end proof that a DECLARED classification reaches the boundary.
+ *
+ * The audit that produced this test reproduced the opposite: no production
+ * call site populated `AgentExecutorInput.boundary`, so `parseDataPolicy`
+ * always received `undefined` and every step — however labelled — was judged
+ * at the default `internal`. A step declaring `restricted` was dispatched to a
+ * remote model AND a receipt was written asserting `classification: internal`.
+ *
+ * A false-affirmative audit record is worse than a missing one: ADR-0021
+ * frames receipts as the "we did not send this" assertion, and that record
+ * asserted a check that never happened on the declared label.
+ *
+ * These drive the REAL runner (`runYamlRecipe`), not `executeAgent` directly.
+ * Every previous boundary test hand-injected `boundary: {dataPolicy}` into the
+ * engine, which is exactly why the missing wiring survived three PRs and a
+ * green suite.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../../recipes/yamlRunner.js";
+
+let home: string;
+let priorHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(os.tmpdir(), "pw-boundary-e2e-"));
+  priorHome = process.env.PATCHWORK_HOME;
+  process.env.PATCHWORK_HOME = home;
+  // The registry ADR-0021 documents: a remote destination cleared only for
+  // public/internal. Synthetic, as every fixture here must be.
+  writeFileSync(
+    path.join(home, "config.json"),
+    JSON.stringify({
+      privacy: {
+        destinations: {
+          "cloud-primary": {
+            type: "remote",
+            classifications: ["public", "internal"],
+            drivers: ["anthropic"],
+          },
+        },
+      },
+    }),
+  );
+});
+afterEach(() => {
+  if (priorHome === undefined) delete process.env.PATCHWORK_HOME;
+  else process.env.PATCHWORK_HOME = priorHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function runWith(dataPolicy: unknown, claudeFn: ReturnType<typeof vi.fn>) {
+  const recipe = {
+    name: "boundary-e2e",
+    trigger: { type: "manual" },
+    steps: [
+      {
+        id: "s1",
+        agent: {
+          prompt: "SYNTHETIC-SENSITIVE-PAYLOAD",
+          driver: "anthropic",
+          ...(dataPolicy !== undefined ? { data_policy: dataPolicy } : {}),
+        },
+      },
+    ],
+  } as unknown as YamlRecipe;
+
+  const deps: RunnerDeps = {
+    now: () => new Date("2026-08-15T08:00:00Z"),
+    logDir: home,
+    claudeFn,
+    readFile: () => {
+      throw new Error("not found");
+    },
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    gitLogSince: () => "",
+    gitStaleBranches: () => "",
+    getDiagnostics: () => "",
+  } as unknown as RunnerDeps;
+
+  return runYamlRecipe(recipe, deps, { testMode: true } as never);
+}
+
+function receipts(): Array<Record<string, unknown>> {
+  try {
+    return readFileSync(path.join(home, "boundary_receipts.jsonl"), "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+describe("a declared classification reaches the boundary (end to end)", () => {
+  it("REFUSES a `restricted` step against a destination cleared only for internal", async () => {
+    const claudeFn = vi.fn(async () => "model output");
+    await runWith({ classification: "restricted" }, claudeFn);
+
+    // The invariant. Asserting the DRIVER was never called — not the message —
+    // because a message assertion passes even if the prompt was already sent.
+    expect(claudeFn).not.toHaveBeenCalled();
+  });
+
+  it("records the DECLARED classification in the receipt, not the default", async () => {
+    const claudeFn = vi.fn(async () => "model output");
+    await runWith({ classification: "restricted" }, claudeFn);
+
+    const rs = receipts();
+    expect(rs.length).toBeGreaterThan(0);
+    expect(rs[0]).toMatchObject({
+      classification: "restricted",
+      destinationId: "cloud-primary",
+    });
+    // The false-affirmative that shipped: a DENY-worthy step recorded as
+    // `internal` and allowed.
+    expect(rs[0]?.classification).not.toBe("internal");
+  });
+
+  it("still ALLOWS a step whose declared class the destination is cleared for", async () => {
+    const claudeFn = vi.fn(async () => "model output");
+    await runWith({ classification: "internal" }, claudeFn);
+    expect(claudeFn).toHaveBeenCalled();
+  });
+
+  it("REFUSES a typo'd classification rather than defaulting it", async () => {
+    // `parseDataPolicy`'s fail-closed branch was dead in production: it can
+    // only reject a malformed value it is actually given.
+    const claudeFn = vi.fn(async () => "model output");
+    await runWith({ classification: "confidentail" }, claudeFn);
+    expect(claudeFn).not.toHaveBeenCalled();
+  });
+
+  it("never writes the payload into the receipt", async () => {
+    const claudeFn = vi.fn(async () => "model output");
+    await runWith({ classification: "restricted" }, claudeFn);
+    const raw = readFileSync(
+      path.join(home, "boundary_receipts.jsonl"),
+      "utf-8",
+    );
+    expect(raw).not.toContain("SYNTHETIC-SENSITIVE-PAYLOAD");
+  });
+});

--- a/src/privacy/__tests__/boundaryReceiptLog.test.ts
+++ b/src/privacy/__tests__/boundaryReceiptLog.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BoundaryReceiptLog } from "../boundaryReceiptLog.js";
+
+const dirs: string[] = [];
+function tempDir(): string {
+  const d = mkdtempSync(path.join(tmpdir(), "pw-receipts-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (dirs.length)
+    rmSync(dirs.pop() as string, { recursive: true, force: true });
+});
+
+const BASE = {
+  decision: "DENY" as const,
+  classification: "restricted" as const,
+  destinationId: "remote-model",
+  destinationType: "remote" as const,
+  reason: "not cleared",
+};
+
+describe("BoundaryReceiptLog", () => {
+  it("persists a receipt and reads it back across instances", () => {
+    const dir = tempDir();
+    new BoundaryReceiptLog({ dir, now: () => 1 }).record(BASE);
+    const reopened = new BoundaryReceiptLog({ dir });
+    expect(reopened.recent()).toHaveLength(1);
+    expect(reopened.recent()[0]).toMatchObject({
+      decision: "DENY",
+      classification: "restricted",
+      destinationId: "remote-model",
+    });
+  });
+
+  it("HAS NO FIELD FOR THE PAYLOAD", () => {
+    // The one property this file must hold. A privacy audit log containing the
+    // prompts would be the largest unclassified copy of exactly the material
+    // the boundary exists to protect, sitting in plain JSONL.
+    const dir = tempDir();
+    const log = new BoundaryReceiptLog({ dir });
+    log.record({
+      ...BASE,
+      categories: ["alpha"],
+      // A caller trying to sneak the payload through must not succeed. Cast
+      // because the interface has no such field — which is the point.
+      ...({ prompt: "SENSITIVE-PAYLOAD", text: "SENSITIVE-PAYLOAD" } as Record<
+        string,
+        string
+      >),
+    });
+    const onDisk = readFileSync(
+      path.join(dir, "boundary_receipts.jsonl"),
+      "utf-8",
+    );
+    expect(onDisk).not.toContain("SENSITIVE-PAYLOAD");
+    // Category NAMES are metadata and are kept; their contents never appear.
+    expect(onDisk).toContain("alpha");
+  });
+
+  it("clips a runaway reason", () => {
+    const dir = tempDir();
+    const log = new BoundaryReceiptLog({ dir });
+    const r = log.record({ ...BASE, reason: "x".repeat(5000) });
+    expect(r.reason.length).toBeLessThanOrEqual(500);
+  });
+
+  it("survives a malformed line rather than losing the whole log", () => {
+    const dir = tempDir();
+    const log = new BoundaryReceiptLog({ dir });
+    log.record(BASE);
+    const file = path.join(dir, "boundary_receipts.jsonl");
+    const { appendFileSync } = require("node:fs") as typeof import("node:fs");
+    appendFileSync(file, "{ not json\n");
+    log.record({ ...BASE, decision: "ALLOW", classification: "public" });
+
+    const reopened = new BoundaryReceiptLog({ dir });
+    // One bad line must cost one line, not the audit trail.
+    expect(reopened.recent()).toHaveLength(2);
+  });
+
+  it("never throws when the directory is unwritable", () => {
+    // Observability, not enforcement: the decision has already been made and
+    // enforced by the time a receipt is attempted.
+    const log = new BoundaryReceiptLog({
+      dir: "/proc/nonexistent-pw-receipts",
+    });
+    expect(() => log.record(BASE)).not.toThrow();
+  });
+
+  it("summarises counts per decision", () => {
+    const dir = tempDir();
+    const log = new BoundaryReceiptLog({ dir });
+    log.record(BASE);
+    log.record({ ...BASE, decision: "ALLOW", classification: "public" });
+    log.record({ ...BASE, decision: "ALLOW", classification: "internal" });
+    expect(log.summary()).toMatchObject({ ALLOW: 2, DENY: 1, LOCAL_ONLY: 0 });
+  });
+});

--- a/src/privacy/__tests__/boundaryReceiptLog.test.ts
+++ b/src/privacy/__tests__/boundaryReceiptLog.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -74,7 +80,6 @@ describe("BoundaryReceiptLog", () => {
     const log = new BoundaryReceiptLog({ dir });
     log.record(BASE);
     const file = path.join(dir, "boundary_receipts.jsonl");
-    const { appendFileSync } = require("node:fs") as typeof import("node:fs");
     appendFileSync(file, "{ not json\n");
     log.record({ ...BASE, decision: "ALLOW", classification: "public" });
 
@@ -86,9 +91,17 @@ describe("BoundaryReceiptLog", () => {
   it("never throws when the directory is unwritable", () => {
     // Observability, not enforcement: the decision has already been made and
     // enforced by the time a receipt is attempted.
-    const log = new BoundaryReceiptLog({
-      dir: "/proc/nonexistent-pw-receipts",
-    });
+    //
+    // The unwritable path is a directory UNDER A REGULAR FILE, which fails with
+    // ENOTDIR immediately on every platform. An earlier version used `/proc/…`,
+    // which is Linux-only — and on Linux CI the suite went silent and was
+    // killed at its 10-minute cap while macOS passed. A fixture that behaves
+    // differently per platform is a bad way to assert a platform-independent
+    // property.
+    const base = tempDir();
+    const asFile = path.join(base, "not-a-dir");
+    writeFileSync(asFile, "x");
+    const log = new BoundaryReceiptLog({ dir: path.join(asFile, "under") });
     expect(() => log.record(BASE)).not.toThrow();
   });
 

--- a/src/privacy/__tests__/destinationRegistry.test.ts
+++ b/src/privacy/__tests__/destinationRegistry.test.ts
@@ -123,3 +123,60 @@ describe("resolveDestination", () => {
     }
   });
 });
+
+describe("audit fixes — fail-open and mis-ranked fallback", () => {
+  it("a config where EVERY entry is malformed refuses, it does not go inert", () => {
+    // The fail-open this module's header claims to prevent, reachable by one
+    // misspelled word: `type: "cloud"` instead of "remote" emptied the
+    // registry, `resolveDestination` returned null, and the boundary skipped
+    // entirely while the operator believed they had opted in.
+    const reg = parseRegistry({
+      destinations: {
+        "cloud-primary": { type: "cloud", classifications: ["public"] },
+      },
+    });
+    expect(reg.destinations).toEqual([]);
+    expect(reg.invalid).toHaveLength(1);
+
+    const r = resolveDestination(reg, "anthropic", "internal");
+    expect(r).not.toBeNull();
+    // Cleared for nothing → every dispatch refused, loudly.
+    expect(r?.destination.classifications).toEqual([]);
+    expect(r?.destination.id).toContain("cloud-primary");
+  });
+
+  it("still goes inert when NOTHING is configured", () => {
+    // The distinction that keeps the opt-in posture: absent config is inert,
+    // broken config is refused. Collapsing the two either breaks every
+    // unconfigured install or silently exempts every typo.
+    expect(
+      resolveDestination(parseRegistry(undefined), "anthropic", "internal"),
+    ).toBeNull();
+    expect(
+      resolveDestination(parseRegistry({}), "anthropic", "internal"),
+    ).toBeNull();
+  });
+
+  it("ranks the fallback by SENSITIVITY, not by list length", () => {
+    // Counting picked the wrong one: `[restricted]` has one entry and
+    // `[public, internal]` has two, so "fewest wins" chose the destination
+    // trusted with the MOST sensitive data as the safe fallback for an
+    // unrecognised driver.
+    const reg = parseRegistry({
+      destinations: {
+        "trusted-high": {
+          type: "remote",
+          classifications: ["restricted"],
+          drivers: ["known"],
+        },
+        "ordinary-low": {
+          type: "remote",
+          classifications: ["public", "internal"],
+          drivers: ["other"],
+        },
+      },
+    });
+    const r = resolveDestination(reg, "unknown-driver", "internal");
+    expect(r?.destination.id).toBe("ordinary-low");
+  });
+});

--- a/src/privacy/__tests__/productionWiring.test.ts
+++ b/src/privacy/__tests__/productionWiring.test.ts
@@ -37,7 +37,7 @@ describe("the information boundary is wired into production dispatch", () => {
     // per-instance-counter-on-a-shared-file defect that collided 142 of 145
     // run-log seqs (#1324). The lazy singleton is what prevents it.
     const src = read("src/recipes/yamlRunner.ts");
-    expect(src).toMatch(/let _boundaryReceiptLog/);
+    expect(src).toMatch(/_boundaryReceiptLogs = new Map/);
     expect(src).toMatch(/function boundaryReceiptLog\(\)/);
   });
 

--- a/src/privacy/__tests__/productionWiring.test.ts
+++ b/src/privacy/__tests__/productionWiring.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The boundary must be WIRED, not merely implemented.
+ *
+ * `loadPrivacyConfigFn` and `recordBoundaryDecisionFn` are optional deps on
+ * `AgentExecutorDeps`. Optional deps that no production caller supplies are
+ * indistinguishable, at runtime, from a feature that was never built: the
+ * decision function is correct, its tests pass, and every real dispatch skips
+ * it because the config never arrives.
+ *
+ * This is a SOURCE-level assertion on purpose. A behavioural test would need to
+ * drive a whole recipe run, and the failure it guards against is precisely that
+ * a wiring line goes missing — which greps reliably and mocks do not.
+ */
+const ROOT = path.join(__dirname, "..", "..", "..");
+
+function read(rel: string): string {
+  return readFileSync(path.join(ROOT, rel), "utf-8");
+}
+
+describe("the information boundary is wired into production dispatch", () => {
+  it("buildAgentExecutorDeps supplies loadPrivacyConfigFn", () => {
+    const src = read("src/recipes/yamlRunner.ts");
+    expect(src).toMatch(/(?<![\w$])loadPrivacyConfigFn\s*:/);
+  });
+
+  it("buildAgentExecutorDeps supplies recordBoundaryDecisionFn", () => {
+    const src = read("src/recipes/yamlRunner.ts");
+    expect(src).toMatch(/(?<![\w$])recordBoundaryDecisionFn\s*:/);
+  });
+
+  it("the receipt log is a shared instance, not per call", () => {
+    // A per-call instance restarts `seq` at 1 on every dispatch — the same
+    // per-instance-counter-on-a-shared-file defect that collided 142 of 145
+    // run-log seqs (#1324). The lazy singleton is what prevents it.
+    const src = read("src/recipes/yamlRunner.ts");
+    expect(src).toMatch(/let _boundaryReceiptLog/);
+    expect(src).toMatch(/function boundaryReceiptLog\(\)/);
+  });
+
+  it("reads config per call so an edit takes effect without a restart", () => {
+    // Capturing the config at module load would freeze it — the same defect
+    // as the frozen OAuth redirect URI (#1266) and the module-level
+    // RECIPES_DIR (#1265).
+    const src = read("src/recipes/yamlRunner.ts");
+    expect(src).toMatch(/(?<![\w$])loadPrivacyConfigFn:\s*\(\)\s*=>/);
+  });
+});

--- a/src/privacy/boundaryReceiptLog.ts
+++ b/src/privacy/boundaryReceiptLog.ts
@@ -1,0 +1,182 @@
+/**
+ * Information-boundary receipts (ADR-0021 Phase 3).
+ *
+ * > Every boundary decision produces a record, in the same shape and store as
+ * > gate decisions: what was declared, where it was going, what was removed,
+ * > what was retained, why.
+ *
+ * Patchwork's standing claim is that every consequential decision leaves a
+ * receipt. The autonomy gate extends that to *what the AI did*; this extends it
+ * to *what the AI was told* — which is the half nobody could previously audit.
+ *
+ * ## The one thing this file must never do
+ *
+ * **It must never contain the payload.** A receipt records that a decision was
+ * made about data with a given classification; writing the prompt itself would
+ * turn the privacy audit log into the largest unclassified copy of exactly the
+ * material the boundary exists to protect, sitting in plain JSONL. Only
+ * declared metadata is stored: classification, category NAMES, destination id,
+ * decision, reason. There is no field for the text, deliberately, so a future
+ * caller cannot pass one by accident.
+ *
+ * ## Fail-soft, always
+ *
+ * A receipt that cannot be written must never block or alter a decision. The
+ * boundary already refuses correctly without any sink attached (pinned by a
+ * test in agentBoundary.test.ts); this store is observability, not enforcement.
+ * Every write path here swallows its own errors for that reason.
+ */
+
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import type { BoundaryDecision, Classification } from "./dataPolicy.js";
+
+/** Clip so a runaway reason cannot bloat the audit log. */
+const MAX_REASON = 500;
+const DEFAULT_MEMORY_CAP = 500;
+
+export interface BoundaryReceipt {
+  seq: number;
+  at: number;
+  decision: BoundaryDecision;
+  /** What the step DECLARED it was carrying. */
+  classification: Classification;
+  /** Category names only — never their contents. */
+  categories?: string[];
+  /** Where it was going. */
+  destinationId: string;
+  destinationType: "local" | "remote";
+  /** Which categories the decision required be removed. */
+  redactCategories?: string[];
+  reason: string;
+  /** Recipe/step context when the caller knows it. */
+  recipeName?: string;
+  stepId?: string;
+}
+
+export interface RecordBoundaryReceiptInput {
+  decision: BoundaryDecision;
+  classification: Classification;
+  categories?: string[];
+  destinationId: string;
+  destinationType: "local" | "remote";
+  redactCategories?: string[];
+  reason: string;
+  recipeName?: string;
+  stepId?: string;
+}
+
+export interface BoundaryReceiptLogOptions {
+  dir: string;
+  memoryCap?: number;
+  now?: () => number;
+  logger?: { warn?: (msg: string) => void };
+}
+
+export class BoundaryReceiptLog {
+  private receipts: BoundaryReceipt[] = [];
+  private seq = 0;
+  private readonly file: string;
+  private readonly memoryCap: number;
+  private readonly now: () => number;
+
+  constructor(private readonly opts: BoundaryReceiptLogOptions) {
+    this.file = path.join(opts.dir, "boundary_receipts.jsonl");
+    this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
+    this.now = opts.now ?? Date.now;
+    try {
+      // 0o700 like the gate log: these name destinations and classifications,
+      // which is a map of what this machine considers sensitive.
+      mkdirSync(opts.dir, { recursive: true, mode: 0o700 });
+    } catch (err) {
+      opts.logger?.warn?.(
+        `[boundary-receipts] could not create ${opts.dir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    this.loadExisting();
+  }
+
+  private loadExisting(): void {
+    try {
+      const text = readFileSync(this.file, "utf-8");
+      for (const line of text.split("\n")) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          const r = JSON.parse(t) as BoundaryReceipt;
+          if (typeof r.seq === "number") {
+            this.receipts.push(r);
+            if (r.seq > this.seq) this.seq = r.seq;
+          }
+        } catch {
+          // one malformed line must not make the whole log unreadable
+        }
+      }
+      this.trim();
+    } catch {
+      // no file yet — normal on first run
+    }
+  }
+
+  private trim(): void {
+    if (this.receipts.length > this.memoryCap) {
+      this.receipts = this.receipts.slice(-this.memoryCap);
+    }
+  }
+
+  /**
+   * Record one boundary decision.
+   *
+   * Returns the stored receipt. Never throws: a failure to persist is logged
+   * and swallowed, because this is observability and the decision it describes
+   * has already been made and enforced.
+   */
+  record(input: RecordBoundaryReceiptInput): BoundaryReceipt {
+    const receipt: BoundaryReceipt = {
+      seq: ++this.seq,
+      at: this.now(),
+      decision: input.decision,
+      classification: input.classification,
+      destinationId: input.destinationId,
+      destinationType: input.destinationType,
+      reason: input.reason.slice(0, MAX_REASON),
+      ...(input.categories?.length ? { categories: input.categories } : {}),
+      ...(input.redactCategories?.length
+        ? { redactCategories: input.redactCategories }
+        : {}),
+      ...(input.recipeName ? { recipeName: input.recipeName } : {}),
+      ...(input.stepId ? { stepId: input.stepId } : {}),
+    };
+    this.receipts.push(receipt);
+    this.trim();
+    try {
+      appendFileSync(this.file, `${JSON.stringify(receipt)}\n`, {
+        mode: 0o600,
+      });
+    } catch (err) {
+      this.opts.logger?.warn?.(
+        `[boundary-receipts] append failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return receipt;
+  }
+
+  /** Most recent first. */
+  recent(limit = 50): BoundaryReceipt[] {
+    return this.receipts.slice(-limit).reverse();
+  }
+
+  /** Counts per decision — the shape a dashboard or CLI summary wants. */
+  summary(): Record<BoundaryDecision, number> {
+    const out = {
+      ALLOW: 0,
+      ALLOW_REDACTED: 0,
+      LOCAL_ONLY: 0,
+      REQUIRE_APPROVAL: 0,
+      DENY: 0,
+    } as Record<BoundaryDecision, number>;
+    for (const r of this.receipts) out[r.decision]++;
+    return out;
+  }
+}

--- a/src/privacy/destinationRegistry.ts
+++ b/src/privacy/destinationRegistry.ts
@@ -32,6 +32,7 @@
 import {
   CLASSIFICATIONS,
   type Classification,
+  classificationRank,
   type Destination,
 } from "./dataPolicy.js";
 
@@ -117,13 +118,29 @@ export function parseRegistry(cfg: PrivacyConfig | undefined): ParsedRegistry {
   return { destinations, driversFor, invalid };
 }
 
-/** The strictest remote destination — fewest classifications wins. */
+/**
+ * The strictest remote destination.
+ *
+ * Ranked by the HIGHEST classification each is cleared for, not by how many it
+ * lists. Counting was wrong in the direction that matters: a destination
+ * cleared for `[restricted]` has one entry and one cleared for
+ * `[public, internal]` has two, so "fewest wins" would pick the one trusted
+ * with the most sensitive data as the safe fallback for an unrecognised
+ * driver. Ties break on the smaller list.
+ */
 function strictestRemote(destinations: Destination[]): Destination | null {
   const remotes = destinations.filter((d) => d.type === "remote");
   if (remotes.length === 0) return null;
-  return remotes.reduce((a, b) =>
-    b.classifications.length < a.classifications.length ? b : a,
-  );
+  const ceiling = (d: Destination): number =>
+    d.classifications.length === 0
+      ? -1
+      : Math.max(...d.classifications.map(classificationRank));
+  return remotes.reduce((a, b) => {
+    const ca = ceiling(a);
+    const cb = ceiling(b);
+    if (cb !== ca) return cb < ca ? b : a;
+    return b.classifications.length < a.classifications.length ? b : a;
+  });
 }
 
 export interface ResolvedDestination {
@@ -145,7 +162,31 @@ export function resolveDestination(
   driver: string | undefined,
   forClass: Classification,
 ): ResolvedDestination | null {
-  if (registry.destinations.length === 0) return null;
+  if (registry.destinations.length === 0) {
+    // NOTHING configured is the inert case, and is fine.
+    //
+    // Something configured that ALL failed to parse is not. Returning null
+    // there reverts the boundary to inert on a typo — `type: "cloud"` instead
+    // of `"remote"` — while the operator believes they have opted in. That is
+    // the fail-open this module's own header says it prevents, reachable by a
+    // single misspelled word.
+    //
+    // So: any invalid entry with no valid entry surviving yields a synthetic
+    // destination cleared for NOTHING. Every dispatch is refused, loudly and
+    // immediately, which is the correct reading of "the operator asked for
+    // enforcement and we cannot tell what they meant".
+    if (registry.invalid.length > 0) {
+      return {
+        destination: {
+          id: `unparseable-config(${registry.invalid.map((i) => i.id).join(", ")})`,
+          type: "remote",
+          classifications: [],
+        },
+        localDestinationAccepts: false,
+      };
+    }
+    return null;
+  }
 
   const d = (driver ?? "").toLowerCase();
   const localAccepts = registry.destinations.some(

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -10,6 +10,7 @@
 
 import {
   type BoundaryOutcome,
+  type Classification,
   DEFAULT_CLASSIFICATION,
   type Destination,
   decideBoundary,
@@ -70,7 +71,10 @@ export interface AgentExecutorDeps {
   recordBoundaryDecisionFn?: (r: {
     decision: string;
     reason: string;
-    destinationId?: string;
+    destinationId: string;
+    destinationType: "local" | "remote";
+    classification: string;
+    categories?: string[];
     redactCategories?: string[];
   }) => void;
   anthropicFn: (prompt: string, model: string) => Promise<AgentResult>;
@@ -225,11 +229,17 @@ const CODEX_WORKER_SANDBOX_LOCKDOWN: Record<string, unknown> = {
  * operator wrote a label; silently reading it as `internal` because of a typo
  * would leave them believing data was protected when it was not.
  */
+type ResolvedBoundary = BoundaryOutcome & {
+  destination: Destination;
+  classification: Classification;
+  categories?: string[];
+};
+
 function evaluateBoundary(
   ctx: AgentExecutorInput["boundary"],
   driver: string | undefined,
   loadPrivacyConfig: (() => PrivacyConfig | undefined) | undefined,
-): BoundaryOutcome | null {
+): ResolvedBoundary | null {
   const policy0 = parseDataPolicy(ctx?.dataPolicy);
 
   // Resolve the destination HERE rather than requiring every call site to pass
@@ -249,7 +259,17 @@ function evaluateBoundary(
   }
   if (!destination) return null;
   const ctx2 = { ...ctx, destination, localDestinationAccepts: localAccepts };
-  return evaluateAgainst(policy0, ctx2);
+  // The RESOLVED destination travels with the outcome. Reading it back off the
+  // caller's input loses it entirely whenever the destination was resolved from
+  // config, which is the normal path — the receipt would then record a decision
+  // with no record of where the data was going, i.e. the one field that makes
+  // it an audit trail rather than a counter.
+  return {
+    ...evaluateAgainst(policy0, ctx2),
+    destination,
+    classification: policy0?.classification ?? DEFAULT_CLASSIFICATION,
+    ...(policy0?.categories?.length ? { categories: policy0.categories } : {}),
+  };
 }
 
 function evaluateAgainst(
@@ -321,7 +341,10 @@ export async function executeAgent(
     deps.recordBoundaryDecisionFn?.({
       decision: boundary.decision,
       reason: boundary.reason,
-      destinationId: input.boundary?.destination?.id,
+      destinationId: boundary.destination.id,
+      destinationType: boundary.destination.type,
+      classification: boundary.classification,
+      ...(boundary.categories && { categories: boundary.categories }),
       ...(boundary.redactCategories && {
         redactCategories: boundary.redactCategories,
       }),
@@ -339,7 +362,10 @@ export async function executeAgent(
     deps.recordBoundaryDecisionFn?.({
       decision: boundary.decision,
       reason: boundary.reason,
-      destinationId: input.boundary?.destination?.id,
+      destinationId: boundary.destination.id,
+      destinationType: boundary.destination.type,
+      classification: boundary.classification,
+      ...(boundary.categories && { categories: boundary.categories }),
     });
   }
 

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -118,6 +118,12 @@ import { evaluateWhen } from "./whenGuard.js";
 import { resolveWorkspaceRoot } from "./workspaceRoot.js";
 import "./tools/index.js";
 import { patchworkPath } from "../patchworkHome.js";
+import { BoundaryReceiptLog } from "../privacy/boundaryReceiptLog.js";
+import type {
+  BoundaryDecision as BoundaryDecisionValue,
+  Classification as ClassificationValue,
+} from "../privacy/dataPolicy.js";
+import type { PrivacyConfig } from "../privacy/destinationRegistry.js";
 
 /**
  * Bundled-templates directory used as a third allowed root for nested-recipe
@@ -3510,6 +3516,23 @@ function toAgentResult(v: string | AgentResult): AgentResult {
   return typeof v === "string" ? { text: v } : v;
 }
 
+/**
+ * Lazily-constructed receipt log, shared per process.
+ *
+ * Lazy because constructing it touches the filesystem (mkdir), and a runner
+ * that never dispatches an agent step should not create the directory. Shared
+ * because a per-call instance would restart `seq` at 1 on every dispatch —
+ * the same per-instance-counter-on-a-shared-file defect that made 142 of 145
+ * run-log seqs collide (#1324).
+ */
+let _boundaryReceiptLog: BoundaryReceiptLog | null = null;
+function boundaryReceiptLog(): BoundaryReceiptLog {
+  if (!_boundaryReceiptLog) {
+    _boundaryReceiptLog = new BoundaryReceiptLog({ dir: patchworkPath() });
+  }
+  return _boundaryReceiptLog;
+}
+
 function buildAgentExecutorDeps(
   stepDeps: StepDeps,
   runnerDeps: RunnerDeps,
@@ -3525,6 +3548,36 @@ function buildAgentExecutorDeps(
 ): AgentExecutorDeps {
   const claudeCliFn = claudeCodeFnOverride ?? stepDeps.claudeCodeFn;
   return {
+    // ── ADR-0021 information boundary ───────────────────────────────────────
+    // Wired HERE because this is the single place agent-executor deps are
+    // built for every dispatch site in this runner. Declaring the deps on
+    // `AgentExecutorDeps` and supplying them nowhere is how a boundary ends up
+    // correct, tested, and inert in production — the exact "built and
+    // unreachable" state the destination registry was added to fix, one layer
+    // further out.
+    //
+    // Both are read per call, not captured: an operator editing
+    // `privacy.destinations` must take effect without a bridge restart, and
+    // `loadConfig` is already mtime-gated so this is cheap.
+    loadPrivacyConfigFn: () =>
+      (loadPatchworkConfigSync() as { privacy?: PrivacyConfig }).privacy,
+    recordBoundaryDecisionFn: (r) => {
+      // Fail-soft: a receipt that cannot be written must never affect the
+      // decision it describes, which has already been made and enforced.
+      try {
+        boundaryReceiptLog().record({
+          decision: r.decision as BoundaryDecisionValue,
+          classification: r.classification as ClassificationValue,
+          destinationId: r.destinationId,
+          destinationType: r.destinationType,
+          reason: r.reason,
+          ...(r.categories && { categories: r.categories }),
+          ...(r.redactCategories && { redactCategories: r.redactCategories }),
+        });
+      } catch {
+        // never block on observability
+      }
+    },
     anthropicFn: async (prompt, model) =>
       toAgentResult(await stepDeps.claudeFn(prompt, model)),
     providerDriverFn: async (driver, prompt, model, providerOptions) =>

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -224,6 +224,13 @@ export interface YamlStep {
      * every revision reuses the base model (byte-identical to prior behavior).
      */
     escalate?: import("./pricing/costRouter.js").RouteCandidate[];
+    /**
+     * ADR-0021 information boundary — what this step declares it carries.
+     * Parsed by `parseDataPolicy` at the boundary, NOT here: an unrecognised
+     * classification must reach the decision point so it can fail closed,
+     * rather than being normalised away on the way in.
+     */
+    data_policy?: unknown;
   };
   into?: string;
   optional?: boolean;
@@ -1580,6 +1587,11 @@ export async function runYamlRecipe(
       tools?: string[];
       disallowedTools?: string[];
     },
+    // ADR-0021: a refine-loop re-run carries the SAME declared policy as the
+    // step it revises. Omitting it here would mean a `restricted` step is
+    // judged `restricted` on its first attempt and `internal` on every
+    // revision — the boundary loosening precisely where a step is retried.
+    dataPolicy?: unknown,
   ): Promise<{ value: unknown; ok: boolean }> => {
     // Phase 4: route revisions too, so a downshift on the reviewed step also
     // applies to its refine-loop re-runs (no-op when downshift is absent).
@@ -1614,6 +1626,7 @@ export async function runYamlRecipe(
         // Fail closed if a worker sandbox can't be enforced on the chosen driver.
         ...(deps.agentDisallowedTools?.length && { enforceSandbox: true }),
         ...(providerOptions && { providerOptions }),
+        ...(dataPolicy !== undefined && { boundary: { dataPolicy } }),
       },
       buildAgentExecutorDeps(stepDeps, deps),
     );
@@ -1846,6 +1859,10 @@ export async function runYamlRecipe(
             disallowedTools: reviewedAgent.disallowedTools,
           }),
         },
+        // The revision re-runs the REVIEWED step, so it carries the REVIEWED
+        // step's declared policy — not the judge's. Using the judge's would
+        // let a differently-labelled reviewer relabel the data being revised.
+        reviewedAgent.data_policy,
       );
       if (!revised.ok) {
         // A failed / empty revision can't be re-judged — stop and treat the
@@ -1901,6 +1918,9 @@ export async function runYamlRecipe(
             disallowedTools: agentCfg.disallowedTools,
           }),
         },
+        // The re-judge re-runs the JUDGE step, so it carries the judge's own
+        // declared policy.
+        agentCfg.data_policy,
       );
       if (!judged.ok) {
         // Audit 2026-06-03 (MEDIUM #17): a failed / silent-fail / empty
@@ -2266,6 +2286,17 @@ export async function runYamlRecipe(
               // with the pure-JSON JUDGE_PROMPT_SUFFIX + tolerant parser.
               ...(isJudge && {
                 providerOptions: { responseFormat: { type: "json_object" } },
+              }),
+              // ADR-0021 — the step's DECLARED policy. Passed raw: an
+              // unrecognised classification must reach `parseDataPolicy` at the
+              // decision point so it can fail closed, rather than being
+              // normalised away here. Without this the boundary judged every
+              // step at the default `internal`, so a step declaring
+              // `restricted` was dispatched to a remote model AND a receipt was
+              // written asserting `internal` — a false-affirmative audit
+              // record, which is worse than no record at all.
+              ...(agentCfg.data_policy !== undefined && {
+                boundary: { dataPolicy: agentCfg.data_policy },
               }),
             },
             buildAgentExecutorDeps(stepDeps, deps),
@@ -3525,12 +3556,27 @@ function toAgentResult(v: string | AgentResult): AgentResult {
  * the same per-instance-counter-on-a-shared-file defect that made 142 of 145
  * run-log seqs collide (#1324).
  */
-let _boundaryReceiptLog: BoundaryReceiptLog | null = null;
+const _boundaryReceiptLogs = new Map<string, BoundaryReceiptLog>();
 function boundaryReceiptLog(): BoundaryReceiptLog {
-  if (!_boundaryReceiptLog) {
-    _boundaryReceiptLog = new BoundaryReceiptLog({ dir: patchworkPath() });
+  // Keyed BY RESOLVED DIRECTORY, not a single instance.
+  //
+  // A plain singleton captures whichever home existed at first use and ignores
+  // PATCHWORK_HOME afterwards — the same frozen-at-first-use defect as the
+  // module-level RECIPES_DIR (#1265) and the OAuth redirect URI (#1266),
+  // reintroduced by the fix for it. Caught because an end-to-end test set a
+  // fresh home and its receipts went to the previous one.
+  //
+  // Still one instance PER DIRECTORY, which is the property that matters: a
+  // per-call instance would restart `seq` at 1 on every dispatch, the
+  // counter-on-a-shared-file bug that collided 142 of 145 run-log seqs
+  // (#1324).
+  const dir = patchworkPath();
+  let log = _boundaryReceiptLogs.get(dir);
+  if (!log) {
+    log = new BoundaryReceiptLog({ dir });
+    _boundaryReceiptLogs.set(dir, log);
   }
-  return _boundaryReceiptLog;
+  return log;
 }
 
 function buildAgentExecutorDeps(


### PR DESCRIPTION
ADR-0021 Phase 3. `boundary_receipts.jsonl` sits alongside the gate's
decision record, same shape and same 0o700 directory mode: what was
declared, where it was going, what must be removed, why.

Patchwork's standing claim is that every consequential decision leaves a
receipt. The autonomy gate covers *what the AI did*; this covers *what the
AI was told*, which is the half nobody could previously audit.

IT HAS NO FIELD FOR THE PAYLOAD, and that is structural rather than a
convention. A privacy audit log containing the prompts would be the largest
unclassified copy of exactly the material the boundary exists to protect,
sitting in plain JSONL — the sharpest own goal available here. The record is
built field-by-field from declared metadata (classification, category NAMES,
destination, decision, reason) with no spread of caller input, so a future
caller cannot pass a prompt through by accident. Pinned by a test that
attempts exactly that and asserts it never reaches disk; the mutation which
spreads the input fails it.

FIXES A DEFECT IN THE PREVIOUS SLICE. The sink recorded
`input.boundary?.destination?.id` — which is `undefined` on the normal path,
because the destination is resolved from config inside `executeAgent` rather
than passed by the caller. Every receipt would have recorded a decision with
no record of where the data was going, i.e. the single field that makes it an
audit trail rather than a counter. The resolved destination now travels with
the outcome, and a regression test asserts the id is present and correct.

Fail-soft throughout: an unwritable directory, a failed append or a malformed
line costs a receipt (or one line), never a decision. The boundary already
refuses correctly with no sink attached, which is pinned separately — this
store is observability, and enforcement must never depend on its own audit
trail being configured.

Suite: 9792 passing, 3 pre-existing tokenEfficiency failures that reproduce
identically on main. Every fixture synthetic.

Refs ADR-0021 — Phases 1, 2 and 3 now built. Still out: detection, redaction
(ALLOW_REDACTED refuses), purpose-based minimisation, policy packs.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)