### PR TITLE
fix(tests): connector-callback tests outlived vitest teardown (#1386)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `fix/1386-connector-callback-teardown-race` — #1386: connector-callback tests fired fire-and-forget dynamic imports and never awaited them, so they outlived vitest teardown — test-only fix in 2 files
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-18 `fix/1386-connector-callback-teardown-race` — #1386: connector-callback tests fired fire-and-forget dynamic imports and never awaited them, so they outlived vitest teardown — test-only fix in 2 files
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/__tests__/connectorCallback404AndPortMismatch.test.ts
+++ b/src/__tests__/connectorCallback404AndPortMismatch.test.ts
@@ -28,9 +28,14 @@ function makeRes(): {
   res: ServerResponse;
   status: () => number;
   body: () => string;
+  done: Promise<void>;
 } {
   let status = 0;
   const chunks: string[] = [];
+  let resolveDone!: () => void;
+  const done = new Promise<void>((r) => {
+    resolveDone = r;
+  });
   const res = {
     writeHead(s: number) {
       status = s;
@@ -38,10 +43,11 @@ function makeRes(): {
     },
     end(c?: string) {
       if (c) chunks.push(c);
+      resolveDone();
       return this;
     },
   } as unknown as ServerResponse;
-  return { res, status: () => status, body: () => chunks.join("") };
+  return { res, status: () => status, body: () => chunks.join(""), done };
 }
 
 describe("unknown connector on a callback path 404s, it does not 401", () => {
@@ -62,7 +68,7 @@ describe("unknown connector on a callback path 404s, it does not 401", () => {
     expect(body()).toContain("githbu");
   });
 
-  it("does NOT claim a real connector's callback (control)", () => {
+  it("does NOT claim a real connector's callback (control)", async () => {
     // What this actually guards is POSITION, established by probing rather
     // than assumed. Widening the new branch's condition to `slug !== null`
     // changes nothing — it sits after every real handler, so a known slug has
@@ -74,7 +80,7 @@ describe("unknown connector on a callback path 404s, it does not 401", () => {
     // Then every real callback 404s and OAuth breaks completely. Probed: with
     // the check moved to the top of the dispatcher, this test fails.
     const slug = oauthConnectorIds()[0] as string;
-    const { res } = makeRes();
+    const { res, done: res_done } = makeRes();
     const handled = tryHandlePublicConnectorRoute(
       makeReq("GET"),
       res,
@@ -88,6 +94,21 @@ describe("unknown connector on a callback path 404s, it does not 401", () => {
       probe.res,
       new URL(`http://x/connections/${slug}/callback?code=abc&state=x`),
     );
+    // `await` before reading the status, for two independent reasons (#1386).
+    //
+    // 1. Correctness of THIS assertion. The real handler is a fire-and-forget
+    //    `void (async () => { await import(...) })()`, so nothing has been
+    //    written when it returns. `status` starts at 0, and `0 !== 404` — the
+    //    check passed even if the handler never ran at all. It asserted the
+    //    absence of a synchronous write, which no code path could produce.
+    // 2. The dynamic import outlived the test. Whichever import had not
+    //    resolved at environment teardown threw `EnvironmentTeardownError`
+    //    and failed the CI step after every test reported passing.
+    //
+    // Asserting a real status is what makes the leak impossible to reopen:
+    // drop the await and `0` is not a status any handler returns.
+    await Promise.all([probe.done, res_done]);
+    expect(probe.status()).toBeGreaterThan(0);
     expect(probe.status()).not.toBe(404);
   });
 

--- a/src/__tests__/connectorRoutes-cache-and-callback-dedup.test.ts
+++ b/src/__tests__/connectorRoutes-cache-and-callback-dedup.test.ts
@@ -35,6 +35,14 @@ function makeReq(method: string): IncomingMessage {
   return req;
 }
 
+// Records which responses actually got written, so a test can assert the
+// route finished rather than merely that it claimed the path (#1386).
+const endedResponses = new WeakSet<ServerResponse>();
+
+function endedFor(res: ServerResponse): boolean {
+  return endedResponses.has(res);
+}
+
 function makeRes(): { res: ServerResponse; done: Promise<void> } {
   let resolveDone!: () => void;
   const done = new Promise<void>((r) => {
@@ -45,6 +53,7 @@ function makeRes(): { res: ServerResponse; done: Promise<void> } {
       return this;
     },
     end() {
+      endedResponses.add(res);
       resolveDone();
       return this;
     },
@@ -160,14 +169,29 @@ describe("http-routes-3 — OAuth callbacks not duplicated in the auth-gated dis
       expect(handled).toBe(false);
     });
 
-    it(`tryHandlePublicConnectorRoute DOES claim /connections/${vendor}/callback`, () => {
-      const { res } = makeRes();
+    it(`tryHandlePublicConnectorRoute DOES claim /connections/${vendor}/callback`, async () => {
+      const { res, done } = makeRes();
       const handled = tryHandlePublicConnectorRoute(
         makeReq("GET"),
         res,
         new URL(`http://x/connections/${vendor}/callback?code=abc&state=xyz`),
       );
       expect(handled).toBe(true);
+      // `await done` is load-bearing, not tidiness (#1386). The route body is
+      // a fire-and-forget `void (async () => { await import(...) })()` — it
+      // returns `true` while the connector module graph is STILL LOADING
+      // (measured: 2.7-14.6 ms after return, for all 13 vendors). Asserting
+      // `handled` and returning here left up to 13 in-flight dynamic imports
+      // per file; whichever had not resolved when vitest tore the environment
+      // down threw `EnvironmentTeardownError: Cannot load .../mcpOAuth.ts
+      // imported from src/connectors/github.ts after the environment was torn
+      // down`, failing the CI step AFTER every test had reported passing.
+      // Timing-dependent, hence the flakiness and the Windows bias.
+      //
+      // The `ended` assertion is what keeps this honest: delete the await and
+      // it fails deterministically rather than going quietly back to leaking.
+      await done;
+      expect(endedFor(res)).toBe(true);
     });
   }
 });


### PR DESCRIPTION
Root-cause fix for #1386 — the "windows-latest Coverage step fails on unrelated PRs and passes on re-run" flake.

## It was never a coverage threshold

#1440's CI log contains **no coverage-threshold error at all**. It contains three of:

```
EnvironmentTeardownError: Cannot load /src/connectors/mcpOAuth.ts
imported from src/connectors/github.ts after the environment was torn down
```

callstack `connectorRoutes-cache-and-callback-dedup.test.ts` → `connectorRoutes.ts` → `github.ts` → `mcpOAuth.ts`. `src/connectors/github.ts:29` statically imports `./mcpOAuth.js`, matching it exactly.

## Mechanism

The callback routes in `connectorRoutes.ts` are deliberately fire-and-forget:

```ts
void (async () => {
  const { handleGithubCallback } = await import("./connectors/github.js");
  ...
})();
return true;
```

That is correct for an HTTP route. The defect is on the test side: two files asserted the returned `true` and moved straight on, never awaiting the response. Each `it` therefore left an in-flight `await import()` — up to 13 per file, one per OAuth vendor. Whichever had not resolved when vitest tore the environment down threw, and the **step** exited 1 *after every test had already reported passing*.

That explains all three reported symptoms: the "coverage" attribution (the error surfaces at the step, not in a test), the clean re-run on an identical commit, and the Windows bias (slower module I/O widens the window).

## Measured

Nothing is written synchronously — all 13 OAuth vendors, response completing after the route returns:

```
gmail 12.8ms · google-calendar 4.2 · google-drive 5.4 · google-docs 4.2
github 14.6ms · linear 3.4 · sentry 2.7 · slack 4.4 · asana 10.9
discord 5.7 · gitlab 5.6 · monday 6.5 · salesforce 7.3
```

This is a mechanism established by evidence, not a measured failure *rate* — I have one CI log, and the race did not reproduce on macOS in 5/5 local runs.

## A second, quieter bug

`connectorCallback404AndPortMismatch.test.ts`'s control assertion was passing vacuously. `status` starts at `0` and the handler writes nothing synchronously, so `expect(probe.status()).not.toBe(404)` compared `0 !== 404` — it would have passed **even if the handler never ran**. It now awaits and asserts a real status.

## Verification that could actually fail

Both guards were confirmed by mutation rather than assumed:

- delete the `await` in file 1 → **13 tests fail** (one per vendor)
- delete the `await` in file 2 → the status assertion fails

Full suite: 731 files / 10054 passed. The 4 failures in `tokenEfficiency` + `extensionClient-edge-cases` are **pre-existing** — verified by stashing this change and reproducing them identically on clean `main`.

Test-only change; no production code touched.