### PR TITLE
feat(ci): make a killed vitest run say what it was doing (#1365)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,17 +79,40 @@ jobs:
       - name: Build
         run: npm run build
       - name: Test
-        run: npm test -- --reporter=dot --reporter=github-actions
+        run: npm test -- --reporter=dot --reporter=github-actions --reporter=./scripts/vitest-progress-reporter.mjs
+        env:
+          VITEST_PROGRESS_FILE: vitest-progress/test.jsonl
         # Bumped 5→10: the suite has grown past the old 5-minute ceiling (local
         # run: 335s of test time alone, no coverage overhead) and windows-latest
         # runners are consistently slower — CI was killing the step at ~5m0s-5m2s
         # with no failing assertion anywhere in the log, just a hard SIGTERM
         # mid-run. Not a hang; confirmed via a full local `vitest run`
         # completing clean (8759 passed).
+        #
+        # Measured 2026-08-18 across six windows/22 jobs: this step runs
+        # 4.7-5.0 min against the 10 min cap (~50% headroom), while Coverage
+        # below runs 5.4-6.4 min against 8 min (20-32%). Coverage is now the
+        # tight one — raise THAT before this, and see #1365 before raising
+        # either, since a cap bump has already been tried twice and the symptom
+        # recurred at each new ceiling.
         timeout-minutes: 10
       - name: Coverage (enforce 71% lines / 62% branches / 70% functions)
-        run: npm run test:coverage -- --reporter=dot --reporter=github-actions
+        run: npm run test:coverage -- --reporter=dot --reporter=github-actions --reporter=./scripts/vitest-progress-reporter.mjs
+        env:
+          VITEST_PROGRESS_FILE: vitest-progress/coverage.jsonl
         timeout-minutes: 8
+      # `if: always()` is the whole point (#1365). The failure this diagnoses is
+      # a step KILLED at its cap, which uploads nothing on the default
+      # success-only condition — so the one run whose progress anyone wants is
+      # exactly the run that would discard it.
+      - name: Upload vitest progress (#1365)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vitest-progress-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: vitest-progress/
+          if-no-files-found: warn
+          retention-days: 14
 
   schema-audit:
     name: Tool schema breaking-change gate

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ intellij-plugin/.gradle/
 # OUTSIDE the repo entirely (~/.patchwork/private-identifiers.txt), where
 # `git add -f` cannot reach it.
 /.private-denylist
+
+# vitest incremental progress logs (#1365) — CI artifact, never committed
+vitest-progress/
+vitest-progress.jsonl

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `feat/1365-incremental-progress-reporter` — #1365: incremental vitest reporter + always-upload artifact so a KILLED CI step names what was in flight
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-18 `feat/1365-incremental-progress-reporter` — #1365: incremental vitest reporter + always-upload artifact so a KILLED CI step names what was in flight
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/scripts/vitest-progress-reporter.mjs
+++ b/scripts/vitest-progress-reporter.mjs
@@ -1,0 +1,74 @@
+/**
+ * Incremental vitest progress reporter (#1365).
+ *
+ * The problem it exists for: on windows-latest the Test/Coverage step has
+ * repeatedly been KILLED at its `timeout-minutes` cap rather than failing. A
+ * SIGTERM'd vitest flushes no summary, so the log simply stops — and "the run
+ * ended without finishing" is then indistinguishable from a quiet pass, because
+ * absence of output is exactly what a dying process produces. Every remedy so
+ * far (5 -> 10 minute bump) was chosen without knowing which test was in flight,
+ * because that information only ever existed inside the process being killed.
+ *
+ * Every other reporter writes its result at the END, which is precisely the
+ * moment that never arrives. So this one appends synchronously as it goes:
+ * whatever has happened is already on disk before the kill lands. Modules with
+ * a `module-start` and no `module-end` are what was in flight.
+ *
+ * Module-level, not case-level, deliberately: 733 modules costs ~1.5k appends,
+ * where 10k cases would add sync I/O to the hot path on the very platform whose
+ * I/O is already the suspect.
+ *
+ * Never allowed to break a run. A diagnostic that can fail the suite it is
+ * diagnosing is worse than no diagnostic, so every write is swallowed.
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const OUT = resolve(
+  process.env.VITEST_PROGRESS_FILE ?? "vitest-progress.jsonl",
+);
+
+export default class VitestProgressReporter {
+  #write(event) {
+    try {
+      appendFileSync(OUT, `${JSON.stringify({ t: Date.now(), ...event })}\n`);
+    } catch {
+      // A diagnostic must never fail the run it is diagnosing.
+    }
+  }
+
+  onInit() {
+    try {
+      mkdirSync(dirname(OUT), { recursive: true });
+    } catch {
+      // best-effort
+    }
+    this.#write({
+      ev: "run-start",
+      pid: process.pid,
+      platform: process.platform,
+      node: process.version,
+      step: process.env.npm_lifecycle_event ?? "unknown",
+    });
+  }
+
+  onTestModuleStart(m) {
+    this.#write({ ev: "module-start", file: m?.moduleId });
+  }
+
+  onTestModuleEnd(m) {
+    let state;
+    try {
+      state = typeof m?.state === "function" ? m.state() : undefined;
+    } catch {
+      state = undefined;
+    }
+    this.#write({ ev: "module-end", file: m?.moduleId, state });
+  }
+
+  onTestRunEnd(_modules, _errors, reason) {
+    // Reaching this line at all is the signal: the run finished on its own
+    // terms. Its ABSENCE from the file is what identifies a killed run.
+    this.#write({ ev: "run-end", reason });
+  }
+}


### PR DESCRIPTION
#1365 is blocked on an **absence**. On windows-latest the Test/Coverage step has repeatedly been *killed* at its `timeout-minutes` cap rather than failing, and a SIGTERM'd vitest flushes no summary — the log just stops. "The run ended without finishing" is then indistinguishable from a quiet pass, because absence of output is exactly what a dying process produces.

Both remedies tried so far (5 → 10 min) were chosen without knowing which test was in flight, and the symptom recurred at each new ceiling.

## Why a JSON reporter doesn't fix it

Every other reporter writes its result at the **end** — the moment that never arrives for a killed run. `--reporter=json --outputFile` flushes nothing when SIGTERM'd. The instrument has to be incremental.

This one appends synchronously as it goes, so whatever happened is already on disk before the kill lands:

- modules with a `module-start` and no `module-end` = **what was in flight**
- a missing `run-end` = **positively a killed run**, not a quiet one

## Verified by killing a real run

Not assumed — SIGTERM'd a live full-suite run mid-flight:

```
lines on disk after kill : 1298
run-end present          : False   <- marks the kill
modules started/ended    : 649 / 648
in flight at kill        : memoryCard.test.ts
```

A buffered reporter leaves **zero** rows, so this check discriminates rather than passing vacuously.

## Design notes

- **Module-level, not case-level.** 733 modules ≈ 1.5k appends; 10k cases would add sync I/O to the hot path on the very platform whose I/O is already the suspect.
- **Every write is swallowed.** A diagnostic that can fail the suite it diagnoses is worse than no diagnostic.
- **`if: always()` on the upload is load-bearing.** The failure being diagnosed is a killed step, which uploads nothing under the default success-only condition — so the one run anyone wants would be exactly the run that discarded it.

## A measurement that reframes the issue

Across six windows/22 jobs on 2026-08-18:

| step | observed | cap | headroom |
|---|---|---|---|
| Test | 4.7–5.0 m | 10 m | ~50% |
| **Coverage** | **5.4–6.4 m** | **8 m** | **20–32%** |

**Coverage is now the tight step, not Test** — the opposite of where both previous bumps were applied. Recorded in the workflow comment so the next person doesn't raise the wrong cap. No cap is changed here.

## Scope

Diagnostic only. No test, no threshold and no timeout is changed; nothing here can alter pass/fail except by its own presence, which is why this PR's own Windows jobs are the check on the reporter path resolving there.