### PR TITLE
fix(gates): the business-content gate could not see code

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-17 `fix/business-content-gate-reads-code` — `audit-business-content` read tracked MARKDOWN only, so the ADR-0019 licensing boundary was unenforced everywhere a string actually ships: UI components, CLI output, YAML, JSON. Its own header already conceded it cannot see code. Widens to tracked source/config text and excludes the gate + its allowlist BY EXACT PATH (they must contain the vocabulary; 20 of 20 pre-existing non-markdown hits were those two files). Measured: no new findings, allowlist unchanged at 8 entries. Touches `scripts/audit-business-content.mjs` only. — this session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,9 +29,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-17 `fix/business-content-gate-reads-code` — `audit-business-content` read tracked MARKDOWN only, so the ADR-0019 licensing boundary was unenforced everywhere a string actually ships: UI components, CLI output, YAML, JSON. Its own header already conceded it cannot see code. Widens to tracked source/config text and excludes the gate + its allowlist BY EXACT PATH (they must contain the vocabulary; 20 of 20 pre-existing non-markdown hits were those two files). Measured: no new findings, allowlist unchanged at 8 entries. Touches `scripts/audit-business-content.mjs` only. — this session
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-17 `fix/business-content-gate-reads-code` — `audit-business-content` read tracked MARKDOWN only, so the ADR-0019 licensing boundary was unenforced everywhere a string actually ships: UI components, CLI output, YAML, JSON. Its own header already conceded it cannot see code. Widens to tracked source/config text and excludes the gate + its allowlist BY EXACT PATH (they must contain the vocabulary; 20 of 20 pre-existing non-markdown hits were those two files). Measured: no new findings, allowlist unchanged at 8 entries. Touches `scripts/audit-business-content.mjs` only. — merged as #1440
 
 - 2026-08-17 `fix/fixture-gate-ratchets-stale-entries` — `audit-test-fixtures` printed its stale allowlist entries as `[non-blocking]` and exited 0, so nothing ever forced the prune and 20 accumulated (swept in #1438). Its two sibling ratchets, `audit-lsp-tools` and `audit-shape-safety`, already FAIL on their own stale entries, which is why neither has any. Makes stale entries blocking, counted and worded separately from new violations because the remedy is the opposite one (delete the line vs add it). Touches `scripts/audit-test-fixtures.mjs` only. — merged as #1439
 

--- a/scripts/audit-business-content.mjs
+++ b/scripts/audit-business-content.mjs
@@ -98,14 +98,59 @@ const TERMS = [
   },
 ];
 
-/** Files scanned. Markdown only — code comments about cost routing are noise. */
-function trackedMarkdown() {
-  const out = execFileSync("git", ["ls-files", "*.md"], {
+/**
+ * Text extensions scanned alongside markdown.
+ *
+ * Not an arbitrary list: it is the set a shipped string can reach a user
+ * from — UI components, CLI output, YAML, JSON config, templates.
+ */
+const TEXT_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|json|ya?ml|txt|html|css|sh|toml)$/i;
+
+/**
+ * This file and its allowlist are the two places that MUST contain the
+ * vocabulary — one defines the patterns, the other records the accepted
+ * exceptions by term. Scanning them means every term matches itself, which
+ * is not a finding; it is the gate reading its own source. Measured before
+ * this exclusion existed: 20 of 20 hits across the whole non-markdown tree
+ * were these two files.
+ *
+ * Excluded by exact path, never by a "does it look like a gate" heuristic:
+ * a future script that genuinely leaks a price must not be able to exempt
+ * itself by being named like an audit.
+ */
+const SELF = new Set([
+  "scripts/audit-business-content.mjs",
+  "scripts/audit-business-content-allowlist.json",
+]);
+
+/**
+ * Files scanned: tracked markdown AND tracked source/config text.
+ *
+ * It was markdown only, on the reasoning that "code comments about cost
+ * routing are noise". That reasoning covered the false positives and missed
+ * the true ones — the leak this gate exists to stop is an OFFER, and an
+ * offer reaches a user through a UI string or a CLI line at least as
+ * readily as through a document. #1434/#1435 established the general form
+ * in a sibling gate: a clipboard string in TSX promised a command that did
+ * not exist, and the markdown-only checker could not see it. A `Pro plan`
+ * upsell in a component is the same defect with worse consequences, since
+ * ADR-0019 makes this a licensing boundary rather than a docs nit.
+ *
+ * Measured when the boundary was removed: 2,038 non-markdown files, 20
+ * hits, all 20 of them this gate matching itself (see SELF). So this widens
+ * the surface without importing a backlog — the allowlist stays as it is.
+ */
+function trackedFiles() {
+  const out = execFileSync("git", ["ls-files"], {
     cwd: root,
     encoding: "utf8",
-    maxBuffer: 8 * 1024 * 1024,
+    maxBuffer: 32 * 1024 * 1024,
   });
-  return out.split("\n").filter(Boolean);
+  return out
+    .split("\n")
+    .filter(Boolean)
+    .filter((f) => f.endsWith(".md") || TEXT_EXT.test(f))
+    .filter((f) => !SELF.has(f));
 }
 
 function loadAllowlist() {
@@ -134,7 +179,9 @@ function main() {
   const findings = [];
   const used = new Set();
 
-  for (const file of trackedMarkdown()) {
+  const files = trackedFiles();
+
+  for (const file of files) {
     let content;
     try {
       content = readFileSync(path.join(root, file), "utf8");
@@ -161,7 +208,8 @@ function main() {
   const stale = allow.filter((a) => !used.has(`${a.file}::${a.term}`));
 
   console.log(
-    `[business-content] scanned ${trackedMarkdown().length} tracked markdown files · ` +
+    `[business-content] scanned ${files.length} tracked text files ` +
+      `(markdown + source/config) · ` +
       `${allow.length} allowlist entries (${stale.length} unused)`,
   );
   for (const s of stale) {


### PR DESCRIPTION
`audit-business-content` enforces an **ADR-0019 licensing boundary** in a public MIT repo — and it read tracked *markdown only*. Its own header conceded the gap, and CLAUDE.md states it plainly: it "does not read code or tests".

## Why this surface matters

The leak this gate was extended for was an **offer** — a setup step saying a token "is issued when you activate the Pro plan". An offer ships through a UI string or a CLI line at least as readily as through a document. #1434/#1435 established exactly this form in a sibling gate: a clipboard string in TSX promised a command that did not exist, and the markdown-only checker could not see it. A `Pro plan` upsell in a component is that defect with worse consequences, because here the surface is a licence boundary rather than a docs nit.

**250 files scanned before → 2,288 now** (markdown + ts/tsx/js/mjs/json/yaml/html/css/sh/toml).

## Self-exclusion, by exact path

The gate and its allowlist are the two files that *must* contain the vocabulary — one defines the patterns, the other records exceptions by term — so scanning them means every term matches itself. Measured before the exclusion: **20 of 20** hits across the whole non-markdown tree were those two files.

Excluded by exact path, never by a "looks like an audit script" heuristic, so a future script that genuinely leaks a price cannot exempt itself by being named like a gate. A probe covers this (below).

## No backlog imported

Clean tree passes; the allowlist is **unchanged at 8 entries, 0 unused**. This widens the surface without a cleanup campaign attached.

## Verification that could have failed

Planted violations, each probe asserting the file was actually written first:

| Probe | Result |
|---|---|
| TSX UI string — `Upgrade to the Pro plan` | exit 1, `[named tier]` |
| YAML — `billed per-seat, see upsell flow` | exit 1, two labels |
| a sibling script under `scripts/` | exit 1 — self-exclusion is not over-broad |

One probe initially wrote to a directory that doesn't exist; that run proved nothing and was redone rather than counted as a pass.

Also fixes a double `git ls-files` — the summary line re-ran the entire scan just to print its own count.