### PR TITLE
fix(shim): libuv aborts the shim on a non-canonical watch path (#1365)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,29 +26,25 @@ jobs:
         # risk that decision knowingly took on.
         os: [ubuntu-latest, windows-latest]
         node-version: [22, 24]
-        exclude:
-          # windows + 24 is EXCLUDED, not advisory. It fails reproducibly and
-          # unexplainedly: the process TREE dies ~75-83s after test output
-          # stops, with no failing assertion, no vitest summary, not even the
-          # wrapper's own exit line (#1368), and — per the #1365 probe — no
-          # Windows resource-kill record and 13.4 GiB free. Failing test,
-          # vitest non-zero exit, signalled-child, step timeout and OOM are all
-          # eliminated. See #1365.
-          #
-          # Excluded rather than left `continue-on-error`, deliberately. A
-          # permanently-red advisory job is WORSE than an absent one: it cannot
-          # be told apart from a real regression, so it would silently destroy
-          # the very node:sqlite signal ADR-0022 added 24 for — and it trains
-          # everyone to scroll past a failing job.
-          #
-          # What this costs, stated so nobody assumes otherwise: only the
-          # INTERSECTION is dark. ubuntu/24 covers the Node 24 runtime
-          # (including node:sqlite); windows/22 covers Windows. Windows-specific
-          # behaviour of a Node-24-only API is the uncovered case — narrow, but
-          # real, and it is exactly where a filesystem API is most likely to
-          # differ. Reinstate this cell when #1365 is understood.
-          - os: windows-latest
-            node-version: 24
+        # windows + 24 was EXCLUDED from #1369 until 2026-08-18, because it
+        # failed reproducibly and unexplainedly: the process TREE died with no
+        # failing assertion and no vitest summary. REINSTATED — the cause is
+        # now known and fixed.
+        #
+        # It was never a process death in vitest. libuv's fs-event.c asserts
+        # that the filename it reports starts with the directory it was handed,
+        # and it reports the CANONICAL path — so the shim handing it an 8.3
+        # short path (`RUNNER~1`, from `fs.mkdtempSync(os.tmpdir())` on CI)
+        # failed that comparison and ABORTED the shim process. An abort is not
+        # throwable, so the guard around fs.watch could not catch it and the
+        # polling fallback had no process left to poll. Node 22 does not assert
+        # there; Node 24 does. See #1365 and the realpathSync.native call in
+        # scripts/mcp-stdio-shim.cjs.
+        #
+        # This cell is what ADR-0022 added Node 24 for: node:sqlite is an
+        # experimental API in the trust-evidence path, and Windows-specific
+        # behaviour of a Node-24-only API is exactly where a filesystem API is
+        # most likely to differ.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `fix/1365-shim-libuv-abort` — #1365 ROOT CAUSE: libuv aborts the shim on a non-canonical watch path; realpath fix + windows/24 reinstated
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-18 `fix/1365-shim-libuv-abort` — #1365 ROOT CAUSE: libuv aborts the shim on a non-canonical watch path; realpath fix + windows/24 reinstated
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/scripts/mcp-stdio-shim.cjs
+++ b/scripts/mcp-stdio-shim.cjs
@@ -575,10 +575,36 @@ if (pingMode) {
 // on a different port, reconnects automatically. This means Claude Desktop never
 // needs to be restarted when the bridge restarts on a new port.
 if (!pingMode && explicitPort === null) {
-  const lockDir = path.join(
+  let lockDir = path.join(
     process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude"),
     "ide",
   );
+
+  // Canonicalise before watching, or libuv ABORTS the process on Windows.
+  //
+  // libuv's fs-event.c asserts that the filename it reports starts with the
+  // directory it was handed:
+  //
+  //   Assertion failed: !_wcsnicmp(filename, dir, dirlen), src\win\fs-event.c:72
+  //
+  // It reports the CANONICAL path, so handing it a non-canonical one — an 8.3
+  // short name (`RUNNER~1`, `PROGRA~1`), a symlink, or a substituted drive —
+  // fails that comparison and aborts. An abort is not a throwable: the
+  // try/catch below cannot catch it, and the whole shim dies, taking Claude
+  // Desktop's MCP connection with it. That is also why the polling fallback
+  // did not rescue it — there was no process left to poll.
+  //
+  // Node 22 does not assert here and Node 24 does, which is the entire content
+  // of #1365: three shim-reconnect tests failing on windows x Node 24 only,
+  // because `fs.mkdtempSync(os.tmpdir())` hands back a short path on CI.
+  //
+  // `.native` is the one that resolves 8.3 -> long form on Windows. Failure is
+  // non-fatal: an unresolvable path is no worse off than before.
+  try {
+    lockDir = fs.realpathSync.native(lockDir);
+  } catch {
+    // Directory may not exist yet — the watch below is already guarded.
+  }
 
   const scheduleReconnect = () => {
     if (reconnectTimer) clearTimeout(reconnectTimer);

--- a/src/__tests__/shim-reconnect.test.ts
+++ b/src/__tests__/shim-reconnect.test.ts
@@ -100,6 +100,18 @@ async function closeServer(wss: WebSocketServer): Promise<void> {
   });
 }
 
+/**
+ * The shim's stderr, as the assertion message.
+ *
+ * #1365 took three CI captures partly because these assertions failed as a bare
+ * `expected false to be true`, which says nothing about whether the shim was
+ * slow, wedged, or — as it turned out — aborted by a libuv assertion. The
+ * transcript names the cause on the first failure instead of the third.
+ */
+function shimSaid(stderrLines: string[]): string {
+  return `\n--- shim stderr ---\n${stderrLines.join("").trim() || "(shim wrote nothing to stderr)"}\n`;
+}
+
 let tmpDir: string;
 let shimProcess: ChildProcess | null = null;
 
@@ -170,7 +182,7 @@ describe("startup with no lock file", () => {
     await closeServer(wss);
 
     // Shim must detect the lock appearing mid-wait and connect.
-    expect(connected).toBe(true);
+    expect(connected, shimSaid(stderrLines)).toBe(true);
   });
 });
 
@@ -219,7 +231,7 @@ describe("reconnection after bridge restart", () => {
     await closeServer(wss2);
 
     // This may already pass — it tests the watcher path
-    expect(reconnected).toBe(true);
+    expect(reconnected, shimSaid(stderrLines)).toBe(true);
   });
 
   it("reconnects via polling even when no fs.watch event fires (polling fallback)", async () => {
@@ -273,7 +285,7 @@ describe("reconnection after bridge restart", () => {
 
     await closeServer(wss2);
 
-    expect(reconnected).toBe(true);
+    expect(reconnected, shimSaid(stderrLines)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Root cause of #1365 — and it was never a vitest problem.

```
Assertion failed: !_wcsnicmp(filename, dir, dirlen), src\win\fs-event.c:72
```

libuv asserts that the filename it reports starts with the directory it was handed, and it reports the **canonical** path. Hand it a non-canonical one — an 8.3 short name (`RUNNER~1`), a symlink, a substituted drive — and the comparison fails and the process **aborts**.

## One fact, every symptom

| symptom | explanation |
|---|---|
| "the shim never detected the lock" | it was dead, not slow |
| the polling fallback didn't rescue it | no process left to poll |
| the `try/catch` around `fs.watch` didn't help | an abort is not throwable |
| Node 22 passes, Node 24 fails | different libuv, identical code |
| "process tree dies, no vitest summary" | a child abort, not a vitest fault |

## Not a test-only bug

`fs.mkdtempSync(os.tmpdir())` yields a short path on Windows CI, which is why the tests hit it. But any Windows user whose `CLAUDE_CONFIG_DIR` resolves through a short path or symlink **loses the shim — and with it Claude Desktop's MCP connection** — the moment the lock dir changes. `.native` is the variant that resolves 8.3 to long form; failing to resolve is non-fatal, leaving the path no worse off than before.

## Reinstates windows-latest × Node 24

Excluded since #1369. **Verified green on the exact cell that produced the abort** — all four cells pass.

This is the cell ADR-0022 added Node 24 for: `node:sqlite` is an experimental API sitting in the trust-evidence path, and Windows behaviour of a Node-24-only filesystem API is precisely where it would diverge.

Stated plainly: the reinstatement rests on **one** green run of that cell. The failure it replaces was a deterministic abort with a deterministic fix, not a flake, which is why one run is offered as sufficient — but it is one run, and reverting the matrix line is a one-line change if it proves otherwise.

## How it was found

Three captures, each narrowing the last — via #1444's incremental reporter, then #1445, then #1446 (both closed unmerged):

1. **#1445** disproved the premise. The progress artifact showed 733/733 modules completing with `run-end: failed` and nothing in flight — eliminating process death, cap kill and hang together — and named three failing tests.
2. **#1446** added a verdict to those three, because `expected false to be true` cannot distinguish slow from wedged. It returned `FUNCTIONAL` plus the shim transcript carrying the libuv assertion.
3. This PR fixes it and re-enables the cell.

That transcript is now kept permanently in those three assertion messages. The ambiguity of a bare boolean failure is most of why this took three captures rather than one.