### PR TITLE
chore(gates): prune 20 stale fixture-hygiene allowlist entries

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-17 `chore/prune-stale-fixture-allowlist` — the 20 stale entries `audit-test-fixtures` already reports as safe to remove (1 hardcodedTmpPaths, 7 envMutationWithoutRestore, 12 spyOnWithoutRestore). Investigated before pruning, because "stale" has two causes and only one is benign: the test was fixed, or the DETECTOR went blind and can no longer see a violation it once saw — the partial-surface defect this repo keeps hitting. All 20 files still exist and each carries the remediation its entry covered. Allowlist JSON only; no source change. — this session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,9 +29,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-17 `chore/prune-stale-fixture-allowlist` — the 20 stale entries `audit-test-fixtures` already reports as safe to remove (1 hardcodedTmpPaths, 7 envMutationWithoutRestore, 12 spyOnWithoutRestore). Investigated before pruning, because "stale" has two causes and only one is benign: the test was fixed, or the DETECTOR went blind and can no longer see a violation it once saw — the partial-surface defect this repo keeps hitting. All 20 files still exist and each carries the remediation its entry covered. Allowlist JSON only; no source change. — this session
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-17 `chore/prune-stale-fixture-allowlist` — the 20 stale entries `audit-test-fixtures` already reports as safe to remove (1 hardcodedTmpPaths, 7 envMutationWithoutRestore, 12 spyOnWithoutRestore). Investigated before pruning, because "stale" has two causes and only one is benign: the test was fixed, or the DETECTOR went blind and can no longer see a violation it once saw — the partial-surface defect this repo keeps hitting. All 20 files still exist and each carries the remediation its entry covered. Allowlist JSON only; no source change. — merged as #1438
 
 - 2026-08-16 `fix/dashboard-ignores-patchwork-home` — `audit-patchwork-home` scans `src/**` only, so it never saw two lines in the dashboard's connector-requests route that match its OWN regex: `path.join(os.homedir(), ".patchwork", ...)`. PATCHWORK_HOME is ignored there, so with an override set the bridge and dashboard read different directories. Fixes the route and widens the gate. — merged as #1437.
 - 2026-08-16 `fix/fixture-gate-scans-the-dashboard` — `audit-test-fixtures` walked `src/` only, so the dashboard's 126 test files were never checked; it also matched `.test.ts` but never `.test.tsx`. Measured on removing the boundary: 14 violations, one of them introduced the same day by #1430. Touches `scripts/audit-test-fixtures.mjs`, its allowlist, and one dashboard test. — merged as #1436.

--- a/scripts/audit-test-fixtures-allowlist.json
+++ b/scripts/audit-test-fixtures-allowlist.json
@@ -78,7 +78,6 @@
     "src/tools/__tests__/getCodeCoverage.test.ts",
     "src/tools/__tests__/getDependencyTree.test.ts",
     "src/tools/__tests__/getGitHotspots.test.ts",
-    "src/tools/__tests__/getImportedSignatures.test.ts",
     "src/tools/__tests__/getPRTemplate.test.ts",
     "src/tools/__tests__/getSecurityAdvisories.test.ts",
     "src/tools/__tests__/remainingTools.test.ts",
@@ -91,14 +90,7 @@
   ],
   "envMutationWithoutRestore": [
     "dashboard/src/app/api/connections/__tests__/session-guard.test.ts",
-    "dashboard/src/lib/__tests__/bridge.test.ts",
-    "src/__tests__/analyticsConfig.test.ts",
-    "src/__tests__/analyticsSend.test.ts",
-    "src/__tests__/boot-warning.test.ts",
-    "src/__tests__/featureFlags.test.ts",
-    "src/__tests__/patchworkCli.test.ts",
-    "src/adapters/__tests__/adapters.test.ts",
-    "src/tools/__tests__/openInBrowser.test.ts"
+    "dashboard/src/lib/__tests__/bridge.test.ts"
   ],
   "spyOnWithoutRestore": [
     "dashboard/src/app/__tests__/page.test.tsx",
@@ -110,27 +102,15 @@
     "src/__tests__/automation-on-diagnostics-state.test.ts",
     "src/__tests__/automation-on-test-run.test.ts",
     "src/__tests__/automation.test.ts",
-    "src/__tests__/bridge-connectivity.test.ts",
-    "src/__tests__/claudeDriver.test.ts",
     "src/__tests__/httpErrorResponse.test.ts",
     "src/__tests__/transport-edge-cases.test.ts",
     "src/commands/__tests__/cli-warns-when-out-of-jail.test.ts",
     "src/commands/__tests__/launchdInstall.test.ts",
-    "src/connectors/__tests__/asana.test.ts",
-    "src/connectors/__tests__/confluence.test.ts",
-    "src/connectors/__tests__/datadog.test.ts",
-    "src/connectors/__tests__/discord.test.ts",
-    "src/connectors/__tests__/gitlab.test.ts",
-    "src/connectors/__tests__/hubspot.test.ts",
-    "src/connectors/__tests__/intercom.test.ts",
-    "src/connectors/__tests__/notion.test.ts",
     "src/connectors/__tests__/shopify.test.ts",
-    "src/connectors/__tests__/stripe.test.ts",
-    "src/connectors/__tests__/zendesk.test.ts",
     "src/recipes/__tests__/chainedRunner.test.ts",
     "src/recipes/__tests__/dispatchRecipe.parity.test.ts",
     "src/recipes/__tests__/recipeServers.test.ts",
     "src/recipes/__tests__/yamlRunner.test.ts"
   ],
-  "_dashboard_note": "Dashboard entries added 2026-08-16 when the scan was extended past src/. GRANDFATHERED, not endorsed: they pre-date the scan reaching them, and fixing 13 unrelated dashboard tests in the PR that widened the surface would have buried the change that matters. The one violation introduced the SAME DAY (sessionMemberId.test.ts, from #1430) was fixed rather than listed \u2014 a ratchet that grandfathers today's mistake is not a ratchet."
+  "_dashboard_note": "Dashboard entries added 2026-08-16 when the scan was extended past src/. GRANDFATHERED, not endorsed: they pre-date the scan reaching them, and fixing 13 unrelated dashboard tests in the PR that widened the surface would have buried the change that matters. The one violation introduced the SAME DAY (sessionMemberId.test.ts, from #1430) was fixed rather than listed — a ratchet that grandfathers today's mistake is not a ratchet."
 }


### PR DESCRIPTION
`audit-test-fixtures` had been printing these 20 entries as unused and "safe to remove" on every run: 1 `hardcodedTmpPaths`, 7 `envMutationWithoutRestore`, 12 `spyOnWithoutRestore`. A ratcheting allowlist nobody prunes stops being a record of accepted debt and becomes noise, and noise is how a real entry gets skipped.

## Investigated before removing

"Stale" has two causes and only one is benign: the test was genuinely fixed, or the **detector went blind** and can no longer see a violation it once saw. The second is the defect this repo keeps finding — a correct rule pointed at a partial surface — and this same gate had its surface widened yesterday in #1436, exactly the kind of change that can silence a detector.

Checked all 20: every file still exists, and each carries the remediation its entry covered (a `restoreAllMocks`/`resetAllMocks`, or the pattern simply gone). None is a blinded detector.

## Verification that could have failed

1. After the prune the gate is green with its stats **unchanged** — 86 / 2 / 18 — and zero stale notes. Same violations, 20 fewer exemptions.
2. Then, in `src/connectors/__tests__/stripe.test.ts` — a file this PR unlists — the `restoreAllMocks` calls were mutated away. Assert-guarded: 2 occurrences before, 0 after, so the mutation provably applied. The gate went **RED, exit 1, naming that exact file**.

So a non-stale entry would have been caught rather than quietly pruned. File restored; `npx vitest run` over the gate's own tests plus the mutated file passes (41 tests).

Allowlist JSON only — no source or gate-logic change.