### PR TITLE
probe(#1365): capture what windows/24 is doing when it dies — DO NOT MERGE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         # risk that decision knowingly took on.
         os: [ubuntu-latest, windows-latest]
         node-version: [22, 24]
-        exclude:
+        # exclude:  # TEMPORARILY DISABLED for the #1365 capture — DO NOT MERGE
           # windows + 24 is EXCLUDED, not advisory. It fails reproducibly and
           # unexplainedly: the process TREE dies ~75-83s after test output
           # stops, with no failing assertion, no vitest summary, not even the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,11 @@ jobs:
           # behaviour of a Node-24-only API is the uncovered case — narrow, but
           # real, and it is exactly where a filesystem API is most likely to
           # differ. Reinstate this cell when #1365 is understood.
-          - os: windows-latest
-            node-version: 24
+          # TEMPORARILY UN-EXCLUDED (#1365 capture) — DO NOT MERGE.
+          # Re-enabled for ONE run so the #1444 progress reporter can record
+          # what is in flight when this cell dies. Restore before merging.
+          # - os: windows-latest
+          #   node-version: 24
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Draft, closed unmerged once the artifact is read.

#1444 shipped an incremental progress reporter so a **killed** CI step names what was in flight. It only pays off when something dies — and the one cell that dies reproducibly is `windows-latest × Node 24`, excluded since #1369 precisely because nobody could explain it.

This un-excludes it for **one run**. The reporter appends synchronously and the artifact uploads on `if: always()`, so a step killed at its cap still leaves the record that has never existed for this failure.

## What the artifact should settle

- **Which module was in flight** when the process died — the thing #1365 has never had. The issue's leading candidate (`recipeRoutes-install-cleanup.test.ts`) was explicitly flagged as "a lead, not a conclusion" because vitest runs files concurrently.
- **Whether it was killed or exited.** A missing `run-end` means killed at the cap; a present one means vitest ended on its own terms and the death is elsewhere.
- **Which step.** `Test` and `Coverage` write separate files, and Coverage is the tighter step (20–32% headroom vs Test's ~50%).

## Not a re-enable

The workflow comment is right that a permanently-red advisory job is worse than an absent one — it cannot be told apart from a real `node:sqlite` regression, which is the signal ADR-0022 added Node 24 for. The exclusion is restored by closing this branch.

Expect windows/24 to be red. **That is the point of the run**, not a defect in it.