### PR TITLE
fix(dashboard): connector-requests ignored PATCHWORK_HOME

### DIFF
--- a/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
+++ b/dashboard/src/app/api/connector-requests/__tests__/route.test.ts
@@ -6,9 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { POST } from "../route";
 
-// connector-requests writes to ~/.patchwork/connector-requests.json. We
-// redirect HOME via os.homedir() spy and use a fresh temp dir per test
-// so cases don't see each other's writes.
+// connector-requests writes under the Patchwork home. Redirected via the
+// PATCHWORK_HOME env var — the SAME override production uses — with a fresh
+// temp dir per test so cases don't see each other's writes.
+//
+// This used to spy on `os.homedir()`. That stopped working the moment the
+// route began resolving through `patchworkHome()`, which imports `homedir` as
+// a NAMED binding that a spy on the `os` namespace object never reaches. The
+// failure was not a red test: the route wrote to the developer's REAL
+// ~/.patchwork/connector-requests.json, appending 13 fixture rows per run
+// alongside a genuine four-month-old request. Redirecting the documented
+// override instead of monkey-patching the module makes that unreachable.
 
 let tmpHome: string;
 let storeFile: string;
@@ -25,14 +33,21 @@ function makeReq(
   return new Request("https://dashboard.local/api/connector-requests", init);
 }
 
+let priorHome: string | undefined;
+
 beforeEach(() => {
   tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "connreq-test-"));
-  storeFile = path.join(tmpHome, ".patchwork", "connector-requests.json");
-  vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  // PATCHWORK_HOME IS the store root, so the file sits directly inside it —
+  // not under a nested ".patchwork" as the homedir-spy version assumed.
+  storeFile = path.join(tmpHome, "connector-requests.json");
+  priorHome = process.env.PATCHWORK_HOME;
+  process.env.PATCHWORK_HOME = tmpHome;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  if (priorHome === undefined) delete process.env.PATCHWORK_HOME;
+  else process.env.PATCHWORK_HOME = priorHome;
   fs.rmSync(tmpHome, { recursive: true, force: true });
 });
 

--- a/dashboard/src/app/api/connector-requests/route.ts
+++ b/dashboard/src/app/api/connector-requests/route.ts
@@ -1,8 +1,16 @@
 import { NextResponse } from "next/server";
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
 import { requireSameOrigin } from "@/lib/csrf";
+// The SAME resolver the bridge uses. Imported rather than reimplemented:
+// resolving the workspace root by hand is exactly what produced this bug, and
+// a second copy of the rule drifts from the first the moment either changes.
+// `patchworkHome.ts` imports only `node:` builtins, so it crosses the package
+// boundary cleanly.
+import {
+  patchworkHome,
+  patchworkPath,
+} from "../../../../../src/patchworkHome";
 import {
   DASHBOARD_API_BODY_CAPS,
   bodyTooLargeResponse,
@@ -40,7 +48,7 @@ let writeChain: Promise<void> = Promise.resolve();
  */
 export async function GET(): Promise<Response> {
   try {
-    const file = path.join(os.homedir(), ".patchwork", "connector-requests.json");
+    const file = patchworkPath("connector-requests.json");
     if (!fs.existsSync(file)) {
       return NextResponse.json({ requests: [] });
     }
@@ -127,7 +135,7 @@ export async function POST(req: Request): Promise<Response> {
     writeChain = writeChain
       .then(() => {
         try {
-          const dir = path.join(os.homedir(), ".patchwork");
+          const dir = patchworkHome();
           const file = path.join(dir, "connector-requests.json");
 
           fs.mkdirSync(dir, { recursive: true });

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-16 `fix/dashboard-ignores-patchwork-home` — `audit-patchwork-home` scans `src/**` only, so it never saw two lines in the dashboard's connector-requests route that match its OWN regex: `path.join(os.homedir(), ".patchwork", ...)`. PATCHWORK_HOME is ignored there, so with an override set the bridge and dashboard read different directories. Fixes the route and widens the gate.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,10 +29,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-16 `fix/dashboard-ignores-patchwork-home` — `audit-patchwork-home` scans `src/**` only, so it never saw two lines in the dashboard's connector-requests route that match its OWN regex: `path.join(os.homedir(), ".patchwork", ...)`. PATCHWORK_HOME is ignored there, so with an override set the bridge and dashboard read different directories. Fixes the route and widens the gate.
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-16 `fix/dashboard-ignores-patchwork-home` — `audit-patchwork-home` scans `src/**` only, so it never saw two lines in the dashboard's connector-requests route that match its OWN regex: `path.join(os.homedir(), ".patchwork", ...)`. PATCHWORK_HOME is ignored there, so with an override set the bridge and dashboard read different directories. Fixes the route and widens the gate. — merged as #1437.
 - 2026-08-16 `fix/fixture-gate-scans-the-dashboard` — `audit-test-fixtures` walked `src/` only, so the dashboard's 126 test files were never checked; it also matched `.test.ts` but never `.test.tsx`. Measured on removing the boundary: 14 violations, one of them introduced the same day by #1430. Touches `scripts/audit-test-fixtures.mjs`, its allowlist, and one dashboard test. — merged as #1436.
 - 2026-08-16 `fix/cli-gate-reads-ui-strings` — `audit-cli-commands` read tracked MARKDOWN only, so it could not have caught #1434 (a clipboard string in TSX advertising a verb that did not exist). Extends it to UI sources; the first working version found a SECOND live instance on the tasks page. Touches `scripts/audit-cli-commands.mjs` and one dashboard component. — merged as #1435.
 - 2026-08-16 `fix/patchwork-approve-command` — the dashboard copies `patchwork approve <callId>` to the clipboard and the subcommand does not exist (`Unknown command: 'approve'`). Adds approve/reject as a thin shim over the existing `/approve/:callId` + `/reject/:callId` routes, plus `--review`. Also corrects a false comment in `src/bridge.ts` about where `patchwork init` writes DASHBOARD_SESSION_SECRET. Touches `src/index.ts` dispatch and one dashboard string. — merged as #1434.

--- a/scripts/audit-patchwork-home.mjs
+++ b/scripts/audit-patchwork-home.mjs
@@ -53,11 +53,27 @@ const HARDCODED = /homedir\(\)\s*,\s*["']\.patchwork["']/;
 const SELF = "src/patchworkHome.ts";
 
 function trackedSources() {
-  const out = execFileSync("git", ["ls-files", "src/**/*.ts", "src/*.ts"], {
-    cwd: root,
-    encoding: "utf8",
-    maxBuffer: 8 * 1024 * 1024,
-  });
+  // `dashboard/src` as well as `src`. The dashboard is a separate package in
+  // the same repo and reaches the SAME directory on disk, so a hardcode there
+  // desynchronises it from the bridge exactly as one here would — and the
+  // scan stopping at the package boundary is why two such lines sat in
+  // dashboard/src/app/api/connector-requests/route.ts, matching this file's
+  // own HARDCODED regex, while the gate reported clean.
+  const out = execFileSync(
+    "git",
+    [
+      "ls-files",
+      "src/**/*.ts",
+      "src/*.ts",
+      "dashboard/src/**/*.ts",
+      "dashboard/src/**/*.tsx",
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 8 * 1024 * 1024,
+    },
+  );
   return out
     .split("\n")
     .filter(Boolean)


### PR DESCRIPTION
`audit-patchwork-home` scans `src/**` and stopped there, so it never saw two
lines in the dashboard matching its OWN `HARDCODED` regex:

    path.join(os.homedir(), ".patchwork", "connector-requests.json")   :43
    path.join(os.homedir(), ".patchwork")                              :130

Consequence is a real split, not untidiness. With `PATCHWORK_HOME` set the
bridge reads and writes the override directory while the dashboard reads and
writes `~/.patchwork` — so a submitted connector request lands where nothing
looks for it, and the "Your requests" list shows the wrong store.

Both sites now resolve through `patchworkPath()` / `patchworkHome()`, imported
from `src/patchworkHome.ts` rather than reimplemented: resolving the root by
hand is precisely what produced this, and a second copy of the rule drifts from
the first the moment either changes. That module imports only `node:` builtins,
so it crosses the package boundary with no resolution work.

The gate now scans `dashboard/src` too, and the probe that matters is the
SECOND one: with the original hardcode restored AND the gate reverted to
`src/`-only, it prints "0 file(s) resolve ~/.patchwork by hand · OK — the
ratchet holds". That is the state the repository was in this morning — a
matching violation present, the gate reporting clean.

THE TEST WAS WRITING TO THE DEVELOPER'S REAL STORE. It redirected HOME with
`vi.spyOn(os, "homedir")`, which stops working once the route resolves through
`patchworkHome()` — that module imports `homedir` as a NAMED binding a spy on
the `os` namespace object never reaches. This did not surface as a red test; it
appended 13 fixture rows per run to ~/.patchwork/connector-requests.json,
alongside a genuine request from four months earlier. Found while diagnosing
the 7 failures this change caused, cleaned by timestamp cutoff (not by name —
filtering on fixture names would delete a real request that happened to be
called "Asana"), and the genuine entry is intact.

The test now redirects `PATCHWORK_HOME`, the same override production uses, so
monkey-patching a module is not involved and the failure mode is unreachable.
Verified by hashing the real file before and after a full run: unchanged.

`next build` caught the import depth (5 levels, not 6 — one fewer path segment
than the file I copied the pattern from). Fourth instance today of a correct
rule pointed at a partial surface; see #1432, #1435, #1436.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)