### PR TITLE
fix(gates): audit-cli-commands could not see the surface that broke

### DIFF
--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -223,17 +223,14 @@ function TaskDetail({ task, onCancel, cancelling }: {
           flexWrap: "wrap",
         }}
       >
-        <button
-          type="button"
-          className="btn sm ghost"
-          style={{ fontSize: "var(--fs-s)" }}
-          onClick={async () => {
-            await navigator.clipboard.writeText(`patchwork task resume ${task.taskId}`);
-            flash("term");
-          }}
-        >
-          {copied === "term" ? "✓ Copied" : "> Open in terminal"}
-        </button>
+        {/* "Open in terminal" removed 2026-08-16: it copied
+            `patchwork task resume <id>` and there is no `task` verb — pasting
+            it printed "Unknown command: 'task'. Did you mean: start?". Nothing
+            behind it either: no bridge route and no dashboard API for resume;
+            the `resumeClaudeTask` MCP tool is reachable only from an MCP
+            client, never the CLI. Same call as the Replay button above, and
+            the degraded form (copy the id) is the button immediately below, so
+            nothing is lost. Restore once a real resume verb exists. */}
         {/* Replay button removed 2026-05-17 (#600 BLOCKER #2): targeted
             POST /api/bridge/tasks/:id/replay which the bridge never
             implemented (only POST /runs/:seq/replay exists, for recipe

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,10 +29,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-16 `fix/cli-gate-reads-ui-strings` — `audit-cli-commands` read tracked MARKDOWN only, so it could not have caught #1434 (a clipboard string in TSX advertising a verb that did not exist). Extends it to UI sources; the first working version found a SECOND live instance on the tasks page. Touches `scripts/audit-cli-commands.mjs` and one dashboard component.
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-16 `fix/cli-gate-reads-ui-strings` — `audit-cli-commands` read tracked MARKDOWN only, so it could not have caught #1434 (a clipboard string in TSX advertising a verb that did not exist). Extends it to UI sources; the first working version found a SECOND live instance on the tasks page. Touches `scripts/audit-cli-commands.mjs` and one dashboard component. — merged as #1435.
 - 2026-08-16 `fix/patchwork-approve-command` — the dashboard copies `patchwork approve <callId>` to the clipboard and the subcommand does not exist (`Unknown command: 'approve'`). Adds approve/reject as a thin shim over the existing `/approve/:callId` + `/reject/:callId` routes, plus `--review`. Also corrects a false comment in `src/bridge.ts` about where `patchwork init` writes DASHBOARD_SESSION_SECRET. Touches `src/index.ts` dispatch and one dashboard string. — merged as #1434.
 - 2026-08-16 `docs/correct-stale-trust-evidence-claims` — three measured claims in CLAUDE.md had gone stale and all three overstate a problem, which is the direction that wastes a session: retention (18.2h -> re-measured 88h), `worker_trust/` checkpoints ("never written" -> a checkpoint exists) and join-key coverage ("1 of 63" -> 11 of 17 non-reversible). Docs only. — merged as #1433.
 - 2026-08-16 `fix/gates-that-cannot-catch-their-own-failures` — two checks that could not catch what they exist to catch. audit-in-flight's branch pattern was wrong in BOTH directions (invented branches from backticked file paths, missed real branch names past the second slash); the dashboard had no typecheck script, so nothing local ran tsc --noEmit and a broken main passed four green local checks. Touches `scripts/audit-in-flight.mjs`, `dashboard/package.json` and the CI workflow. — merged as #1432.

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-16 `fix/cli-gate-reads-ui-strings` — `audit-cli-commands` read tracked MARKDOWN only, so it could not have caught #1434 (a clipboard string in TSX advertising a verb that did not exist). Extends it to UI sources; the first working version found a SECOND live instance on the tasks page. Touches `scripts/audit-cli-commands.mjs` and one dashboard component.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/scripts/audit-cli-commands.mjs
+++ b/scripts/audit-cli-commands.mjs
@@ -150,6 +150,64 @@ function trackedMarkdown() {
 }
 
 /** Lines inside ``` fences, with their 1-based line numbers. */
+/**
+ * Tracked UI sources that may hand a command to the user.
+ *
+ * ## Why markdown was never enough
+ *
+ * `patchwork approve <callId>` shipped as a clipboard string in the approvals
+ * screen while the subcommand did not exist — pasting it printed
+ * `Unknown command: 'approve'. Did you mean: approvals?` (fixed in #1434).
+ * This gate could not have caught it: it read tracked MARKDOWN, and the
+ * advertisement was a template literal in TSX.
+ *
+ * A command a button copies to the clipboard is a stronger promise than one in
+ * a doc — the user did not choose to type it, the product handed it over — so
+ * the surface that most needs checking was the one surface not checked.
+ */
+/**
+ * The same invocation shape, with the delimiters a SOURCE FILE uses.
+ *
+ * Deliberately NOT the markdown `INVOCATION`, and not a widening of it. That
+ * one is tuned to avoid prose noise in documentation, where a leading `$` or
+ * `|` is what separates a real command from a sentence containing the word.
+ * In TSX the command lives inside a string, so the character before it is a
+ * quote or a paren.
+ *
+ * This distinction is the entire bug. My first version of this check reused
+ * `INVOCATION`, reported "5 invocations in 430 UI sources" and passed — while
+ * being structurally unable to see a single clipboard string, because
+ * `` `patchwork approve ${id}` `` presents a BACKTICK where the regex demands
+ * a shell delimiter. All three probes passed against it, including one that
+ * reproduced #1434 exactly. A check that cannot fail is worse than no check:
+ * it reports the surface as covered.
+ */
+const UI_INVOCATION =
+  /(?:^|[`'"($;|]|&&|\|\|)\s*(?:npx\s+)?patchwork(?:-os)?(?:@[\w.-]+)?\s+([a-z][a-z0-9-]*)/g;
+
+function trackedUiSources() {
+  return execFileSync(
+    "git",
+    ["ls-files", "dashboard/src/*.ts", "dashboard/src/*.tsx"],
+    { cwd: root, encoding: "utf8" },
+  )
+    .split("\n")
+    .filter(Boolean);
+}
+
+/**
+ * Remove comments so a note ABOUT a verb is not read as advertising one.
+ *
+ * LINE comments first, then block comments — the ordering is load-bearing and
+ * this repository has now had it backwards twice (#1412, #1421). A `/*` inside
+ * a line comment opens a pseudo-block that swallows every line to the next
+ * real terminator, deleting live code before any match is attempted, and a
+ * gate that deletes what it is meant to read reports a clean pass.
+ */
+function stripComments(text) {
+  return text.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
 function fencedLines(text) {
   const out = [];
   let inFence = false;
@@ -220,6 +278,33 @@ function main() {
     }
   }
 
+  // UI strings. A command the product COPIES TO THE CLIPBOARD is a stronger
+  // promise than one in a doc, and until #1434 it was the one surface this
+  // gate never read.
+  const uiFiles = trackedUiSources();
+  const uiBad = [];
+  let uiChecked = 0;
+  for (const file of uiFiles) {
+    let text;
+    try {
+      text = stripComments(readFileSync(path.join(root, file), "utf8"));
+    } catch {
+      continue;
+    }
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? "";
+      for (const m of line.matchAll(UI_INVOCATION)) {
+        const verb = m[1];
+        if (!verb || verb.startsWith("-") || NOT_A_VERB.has(verb)) continue;
+        uiChecked++;
+        if (!known.has(verb)) {
+          uiBad.push({ file, n: i + 1, verb, line: line.trim() });
+        }
+      }
+    }
+  }
+
   // The binary's own help. A reader who doubts the README checks `--help`,
   // so an unknown verb there is the more expensive of the two.
   const helpBad = [];
@@ -228,8 +313,23 @@ function main() {
   }
 
   console.log(
-    `[cli-commands] ${checked} invocation(s) in ${files.length} tracked markdown files · ${known.size} known verbs`,
+    `[cli-commands] ${checked} invocation(s) in ${files.length} tracked markdown files · ` +
+      `${uiChecked} in ${uiFiles.length} UI source(s) · ${known.size} known verbs`,
   );
+
+  if (uiBad.length > 0) {
+    console.error(
+      `\n[cli-commands] FAIL — ${uiBad.length} unknown verb(s) advertised in the UI:\n`,
+    );
+    for (const b of uiBad) {
+      console.error(`  ${b.file}:${b.n}  patchwork ${b.verb}\n    ${b.line}`);
+    }
+    console.error(
+      "\nThe product hands this command to the user — a clipboard button, a\n" +
+        "rendered hint — and running it fails. Fix the string, or add the verb.\n",
+    );
+    process.exit(1);
+  }
 
   if (helpBad.length > 0) {
     console.error(


### PR DESCRIPTION
#1434 shipped a clipboard button copying `patchwork approve <callId>` while
the subcommand did not exist. This gate exists to catch exactly that and could
not have: it read tracked MARKDOWN, and the advertisement was a template
literal in TSX. A command a button copies is a STRONGER promise than one in a
doc — the user did not choose to type it, the product handed it over — so the
surface most needing the check was the one surface unchecked.

MY FIRST VERSION OF THIS FIX WAS ITSELF UNFALSIFIABLE, which is the part worth
recording. It reused the markdown `INVOCATION` regex, reported "5 invocations
in 430 UI sources" and passed — while structurally unable to see a single
clipboard string. All three probes passed against it, including one that
reproduced #1434 exactly. The regex requires a shell delimiter (`^`, `$`, `;`,
`|`, `&&`) before the binary name, and `` `patchwork approve ${id}` `` presents
a BACKTICK; the 5 hits were unrelated JSX text where the word began a line. A
check that cannot fail is worse than none — it reports the surface as covered.
Fixed with a separate `UI_INVOCATION` accepting the delimiters a SOURCE file
uses. Deliberately not a widening of the markdown one: that is tuned to reject
prose, where a leading `$` is what separates a command from a sentence.

With it working, UI invocations went 5 -> 18 and it immediately found a SECOND
LIVE INSTANCE: the tasks page copied `patchwork task resume <id>`, which
prints "Unknown command: 'task'. Did you mean: start?". Verified on the built
binary. Nothing sits behind it either — no bridge route, no dashboard API for
resume; `resumeClaudeTask` is an MCP tool reachable only from an MCP client,
never the CLI. So that button has never worked.

Removed rather than repaired, following the precedent eight lines above it in
the same file: the Replay button was deleted in #600 for the identical reason
(it targeted an endpoint the bridge never implemented). The degraded form —
copy the id — is already the button immediately below, so nothing is lost, and
a comment records what would restore it. I did not invent a `task resume` verb:
that needs a real bridge route and is its own change.

Comments are stripped before matching, LINE comments first then block — the
ordering this repo has had backwards twice (#1412, #1421). Honest about the
evidence for each half: stripping IS load-bearing and proven (disabling it
takes UI invocations 17 -> 21 and turns the gate RED, because comments
explaining removed buttons name the dead verbs). The ORDERING currently
discriminates nothing — reversing it leaves the count identical — and is fixed
defensively, exactly as in #1421.

Probed: removing approve/reject from KNOWN_SUBCOMMANDS (reproducing #1434)
turns it red with 3 unknown verbs; a UI string naming a verb that never
existed turns it red; disabling stripComments turns it red. Each
assert-guarded, each restored.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)