### PR TITLE
fix(tests): halve WAL commits in the sqlite retention test (#1386)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-18 `fix/1386-sqlite-wal-commit-count` — #1386 cause 2: halve the sqlite retention test WAL commits so the Windows contention spike stops timing it out
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `fix/1386-sqlite-wal-commit-count` — #1386 cause 2: halve the sqlite retention test WAL commits so the Windows contention spike stops timing it out
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/runStore/__tests__/sqliteRunStoreSpecifics.test.ts
+++ b/src/runStore/__tests__/sqliteRunStoreSpecifics.test.ts
@@ -107,17 +107,38 @@ describe("SQLite run store — what JSONL could not do", () => {
    * ~1,380 rows. 2,000 clears it decisively while staying honest about what is
    * being demonstrated.
    *
-   * The generous timeout is for Windows, not for slack: every startRun +
-   * completeRun is its own WAL transaction, and Windows fsync (plus Defender)
-   * makes that ~30x slower than POSIX — 528 ms locally versus a 15 s timeout
-   * on windows-latest. The store is not slow; per-row transactions are, and
-   * production writes one run at a time.
+   * The generous timeout is for Windows, not for slack: each commit is its own
+   * WAL transaction, and Windows fsync (plus Defender) is far slower. MEASURED
+   * (#1386, PR #1442) for 4,000 commits: macOS 271 ms (14,755 commits/s),
+   * ubuntu 673-1,276 ms, windows-latest 18.6-19.8 s (~202 commits/s) — Windows
+   * is ~73x slower than macOS. The store is not slow; per-row transactions are,
+   * and production writes one run at a time.
+   *
+   * Why only a SAMPLE is completed. At 4,000 commits this sat ~19 s against the
+   * 60 s timeout — 3.2x headroom — and a contention spike on windows-latest ate
+   * it, timing out all three CI retries while the Test step on the same runner
+   * passed (#1386 cause 2). Raising the timeout is the wrong lever: `retry: 2`
+   * means three attempts and the Coverage step's budget is `timeout-minutes: 8`
+   * against a ~6.4 min run, so 120 s would blow the STEP timeout instead and
+   * trade a diagnosable failure for an undiagnosable kill.
+   *
+   * Halving the commits is the right lever, because the second commit per row
+   * was never load-bearing HERE: this test asserts row RETENTION, and `query`
+   * only adds a status clause when one is passed. Completing a sample at both
+   * ends keeps the realistic start+complete path exercised — including on
+   * `bulk-0`, the oldest row, which is what the rotation assertion turns on —
+   * and the `status: "done"` assertion below makes the sample load-bearing, so
+   * dropping completeRun entirely fails rather than silently passing.
+   *
+   * ~2,100 commits ≈ 10 s on windows-latest: ~5.7x headroom, worst case
+   * unchanged at 3 x 60 s.
    */
   it("retains far more rows than the JSONL cap would have held", {
     timeout: 60_000,
   }, () => {
     const repo = open();
     const ROWS = 2_000;
+    const COMPLETED_SAMPLE = 50;
     for (let i = 0; i < ROWS; i++) {
       const seq = repo.startRun({
         taskId: `bulk-${i}`,
@@ -125,14 +146,19 @@ describe("SQLite run store — what JSONL could not do", () => {
         trigger: "cron",
         createdAt: 1_000 + i,
       });
-      repo.completeRun(seq, {
-        status: "done",
-        doneAt: 2_000 + i,
-        durationMs: 1,
-        stepResults: [],
-      });
+      if (i < COMPLETED_SAMPLE || i >= ROWS - COMPLETED_SAMPLE) {
+        repo.completeRun(seq, {
+          status: "done",
+          doneAt: 2_000 + i,
+          durationMs: 1,
+          stepResults: [],
+        });
+      }
     }
     expect(repo.size()).toBe(ROWS);
+    // Keeps the completion path load-bearing: without this, deleting the
+    // completeRun call above would still pass every other assertion.
+    expect(repo.query({ status: "done" }).length).toBe(COMPLETED_SAMPLE * 2);
     // And the oldest is still there — the property that actually matters, since
     // rotation dropped precisely the oldest rows.
     expect(repo.query({ limit: 1, recipe: "noisy", since: 1_000 }).length).toBe(


### PR DESCRIPTION
Second cause of #1386. The first (an `EnvironmentTeardownError` from unawaited dynamic imports) was fixed in #1441; this is the other one.

`sqliteRunStoreSpecifics.test.ts:116` timed out at 60 s on **all three** CI retries in the Coverage step, while the Test step on the same Windows runner passed and a re-run of the identical commit passed.

## Measured first

Instrumented via #1442 (closed unmerged). 4,000 commits:

| platform | step | elapsed | commits/sec |
|---|---|---|---|
| macOS | — | 271 ms | 14,755 |
| ubuntu 22 | Test / Coverage | 673 ms / 1,033 ms | 5,940 / 3,871 |
| ubuntu 24 | Test / Coverage | 1,098 ms / 1,276 ms | 3,642 / 3,135 |
| **windows 22** | **Test / Coverage** | **19,771 ms / 18,561 ms** | **202 / 216** |

Two results that overturned the obvious theories:

- **Coverage is not the variable.** On Windows the Coverage step ran *faster* than the Test step. Ubuntu shows a mild 1.2–1.5x coverage penalty; Windows none.
- **The test was not permanently marginal.** ~19 s against a 60 s timeout is 3.2x headroom. Reaching 60 s required a further ~3x contention excursion on top of a baseline that is already ~73x slower than macOS.

## Why not just raise the timeout

`retry: 2` means three attempts, and the Coverage step's budget is `timeout-minutes: 8` against a run that already takes ~6.4 min. At 60 s that is 180 s worst case; at 120 s it becomes 360 s and blows the **step** timeout instead — trading a diagnosable test failure for an undiagnosable step kill.

## What changed

Halve the commits. The second commit per row was never load-bearing *here*: the test asserts row **retention**, and `query` only adds a status clause when one is passed. A 50-row sample at each end still exercises the realistic start+complete path — including on `bulk-0`, the oldest row, which the rotation assertion turns on.

`ROWS` stays 2,000, so the demonstration is unchanged: the ~1,380-row JSONL cap equivalent is still cleared decisively.

~2,100 commits ≈ 10 s on windows-latest (~5.7x headroom), worst case unchanged at 3 × 60 s. Local: 287 ms → 172 ms.

## Verification that could fail

Reducing coverage is exactly the change that can quietly delete what a test checked, so the sample is made load-bearing by a new `status: "done"` assertion. Verified by mutation — deleting the `completeRun` call fails with `expected +0 to be 100` instead of silently passing every other assertion.

Typecheck clean; full `src/runStore` suite 90 passed.