### PR TITLE
fix(gates): the fixture-hygiene audit stopped at the package boundary

### DIFF
--- a/dashboard/src/app/api/connections/__tests__/sessionMemberId.test.ts
+++ b/dashboard/src/app/api/connections/__tests__/sessionMemberId.test.ts
@@ -8,7 +8,7 @@
  * claim about one, which is the failure this ADR exists to prevent.
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { sessionMemberId } from "../requireSession";
 import { SESSION_COOKIE_NAME, signSession } from "@/lib/session";
@@ -19,8 +19,19 @@ function withCookie(value?: string): Request {
   });
 }
 
+const HAD_SECRET = process.env.DASHBOARD_SESSION_SECRET;
+
 beforeEach(() => {
   process.env.DASHBOARD_SESSION_SECRET = "b".repeat(48);
+});
+
+afterEach(() => {
+  // Restore rather than delete. This file previously left the secret set for
+  // every later test in the same worker, and a test asserting that
+  // verification FAILS without a secret would then pass or fail on file order
+  // alone — the shape of an order-dependent flake, not a deterministic one.
+  if (HAD_SECRET === undefined) delete process.env.DASHBOARD_SESSION_SECRET;
+  else process.env.DASHBOARD_SESSION_SECRET = HAD_SECRET;
 });
 
 describe("sessionMemberId", () => {

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,10 +29,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-16 `fix/fixture-gate-scans-the-dashboard` — `audit-test-fixtures` walked `src/` only, so the dashboard's 126 test files were never checked; it also matched `.test.ts` but never `.test.tsx`. Measured on removing the boundary: 14 violations, one of them introduced the same day by #1430. Touches `scripts/audit-test-fixtures.mjs`, its allowlist, and one dashboard test.
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-16 `fix/fixture-gate-scans-the-dashboard` — `audit-test-fixtures` walked `src/` only, so the dashboard's 126 test files were never checked; it also matched `.test.ts` but never `.test.tsx`. Measured on removing the boundary: 14 violations, one of them introduced the same day by #1430. Touches `scripts/audit-test-fixtures.mjs`, its allowlist, and one dashboard test. — merged as #1436.
 - 2026-08-16 `fix/cli-gate-reads-ui-strings` — `audit-cli-commands` read tracked MARKDOWN only, so it could not have caught #1434 (a clipboard string in TSX advertising a verb that did not exist). Extends it to UI sources; the first working version found a SECOND live instance on the tasks page. Touches `scripts/audit-cli-commands.mjs` and one dashboard component. — merged as #1435.
 - 2026-08-16 `fix/patchwork-approve-command` — the dashboard copies `patchwork approve <callId>` to the clipboard and the subcommand does not exist (`Unknown command: 'approve'`). Adds approve/reject as a thin shim over the existing `/approve/:callId` + `/reject/:callId` routes, plus `--review`. Also corrects a false comment in `src/bridge.ts` about where `patchwork init` writes DASHBOARD_SESSION_SECRET. Touches `src/index.ts` dispatch and one dashboard string. — merged as #1434.
 - 2026-08-16 `docs/correct-stale-trust-evidence-claims` — three measured claims in CLAUDE.md had gone stale and all three overstate a problem, which is the direction that wastes a session: retention (18.2h -> re-measured 88h), `worker_trust/` checkpoints ("never written" -> a checkpoint exists) and join-key coverage ("1 of 63" -> 11 of 17 non-reversible). Docs only. — merged as #1433.

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-16 `fix/fixture-gate-scans-the-dashboard` — `audit-test-fixtures` walked `src/` only, so the dashboard's 126 test files were never checked; it also matched `.test.ts` but never `.test.tsx`. Measured on removing the boundary: 14 violations, one of them introduced the same day by #1430. Touches `scripts/audit-test-fixtures.mjs`, its allowlist, and one dashboard test.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/scripts/audit-test-fixtures-allowlist.json
+++ b/scripts/audit-test-fixtures-allowlist.json
@@ -1,6 +1,13 @@
 {
-  "_comment": "Ratcheting allowlist for test fixture hygiene. Each category only shrinks — remove entries once the underlying issue is fixed. Add new entries only when grandfathering pre-existing violations, with a comment explaining why fixing them is deferred.",
+  "_comment": "Ratcheting allowlist for test fixture hygiene. Each category only shrinks \u2014 remove entries once the underlying issue is fixed. Add new entries only when grandfathering pre-existing violations, with a comment explaining why fixing them is deferred.",
   "hardcodedTmpPaths": [
+    "dashboard/src/app/__tests__/page.test.tsx",
+    "dashboard/src/app/api/relay/push/__tests__/route.test.ts",
+    "dashboard/src/app/approvals/__tests__/batchApproveEvidenceGate.test.tsx",
+    "dashboard/src/app/approvals/__tests__/batchDecide.test.tsx",
+    "dashboard/src/app/approvals/__tests__/unownedApproval.test.tsx",
+    "dashboard/src/app/inbox/__tests__/page.test.tsx",
+    "dashboard/src/app/transactions/__tests__/discardAllExpired.test.tsx",
     "src/__tests__/activityLog.test.ts",
     "src/__tests__/ant-driver.test.ts",
     "src/__tests__/approvalHookScript.test.ts",
@@ -26,6 +33,7 @@
     "src/__tests__/recipeRoutes-install.test.ts",
     "src/__tests__/recipeVariants.test.ts",
     "src/__tests__/registration-coverage.test.ts",
+    "src/__tests__/security-path-traversal.test.ts",
     "src/__tests__/server-approval-detail.test.ts",
     "src/__tests__/server-kill-switch.test.ts",
     "src/__tests__/server-recipes-content.test.ts",
@@ -70,6 +78,7 @@
     "src/tools/__tests__/getCodeCoverage.test.ts",
     "src/tools/__tests__/getDependencyTree.test.ts",
     "src/tools/__tests__/getGitHotspots.test.ts",
+    "src/tools/__tests__/getImportedSignatures.test.ts",
     "src/tools/__tests__/getPRTemplate.test.ts",
     "src/tools/__tests__/getSecurityAdvisories.test.ts",
     "src/tools/__tests__/remainingTools.test.ts",
@@ -78,11 +87,11 @@
     "src/tools/__tests__/terminal-namespacing.test.ts",
     "src/tools/__tests__/terminal.test.ts",
     "src/tools/__tests__/testTraceToSource.test.ts",
-    "src/__tests__/security-path-traversal.test.ts",
-    "src/tools/__tests__/utils-security.test.ts",
-    "src/tools/__tests__/getImportedSignatures.test.ts"
+    "src/tools/__tests__/utils-security.test.ts"
   ],
   "envMutationWithoutRestore": [
+    "dashboard/src/app/api/connections/__tests__/session-guard.test.ts",
+    "dashboard/src/lib/__tests__/bridge.test.ts",
     "src/__tests__/analyticsConfig.test.ts",
     "src/__tests__/analyticsSend.test.ts",
     "src/__tests__/boot-warning.test.ts",
@@ -92,13 +101,17 @@
     "src/tools/__tests__/openInBrowser.test.ts"
   ],
   "spyOnWithoutRestore": [
-    "src/__tests__/bridge-connectivity.test.ts",
-    "src/__tests__/claudeDriver.test.ts",
+    "dashboard/src/app/__tests__/page.test.tsx",
+    "dashboard/src/app/api/bridge/[...path]/__tests__/route.test.ts",
+    "dashboard/src/app/insights/__tests__/page.keys.test.tsx",
+    "dashboard/src/components/__tests__/GlobalLiveRunsStrip.test.tsx",
     "src/__tests__/automation-on-compaction.test.ts",
     "src/__tests__/automation-on-debug-session.test.ts",
     "src/__tests__/automation-on-diagnostics-state.test.ts",
     "src/__tests__/automation-on-test-run.test.ts",
     "src/__tests__/automation.test.ts",
+    "src/__tests__/bridge-connectivity.test.ts",
+    "src/__tests__/claudeDriver.test.ts",
     "src/__tests__/httpErrorResponse.test.ts",
     "src/__tests__/transport-edge-cases.test.ts",
     "src/commands/__tests__/cli-warns-when-out-of-jail.test.ts",
@@ -118,5 +131,6 @@
     "src/recipes/__tests__/dispatchRecipe.parity.test.ts",
     "src/recipes/__tests__/recipeServers.test.ts",
     "src/recipes/__tests__/yamlRunner.test.ts"
-  ]
+  ],
+  "_dashboard_note": "Dashboard entries added 2026-08-16 when the scan was extended past src/. GRANDFATHERED, not endorsed: they pre-date the scan reaching them, and fixing 13 unrelated dashboard tests in the PR that widened the surface would have buried the change that matters. The one violation introduced the SAME DAY (sessionMemberId.test.ts, from #1430) was fixed rather than listed \u2014 a ratchet that grandfathers today's mistake is not a ratchet."
 }

--- a/scripts/audit-test-fixtures.mjs
+++ b/scripts/audit-test-fixtures.mjs
@@ -20,12 +20,14 @@
  * Exit code 0 = all checks pass. Exit code 1 = new violations found.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const SRC = join(ROOT, "src");
+/** The dashboard is a separate package in the same repo, with its own tests. */
+const DASHBOARD_SRC = join(ROOT, "dashboard", "src");
 const ALLOWLIST_PATH = join(
   ROOT,
   "scripts",
@@ -34,13 +36,22 @@ const ALLOWLIST_PATH = join(
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-/** Recursively collect all *.test.ts files under a directory. */
+/**
+ * Recursively collect test files under a directory.
+ *
+ * `.test.tsx` as well as `.test.ts`: the dashboard's component tests use the
+ * TSX extension, so a `.test.ts`-only matcher would have skipped most of them
+ * even once the dashboard root was added below.
+ */
 function walkTestFiles(dir, acc = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
       walkTestFiles(full, acc);
-    } else if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+    } else if (
+      entry.isFile() &&
+      (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.tsx"))
+    ) {
       acc.push(full);
     }
   }
@@ -54,7 +65,23 @@ function rel(absPath) {
 
 // ── scan ─────────────────────────────────────────────────────────────────────
 
-const testFiles = walkTestFiles(SRC);
+/**
+ * Both test trees.
+ *
+ * The dashboard's 126 test files were never scanned: this walked `src/` alone,
+ * so every fixture-hygiene rule stopped at the package boundary. Measured when
+ * the boundary was removed — 7 hardcoded /tmp/ paths, 3 env mutations with no
+ * restore and 4 `vi.spyOn` without restore, none of which any gate could see.
+ *
+ * One of them was introduced the same day by the session adding this scan
+ * (#1430's sessionMemberId.test.ts set DASHBOARD_SESSION_SECRET in a
+ * beforeEach and never cleaned up), which is the argument for the extension in
+ * one line: the rules were fine, the surface was half.
+ */
+const testFiles = [
+  ...walkTestFiles(SRC),
+  ...(existsSync(DASHBOARD_SRC) ? walkTestFiles(DASHBOARD_SRC) : []),
+];
 
 const hardcodedTmpPaths = [];
 const envMutationWithoutRestore = [];


### PR DESCRIPTION
`audit-test-fixtures` walked `src/` and nothing else, so the dashboard's 126
test files were never checked by any of its three rules. It also matched
`.test.ts` but never `.test.tsx`, so most dashboard component tests would have
been skipped even if the root had been added.

Measured on removing the boundary — 860 files scanned instead of 734, and 14
violations that no gate could see: 7 hardcoded /tmp/ paths, 3 process.env
mutations with no restore, 4 `vi.spyOn` without restore.

ONE OF THE 14 WAS MINE, FROM EARLIER THE SAME DAY. #1430's
sessionMemberId.test.ts sets DASHBOARD_SESSION_SECRET in a beforeEach and never
cleans up, leaking it into every later test in the worker — so a test asserting
that verification FAILS without a secret would pass or fail on file order
alone. That is the shape of an order-dependent flake. It is fixed here, not
grandfathered, and it restores the previous value rather than deleting: the
variable may legitimately be set in the ambient environment.

A ratchet that grandfathers the mistake made the same day is not a ratchet.
The other 13 pre-date the scan reaching them and ARE grandfathered, with the
reason recorded in the allowlist. Fixing 13 unrelated dashboard tests inside
the PR that widened the surface would have buried the change that matters;
they are now visible, ratcheted, and cannot grow.

Probed: a new dashboard test carrying all three violations is flagged three
times and the gate exits 1 (so it can catch what it previously could not);
reverting the scan to `src/` alone drops coverage back to 734 files, 79/0/14 —
the pre-fix numbers exactly.

NOT DONE, and pre-existing on main rather than caused here (verified by running
the gate on a stashed tree): 20 stale allowlist entries the gate already
reports as safe to remove. Cleaning them is real ratchet maintenance and is
unrelated line-churn in this diff.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)