### PR TITLE
measure(#1386): WAL commit cost on Windows — DO NOT MERGE

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `measure/1386-sqlite-wal-cost` — #1386 cause 2: MEASUREMENT ONLY, do not merge — prints WAL commit cost from inside the sqlite retention test to get a Windows number
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/runStore/__tests__/sqliteRunStoreSpecifics.test.ts
+++ b/src/runStore/__tests__/sqliteRunStoreSpecifics.test.ts
@@ -118,6 +118,15 @@ describe("SQLite run store — what JSONL could not do", () => {
   }, () => {
     const repo = open();
     const ROWS = 2_000;
+    // TEMPORARY MEASUREMENT (#1386 cause 2) — remove before merge.
+    // This test timed out at 60 s three times in the Coverage step while the
+    // Test step on the same Windows runner passed. v8 coverage was measured to
+    // add ~nothing to execution (297 ms vs 302 ms, macOS), so the cause is not
+    // instrumentation and "raise the timeout" would be tuning the wrong
+    // variable. We have no Windows number because --reporter=dot destroys
+    // per-test timings, so print one from inside the test: it survives any
+    // reporter and fires whether or not the flake reproduces.
+    const t0 = performance.now();
     for (let i = 0; i < ROWS; i++) {
       const seq = repo.startRun({
         taskId: `bulk-${i}`,
@@ -132,6 +141,13 @@ describe("SQLite run store — what JSONL could not do", () => {
         stepResults: [],
       });
     }
+    const elapsed = performance.now() - t0;
+    console.error(
+      `[WAL-COST] platform=${process.platform} rows=${ROWS} ` +
+        `commits=${ROWS * 2} elapsed_ms=${elapsed.toFixed(0)} ` +
+        `commits_per_sec=${((ROWS * 2) / (elapsed / 1000)).toFixed(1)} ` +
+        `step=${process.env.npm_lifecycle_event ?? "unknown"}`,
+    );
     expect(repo.size()).toBe(ROWS);
     // And the oldest is still there — the property that actually matters, since
     // rotation dropped precisely the oldest rows.


### PR DESCRIPTION
**Draft. Measurement only — do not merge.** Will be closed once the number is read.

## Why

`src/runStore/__tests__/sqliteRunStoreSpecifics.test.ts:116` timed out at 60s **three times** (all CI retries) in the Coverage step on windows/22, while the Test step on the same runner passed and a re-run of the identical commit passed. That is the second, still-unfixed cause of #1386 — the first was the teardown race fixed in #1441.

Every account of *why* it is slow on Windows is currently inference. `--reporter=dot` destroys per-test timings, so no Windows number exists.

## What this does

Prints the cost from inside the test. It survives any reporter, and it fires whether or not the flake reproduces — so this run yields the number either way.

## Baseline

macOS: **4,000 commits in 271 ms (14,755 commits/sec)**.

For Windows to exceed the 60s timeout, that must fall below **~67 commits/sec** — a ~220x degradation.

## What the number decides

- **~50x (≈13s)** → the test is comfortable and only breaks under rare contention; the remedy is tolerance, not surgery.
- **~200x (≈55s)** → it is permanently marginal and passing on luck; the remedy must cut fsync count, since raising a timeout it already sits against just moves the cliff.

## Correction to an earlier claim

I previously measured v8 coverage as adding ~nothing to this test (297ms vs 302ms) and concluded coverage was not the variable. That measurement was on a **single file**. The CI Coverage step instruments 733 files across many workers, so it does not generalise, and the conclusion drawn from it was stronger than the evidence supported. This run measures both steps directly instead.