### PR TITLE
feat(privacy): shadow mode for the information boundary (ADR-0021)

### DIFF
--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -35,6 +35,32 @@
 >   indistinguishable at runtime from a feature that was never built.
 >   A source-level test asserts the wiring is present, because the
 >   regression it guards is a line going missing.
+> - **Shadow mode (`patchwork privacy shadow`)** — built 2026-08-18.
+>   Observes what a CANDIDATE policy would have done without enforcing it.
+>   Three things about it are load-bearing:
+>
+>   - It reads `privacy.shadow`, a SEPARATE key from `privacy.destinations`.
+>     One key would mean switching shadow on switches enforcement on, so an
+>     operator asking "what would this policy do?" would find out by having it
+>     applied to live traffic.
+>   - It observes LIVE at the decision point; it does not replay. `workers
+>     shadow` and the Butler grader both replay `runs.jsonl`, and copying them
+>     was the obvious move and does not work: a run-log `agent` step records
+>     no `data_policy`, no driver and no destination, so a replay tool would
+>     have to invent its inputs. A privacy report built on invented inputs is
+>     worse than none, because it reads as measurement.
+>   - It reports the DENOMINATOR first and refuses to print a bare crossing
+>     count. `agent` steps were ~3% of logged step volume when this was built
+>     (54 of 1,795), and orchestrator dispatch is not observed at all — so "N
+>     crossings" alone invites "my policy is fine" from a partial surface. An
+>     empty ledger reports "nothing observed", never "0 crossings".
+>
+>   It lives INSIDE the enforcement chokepoint, so the guarantee that matters
+>   is that it cannot perturb enforcement: the observer returns void and
+>   swallows everything, and a test asserts dispatch is identical with and
+>   without a shadow policy that would DENY. That test is paired with an
+>   assertion that the shadow actually disagreed, or it would pass for the
+>   wrong reason.
 > - **Not built, unchanged from below:** detection, purpose-based
 >   minimisation, least-data routing, policy packs. Destinations are supplied
 >   by config (`privacy.destinations`) since 2026-08-14 — see
@@ -264,10 +290,13 @@ to have silently mis-recorded its own evidence three separate ways (#1340, #1341
 and is the worst possible place to discover a fourth silent-loss path. Do not
 start Phase 3 until trust accrual has been observed end to end on real evidence.
 
-**Shadow mode early, not late.** `workers shadow` and `workers backtest` already
-implement replay-without-enforcing. A privacy shadow mode reusing that pattern is
-cheap, and it is the only part of this design that produces evidence a customer
-can act on before they have adopted anything.
+**Shadow mode early, not late.** — BUILT 2026-08-18, and the "reusing that
+pattern" part of this paragraph was wrong. `workers shadow` and `workers
+backtest` replay `runs.jsonl` because their inputs are in it; the boundary's
+inputs (classification, resolved driver, destination) are never persisted, so
+there is nothing to replay. Shadow observes live at the decision point instead.
+The conclusion survives: it is the only part of this design that produces
+evidence a customer can act on before they have adopted anything.
 
 ## Alternatives rejected
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `feat/1021-privacy-shadow-mode` — ADR-0021 shadow mode: observe boundary decisions without enforcing, coverage-first reporting; touches executeAgent (the enforcement chokepoint)
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-18 `feat/1021-privacy-shadow-mode` — ADR-0021 shadow mode: observe boundary decisions without enforcing, coverage-first reporting; touches executeAgent (the enforcement chokepoint)
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,6 +282,7 @@ const KNOWN_SUBCOMMANDS = [
   "gate",
   "outcomes",
   "butler",
+  "privacy",
   "members",
   // Dispatched at `process.argv[2] === "tools"` (and `help`) but absent from
   // this array until 2026-08. The comment below calls this "the dispatch
@@ -370,6 +371,7 @@ if (
       `Diagnose\n` +
       `  halts [--window 1h|24h|overnight|7d]      Morning summary of recent recipe halts\n` +
       `  judgments [--window ...] [--recipe N]     Recent judge-step verdicts across runs\n` +
+      `  privacy shadow [--since-days N]          What a candidate privacy policy would have stopped\n` +
       `  suggest [--since-days N]                  Recipe + unused-tool suggestions\n` +
       `  token-efficiency benchmark                Measure token cost across tool sets\n` +
       `  traces export                             Bundle approval / recipe / decision traces\n` +
@@ -5307,6 +5309,44 @@ if (process.argv[2] === "members") {
 // runs AS the worker, so grading reachable from one would let a worker
 // manufacture the evidence that raises its own trust dial. Nothing here writes
 // the trust ledger — rows go to the Butler shadow ledger and move nothing.
+// --- privacy shadow (ADR-0021) ---
+// Reports what a CANDIDATE policy would have done, without enforcing it. The
+// headline is the DENOMINATOR, not the crossing count: `agent` steps are a
+// small minority of step volume and orchestrator dispatch is not observed at
+// all (#1397), so a bare count invites "my policy is fine" from a partial
+// surface. formatPrivacyShadow refuses to print one without its coverage.
+if (process.argv[2] === "privacy") {
+  const args = process.argv.slice(3);
+  (async () => {
+    if (args[0] !== "shadow") {
+      process.stderr.write(
+        "Usage: patchwork privacy shadow [--since-days N] [--json]\n" +
+          "\n" +
+          "  Observes boundary decisions WITHOUT enforcing them. Configure a\n" +
+          "  candidate policy under `privacy.shadow.destinations` in config.json;\n" +
+          "  `privacy.destinations` stays untouched, so shadow never enforces.\n",
+      );
+      process.exit(2);
+    }
+    const { summarisePrivacyShadow, formatPrivacyShadow } = await import(
+      "./privacy/shadowLog.js"
+    );
+    const idx = args.indexOf("--since-days");
+    const days = idx !== -1 ? Number(args[idx + 1]) : undefined;
+    const summary = summarisePrivacyShadow(
+      days !== undefined && Number.isFinite(days) && days > 0
+        ? { since: Date.now() - days * 86_400_000 }
+        : {},
+    );
+    if (args.includes("--json")) {
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${formatPrivacyShadow(summary)}\n`);
+    }
+    process.exit(0);
+  })();
+}
+
 if (process.argv[2] === "butler") {
   const args = process.argv.slice(3);
   (async () => {

--- a/src/privacy/__tests__/privacyShadow.test.ts
+++ b/src/privacy/__tests__/privacyShadow.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Privacy shadow mode (ADR-0021).
+ *
+ * The dangerous property of this feature is not that it under-reports — it is
+ * that it lives INSIDE the enforcement chokepoint. A shadow evaluation that
+ * perturbs enforcement turns an observation tool into a privacy regression, so
+ * that is what the first two tests are for, and both are written so they would
+ * fail if the property were lost.
+ *
+ * Every fixture here is synthetic. Privacy fixtures pull real names in by
+ * gravity, and a privacy engine that leaks in its own test data is the sharpest
+ * possible own goal.
+ */
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { executeAgent } from "../../recipes/agentExecutor.js";
+import type { PrivacyConfig } from "../destinationRegistry.js";
+import {
+  formatPrivacyShadow,
+  recordPrivacyShadow,
+  summarisePrivacyShadow,
+} from "../shadowLog.js";
+
+/**
+ * A candidate policy that clears NOTHING above `public` for a remote
+ * destination — so a default (`internal`) step is a crossing.
+ */
+const SHADOW_CONFIG: PrivacyConfig = {
+  destinations: {
+    "candidate-remote": {
+      type: "remote",
+      classifications: ["public"],
+      drivers: ["local", "anthropic", "openai"],
+    },
+  },
+};
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "privacy-shadow-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function deps(extra: Record<string, unknown> = {}) {
+  const ran = vi.fn(async () => ({ text: "model output" }));
+  const shadowRows: Array<Record<string, unknown>> = [];
+  return {
+    ran,
+    shadowRows,
+    deps: {
+      localFn: ran,
+      loadPatchworkConfig: () => ({}),
+      ...extra,
+    } as never,
+  };
+}
+
+describe("shadow mode cannot perturb enforcement", () => {
+  it("dispatches identically with and without a shadow policy that would DENY", async () => {
+    // Baseline: no shadow wiring at all.
+    const a = deps();
+    const before = await executeAgent(
+      { prompt: "synthetic prompt", driver: "local" },
+      a.deps,
+    );
+
+    // Same call, but with a candidate policy that refuses this step outright.
+    const b = deps({
+      loadPrivacyShadowConfigFn: () => SHADOW_CONFIG,
+      recordPrivacyShadowFn: (r: Record<string, unknown>) => {
+        b.shadowRows.push(r);
+      },
+    });
+    const after = await executeAgent(
+      { prompt: "synthetic prompt", driver: "local" },
+      b.deps,
+    );
+
+    // The driver ran BOTH times. Asserting the call, not the returned text — a
+    // text-only check would pass even if the shadow path had suppressed the
+    // dispatch, which is precisely the failure being excluded.
+    expect(a.ran).toHaveBeenCalledTimes(1);
+    expect(b.ran).toHaveBeenCalledTimes(1);
+    expect(after.text).toBe(before.text);
+
+    // ...and the shadow genuinely disagreed, or this test proves nothing: a
+    // shadow policy that happened to ALLOW would make the assertions above
+    // pass for the wrong reason.
+    expect(b.shadowRows).toHaveLength(1);
+    expect(b.shadowRows[0]?.decision).not.toBe("ALLOW");
+  });
+
+  it("a shadow recorder that throws does not fail the step", async () => {
+    const d = deps({
+      loadPrivacyShadowConfigFn: () => SHADOW_CONFIG,
+      recordPrivacyShadowFn: () => {
+        throw new Error("ledger is unwritable");
+      },
+    });
+    const result = await executeAgent(
+      { prompt: "synthetic prompt", driver: "local" },
+      d.deps,
+    );
+    expect(d.ran).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe("model output");
+  });
+});
+
+describe("the denominator counts every observed dispatch", () => {
+  it("records ALLOWed dispatches too, not only crossings", async () => {
+    // A candidate policy that clears `internal` — so this step is ALLOWed and
+    // must STILL be observed. If only refusals were recorded, the denominator
+    // would be the refusals themselves and coverage would always read 100%.
+    const permissive: PrivacyConfig = {
+      destinations: {
+        "candidate-local": {
+          type: "local",
+          classifications: ["public", "internal", "personal"],
+          drivers: ["local"],
+        },
+      },
+    };
+    const d = deps({
+      loadPrivacyShadowConfigFn: () => permissive,
+      recordPrivacyShadowFn: (r: Record<string, unknown>) => {
+        d.shadowRows.push(r);
+      },
+    });
+    await executeAgent({ prompt: "synthetic prompt", driver: "local" }, d.deps);
+    expect(d.shadowRows).toHaveLength(1);
+    expect(d.shadowRows[0]?.decision).toBe("ALLOW");
+  });
+});
+
+describe("the ledger carries no payload", () => {
+  it("never stores the prompt, only declared metadata", () => {
+    recordPrivacyShadow(
+      {
+        decision: "DENY",
+        classification: "confidential",
+        categories: ["financial"],
+        destinationId: "candidate-remote",
+        destinationType: "remote",
+        reason: "synthetic reason",
+        enforcing: false,
+      },
+      { dir },
+    );
+    const raw = readFileSync(path.join(dir, "privacy_shadow.jsonl"), "utf-8");
+    const row = JSON.parse(raw.trim());
+    // Category NAMES are metadata; their contents are not. A privacy ledger
+    // holding the prompts would be the largest unclassified copy of exactly
+    // what the boundary protects.
+    expect(row.categories).toEqual(["financial"]);
+    expect(Object.keys(row)).not.toContain("prompt");
+    expect(Object.keys(row)).not.toContain("payload");
+    expect(Object.keys(row)).not.toContain("text");
+  });
+});
+
+describe("reporting leads with coverage and never a bare count", () => {
+  it("an empty ledger reports 'nothing observed', NOT '0 crossings'", () => {
+    const out = formatPrivacyShadow(summarisePrivacyShadow({ dir }));
+    // "0 crossings" from an empty ledger asserts a clean result from a
+    // measurement that never happened — the exact false comfort this whole
+    // feature exists to avoid.
+    expect(out).toContain("Nothing has been observed yet");
+    expect(out).not.toMatch(/\b0 of 0\b/);
+  });
+
+  it("always names the unobserved path alongside any count", () => {
+    for (const decision of ["ALLOW", "DENY", "LOCAL_ONLY"] as const) {
+      recordPrivacyShadow(
+        {
+          decision,
+          classification: "internal",
+          destinationId: "candidate-remote",
+          destinationType: "remote",
+          reason: "synthetic reason",
+          enforcing: false,
+        },
+        { dir },
+      );
+    }
+    const s = summarisePrivacyShadow({ dir });
+    expect(s.observed).toBe(3);
+    expect(s.crossings).toBe(2);
+
+    const out = formatPrivacyShadow(s);
+    // Coverage precedes the finding, in the output itself and not merely in
+    // documentation: the orchestrator path is ungoverned (#1397), so a count
+    // presented without it invites "my policy is fine" from a partial surface.
+    expect(out.indexOf("NOT observed")).toBeLessThan(out.indexOf("would have"));
+    expect(out).toContain("orchestrator task dispatch");
+    expect(out).toContain("2 of 3 observed dispatch(es)");
+  });
+
+  it("separates observations made while a live policy was enforcing", () => {
+    recordPrivacyShadow(
+      {
+        decision: "DENY",
+        classification: "internal",
+        destinationId: "candidate-remote",
+        destinationType: "remote",
+        reason: "synthetic reason",
+        enforcing: true,
+      },
+      { dir },
+    );
+    const s = summarisePrivacyShadow({ dir });
+    // "my candidate disagrees with my live policy" is a different claim from
+    // "here is what a policy would have done on an ungoverned machine".
+    expect(s.enforcingObservations).toBe(1);
+  });
+});

--- a/src/privacy/__tests__/productionWiring.test.ts
+++ b/src/privacy/__tests__/productionWiring.test.ts
@@ -32,6 +32,25 @@ describe("the information boundary is wired into production dispatch", () => {
     expect(src).toMatch(/(?<![\w$])recordBoundaryDecisionFn\s*:/);
   });
 
+  it("buildAgentExecutorDeps supplies the shadow deps too (ADR-0021)", () => {
+    // Shadow mode inherits the same failure mode as the enforcing pair above:
+    // optional deps nobody supplies look exactly like a feature that was never
+    // built. Worse here, because its whole output is a coverage number — an
+    // unwired shadow reports "0 observed" and reads as "nothing crossed".
+    const src = read("src/recipes/yamlRunner.ts");
+    expect(src).toMatch(/(?<![\w$])loadPrivacyShadowConfigFn\s*:/);
+    expect(src).toMatch(/(?<![\w$])recordPrivacyShadowFn\s*:/);
+  });
+
+  it("shadow reads privacy.shadow, NOT privacy.destinations", () => {
+    // Two keys is the safety property, not a naming preference: if shadow read
+    // the enforcing config, switching shadow on would switch ENFORCEMENT on,
+    // and an operator asking "what would this policy do?" would find out by
+    // having it applied to live traffic.
+    const src = read("src/recipes/yamlRunner.ts");
+    expect(src).toMatch(/privacy\?\.shadow/);
+  });
+
   it("the receipt log is a shared instance, not per call", () => {
     // A per-call instance restarts `seq` at 1 on every dispatch — the same
     // per-instance-counter-on-a-shared-file defect that collided 142 of 145

--- a/src/privacy/shadowLog.ts
+++ b/src/privacy/shadowLog.ts
@@ -1,0 +1,269 @@
+/**
+ * Privacy shadow ledger (ADR-0021).
+ *
+ * Answers "how often would the policy I am considering have stopped something?"
+ * WITHOUT enforcing it — the only part of the information-boundary design that
+ * produces evidence an operator can act on before adopting anything.
+ *
+ * ## Why this is observed live and not replayed
+ *
+ * `workers shadow` and the Butler outcome grader both replay `runs.jsonl`,
+ * and the obvious move was to copy them. It does not work here: a run-log
+ * `agent` step persists only
+ *
+ *     durationMs, error, haltCategory, haltReason, id,
+ *     inputTokens, judgeVerdict, outputTokens, status, tool
+ *
+ * — no `data_policy`, no driver, no destination. Those two replay a log that
+ * contains their inputs; this one's inputs are never written down. A replay
+ * tool would have to invent the classification and the destination, and a
+ * privacy report built on invented inputs is worse than no report, because it
+ * reads as measurement.
+ *
+ * So observation happens at the decision point, and this file is only the
+ * ledger and its summariser.
+ *
+ * ## What is deliberately not here
+ *
+ * No payload field, for the same reason `boundary_receipts.jsonl` has none: a
+ * privacy audit log containing the prompts would be the largest unclassified
+ * copy of exactly the material the boundary exists to protect. Only declared
+ * metadata — classification, category NAMES, destination, decision, reason.
+ *
+ * Separate file from `boundary_receipts.jsonl`, and nothing in the live system
+ * reads it. A shadow row is a hypothetical about a policy that is not in force;
+ * mixing it into the receipts would put unenforced decisions into the evidence
+ * trail that is supposed to record what actually happened.
+ */
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { patchworkPath } from "../patchworkHome.js";
+import type { BoundaryDecision, Classification } from "./dataPolicy.js";
+
+export const SHADOW_LOG_BASENAME = "privacy_shadow.jsonl";
+
+/** Clip so a runaway reason cannot bloat the ledger. */
+const MAX_REASON = 500;
+
+/**
+ * The path the boundary DOES observe. Recorded on every row rather than
+ * assumed by the reader, so a future second observed path is a data change
+ * and not a silent redefinition of what the denominator counted.
+ */
+export const OBSERVED_PATH = "recipe agent steps";
+
+/**
+ * Paths that reach a model WITHOUT passing the decision point.
+ *
+ * This is not a caveat, it is part of the result. A crossing count computed
+ * over a partial surface reads as "your policy is fine" when it partly means
+ * "we did not look there" — and `agent` steps are ~3% of logged step volume,
+ * so the unobserved remainder is the larger part of the system.
+ *
+ * Kept in step with `src/__tests__/boundaryScope.test.ts`, which pins the
+ * orchestrator gap to the code.
+ */
+export const UNOBSERVED_PATHS = [
+  "orchestrator task dispatch (runClaudeTask, automation hooks) — ADR-0021 scope, #1397",
+] as const;
+
+export interface PrivacyShadowRow {
+  at: number;
+  decision: BoundaryDecision;
+  classification: Classification;
+  /** Category NAMES only — never their contents. */
+  categories?: string[];
+  destinationId: string;
+  destinationType: "local" | "remote";
+  redactCategories?: string[];
+  reason: string;
+  recipeName?: string;
+  stepId?: string;
+  /**
+   * Whether an ENFORCING policy was also in force for this dispatch.
+   *
+   * A shadow row on a machine that already enforces means something different
+   * from one on a machine that does not, and the summary must not merge them:
+   * the first is "my live policy and my candidate policy disagree", the second
+   * is "here is what a policy would have done".
+   */
+  enforcing: boolean;
+}
+
+export interface ShadowLogOptions {
+  /** Defaults to `${PATCHWORK_HOME}`. */
+  dir?: string;
+  now?: () => number;
+}
+
+export function shadowLogPath(dir?: string): string {
+  return dir
+    ? path.join(dir, SHADOW_LOG_BASENAME)
+    : patchworkPath(SHADOW_LOG_BASENAME);
+}
+
+/**
+ * Append one observation. NEVER throws.
+ *
+ * This runs inside the enforcement chokepoint, so a failure here must be
+ * incapable of disturbing a dispatch. An unwritable shadow ledger is a lost
+ * measurement; a shadow ledger that can abort a step is a privacy feature that
+ * breaks the system it observes.
+ */
+export function recordPrivacyShadow(
+  row: Omit<PrivacyShadowRow, "at">,
+  opts: ShadowLogOptions = {},
+): void {
+  try {
+    const file = shadowLogPath(opts.dir);
+    mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    const full: PrivacyShadowRow = {
+      at: (opts.now ?? Date.now)(),
+      ...row,
+      reason: row.reason.slice(0, MAX_REASON),
+    };
+    appendFileSync(file, `${JSON.stringify(full)}\n`);
+  } catch {
+    // Observation only — never disturb the dispatch being observed.
+  }
+}
+
+export interface PrivacyShadowSummary {
+  /** The denominator. Every observed dispatch, INCLUDING allowed ones. */
+  observed: number;
+  /** Non-ALLOW observations — what a candidate policy would have acted on. */
+  crossings: number;
+  byDecision: Record<string, number>;
+  /** Destination id → count, for "where would it have gone". */
+  byDestination: Record<string, number>;
+  earliest?: number;
+  latest?: number;
+  /** How many observations happened while a live policy was also enforcing. */
+  enforcingObservations: number;
+  observedPath: string;
+  unobservedPaths: readonly string[];
+}
+
+export interface SummariseOptions extends ShadowLogOptions {
+  /** Only count rows at or after this timestamp. */
+  since?: number;
+}
+
+export function summarisePrivacyShadow(
+  opts: SummariseOptions = {},
+): PrivacyShadowSummary {
+  const summary: PrivacyShadowSummary = {
+    observed: 0,
+    crossings: 0,
+    byDecision: {},
+    byDestination: {},
+    enforcingObservations: 0,
+    observedPath: OBSERVED_PATH,
+    unobservedPaths: UNOBSERVED_PATHS,
+  };
+  let text: string;
+  try {
+    text = readFileSync(shadowLogPath(opts.dir), "utf-8");
+  } catch {
+    // No ledger yet. Reported as observed=0, which the formatter renders as
+    // "nothing observed" rather than "no crossings" — see formatPrivacyShadow.
+    return summary;
+  }
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let row: PrivacyShadowRow;
+    try {
+      row = JSON.parse(t) as PrivacyShadowRow;
+    } catch {
+      continue;
+    }
+    if (typeof row.at !== "number" || typeof row.decision !== "string")
+      continue;
+    if (opts.since !== undefined && row.at < opts.since) continue;
+    summary.observed += 1;
+    if (row.decision !== "ALLOW") summary.crossings += 1;
+    if (row.enforcing) summary.enforcingObservations += 1;
+    summary.byDecision[row.decision] =
+      (summary.byDecision[row.decision] ?? 0) + 1;
+    if (row.destinationId) {
+      summary.byDestination[row.destinationId] =
+        (summary.byDestination[row.destinationId] ?? 0) + 1;
+    }
+    if (summary.earliest === undefined || row.at < summary.earliest) {
+      summary.earliest = row.at;
+    }
+    if (summary.latest === undefined || row.at > summary.latest) {
+      summary.latest = row.at;
+    }
+  }
+  return summary;
+}
+
+/**
+ * Render coverage FIRST, and never a bare crossing count.
+ *
+ * "3 crossings last week" invites exactly one reading — that the other
+ * dispatches were fine — and on this surface that reading is wrong twice over:
+ * `agent` steps are a small minority of step volume, and orchestrator dispatch
+ * is not observed at all. The denominator and the blind spots are therefore
+ * part of the finding, not a footnote under it.
+ */
+export function formatPrivacyShadow(s: PrivacyShadowSummary): string {
+  const L: string[] = [];
+  L.push("[privacy-shadow] coverage");
+  L.push(`  observed:   ${s.observed} dispatch(es) on ${s.observedPath}`);
+  for (const p of s.unobservedPaths) L.push(`  NOT observed: ${p}`);
+
+  if (s.observed === 0) {
+    // Deliberately NOT "0 crossings" — that asserts a clean result from an
+    // empty ledger. Nothing was measured, which is a different statement.
+    L.push("");
+    L.push("  Nothing has been observed yet, so there is no result to report.");
+    L.push(
+      "  Configure `privacy.shadow.destinations` and run a recipe with an",
+    );
+    L.push("  agent step; every dispatch is then recorded, allowed or not.");
+    return L.join("\n");
+  }
+
+  const span =
+    s.earliest !== undefined && s.latest !== undefined
+      ? `${new Date(s.earliest).toISOString()} → ${new Date(s.latest).toISOString()}`
+      : "(unknown)";
+  L.push(`  window:     ${span}`);
+  if (s.enforcingObservations > 0) {
+    L.push(
+      `  note:       ${s.enforcingObservations} observed while a live policy was ALSO enforcing`,
+    );
+  }
+  L.push("");
+  const pct = ((s.crossings / s.observed) * 100).toFixed(1);
+  L.push(
+    `[privacy-shadow] ${s.crossings} of ${s.observed} observed dispatch(es) (${pct}%) would have been stopped or altered`,
+  );
+  for (const [d, n] of Object.entries(s.byDecision).sort(
+    (a, b) => b[1] - a[1],
+  )) {
+    L.push(`  ${d.padEnd(18)} ${n}`);
+  }
+  if (Object.keys(s.byDestination).length > 0) {
+    L.push("");
+    L.push("  destinations:");
+    for (const [d, n] of Object.entries(s.byDestination).sort(
+      (a, b) => b[1] - a[1],
+    )) {
+      L.push(`    ${d.padEnd(16)} ${n}`);
+    }
+  }
+  L.push("");
+  L.push(
+    "  Shadow only — nothing was blocked, and no live policy changed. These are",
+  );
+  L.push(
+    "  hypotheticals about the candidate policy in `privacy.shadow`, over the",
+  );
+  L.push("  observed path only.");
+  return L.join("\n");
+}

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  type BoundaryDecision,
   type BoundaryOutcome,
   type Classification,
   DEFAULT_CLASSIFICATION,
@@ -77,6 +78,26 @@ export interface AgentExecutorDeps {
     classification: string;
     categories?: string[];
     redactCategories?: string[];
+  }) => void;
+  /**
+   * CANDIDATE policy for shadow mode (ADR-0021), deliberately a SEPARATE
+   * loader from `loadPrivacyConfigFn`.
+   *
+   * Two keys, not one, because the absence of `privacy` is what keeps the
+   * boundary inert: if shadow reused the enforcing config, switching shadow on
+   * would switch enforcement on with it, and an operator asking "what would
+   * this policy do?" would find out by having it applied.
+   */
+  loadPrivacyShadowConfigFn?: () => PrivacyConfig | undefined;
+  recordPrivacyShadowFn?: (r: {
+    decision: BoundaryDecision;
+    reason: string;
+    destinationId: string;
+    destinationType: "local" | "remote";
+    classification: Classification;
+    categories?: string[];
+    redactCategories?: string[];
+    enforcing: boolean;
   }) => void;
   anthropicFn: (prompt: string, model: string) => Promise<AgentResult>;
   /** Handles openai, grok, gemini, gemini-api, codex — passes driver name through. */
@@ -289,6 +310,58 @@ type ResolvedBoundary = BoundaryOutcome & {
   categories?: string[];
 };
 
+/**
+ * Evaluate the CANDIDATE policy and record what it would have done.
+ *
+ * Reuses `evaluateBoundary` with a different config loader rather than
+ * reimplementing the decision: a shadow that computed its own answer would
+ * drift from the enforcer, and a report that disagrees with the thing it
+ * predicts is worse than no report.
+ *
+ * `destination` is stripped from the context on purpose. When a caller passes
+ * one explicitly, `evaluateBoundary` skips the registry — correct for
+ * enforcement, wrong here, because the whole question is what the CANDIDATE
+ * registry would have chosen.
+ */
+function observeShadowBoundary(
+  input: AgentExecutorInput,
+  resolvedDriver: string | undefined,
+  enforced: ResolvedBoundary | null,
+  deps: AgentExecutorDeps,
+): void {
+  try {
+    if (!deps.loadPrivacyShadowConfigFn || !deps.recordPrivacyShadowFn) return;
+    const ctx = input.boundary
+      ? { ...input.boundary, destination: undefined }
+      : undefined;
+    const shadow = evaluateBoundary(
+      ctx,
+      resolvedDriver,
+      deps.loadPrivacyShadowConfigFn,
+      isLocalFamilyDriver(resolvedDriver)
+        ? () => resolveLocalEndpoint(deps)
+        : undefined,
+    );
+    if (!shadow) return;
+    deps.recordPrivacyShadowFn({
+      decision: shadow.decision,
+      reason: shadow.reason,
+      destinationId: shadow.destination.id,
+      destinationType: shadow.destination.type,
+      classification: shadow.classification,
+      ...(shadow.categories && { categories: shadow.categories }),
+      ...(shadow.redactCategories && {
+        redactCategories: shadow.redactCategories,
+      }),
+      // Distinguishes "my candidate policy disagrees with my live one" from
+      // "here is what a policy would have done on an ungoverned machine".
+      enforcing: enforced !== null,
+    });
+  } catch {
+    // Observation must never disturb the dispatch it observes.
+  }
+}
+
 function evaluateBoundary(
   ctx: AgentExecutorInput["boundary"],
   driver: string | undefined,
@@ -410,6 +483,19 @@ export async function executeAgent(
       ? () => resolveLocalEndpoint(deps)
       : undefined,
   );
+  // ── PRIVACY SHADOW (ADR-0021) ───────────────────────────────────────────
+  // Observation only. Placed HERE — after the enforced decision is computed but
+  // before it is acted on — so every agent dispatch is recorded, including the
+  // allowed ones. Recording only refusals would make the denominator the
+  // refusals themselves, and a coverage report whose denominator is its own
+  // numerator always reads 100%.
+  //
+  // It returns void and swallows everything. That is the load-bearing property:
+  // this runs inside the enforcement chokepoint, so it must be structurally
+  // incapable of changing whether or where a step dispatches. A test asserts
+  // the enforced outcome is identical with and without a shadow policy that
+  // would DENY.
+  observeShadowBoundary(input, resolvedDriver, boundary, deps);
   if (boundary && boundary.decision !== "ALLOW") {
     deps.recordBoundaryDecisionFn?.({
       decision: boundary.decision,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -123,6 +123,7 @@ import type {
   Classification as ClassificationValue,
 } from "../privacy/dataPolicy.js";
 import type { PrivacyConfig } from "../privacy/destinationRegistry.js";
+import { recordPrivacyShadow } from "../privacy/shadowLog.js";
 
 /**
  * Bundled-templates directory used as a third allowed root for nested-recipe
@@ -3604,6 +3605,31 @@ function buildAgentExecutorDeps(
     // `loadConfig` is already mtime-gated so this is cheap.
     loadPrivacyConfigFn: () =>
       (loadPatchworkConfigSync() as { privacy?: PrivacyConfig }).privacy,
+    // Shadow mode (ADR-0021). Wired here for the same reason as the pair above:
+    // deps declared and supplied nowhere are indistinguishable at runtime from
+    // a feature that was never built.
+    //
+    // Reads `privacy.shadow`, NOT `privacy` — a separate key so that turning
+    // shadow on cannot turn enforcement on. An operator asking "what would this
+    // policy do?" must not find out by having it applied.
+    loadPrivacyShadowConfigFn: () =>
+      (
+        loadPatchworkConfigSync() as {
+          privacy?: { shadow?: PrivacyConfig };
+        }
+      ).privacy?.shadow,
+    recordPrivacyShadowFn: (r) => {
+      recordPrivacyShadow({
+        decision: r.decision,
+        reason: r.reason,
+        destinationId: r.destinationId,
+        destinationType: r.destinationType,
+        classification: r.classification,
+        enforcing: r.enforcing,
+        ...(r.categories && { categories: r.categories }),
+        ...(r.redactCategories && { redactCategories: r.redactCategories }),
+      });
+    },
     recordBoundaryDecisionFn: (r) => {
       // Fail-soft: a receipt that cannot be written must never affect the
       // decision it describes, which has already been made and enforced.


### PR DESCRIPTION
Answers *"how often would the policy I'm considering have stopped something?"* without enforcing it — the only part of ADR-0021 that produces evidence an operator can act on before adopting anything.

## Three design points, each against a simpler-looking alternative

### Replay is impossible, so it observes live

The plan was to reuse the shadow-ledger pattern proven twice (`workers shadow`, the Butler grader). **It doesn't transfer.** Those replay `runs.jsonl` because their inputs are in it. An `agent` step persists only:

```
durationMs, error, haltCategory, haltReason, id,
inputTokens, judgeVerdict, outputTokens, status, tool
```

No `data_policy`, no driver, no destination — and per #1398 the boundary judges the *resolved* driver, which isn't recorded either. A replay tool would have to invent its inputs, and a privacy report built on invented inputs is worse than none, because it reads as measurement.

### Coverage is the headline, not the crossing count

Measured on the real log: `agent` steps are **54 of 1,795** logged steps (~3%), and orchestrator dispatch isn't observed at all (#1397).

"N crossings last week" over that surface invites exactly one reading — that everything else was fine — and that reading is wrong twice over. So the denominator and the unobserved paths print first, and an empty ledger reports `nothing observed`, never `0 crossings`:

```
[privacy-shadow] coverage
  observed:   3 dispatch(es) on recipe agent steps
  NOT observed: orchestrator task dispatch (runClaudeTask, automation hooks) — ADR-0021 scope, #1397
  window:     …

[privacy-shadow] 2 of 3 observed dispatch(es) (66.7%) would have been stopped or altered
```

### A separate config key

Shadow reads `privacy.shadow`, **not** `privacy.destinations`. One key would mean enabling shadow enables enforcement — an operator asking what a policy would do would find out by having it applied to live traffic.

## The risk actually worth testing

This lives **inside the enforcement chokepoint**. The observer returns `void` and swallows everything, and the guard asserts dispatch is identical with and without a shadow policy that would `DENY` — paired with an assertion that the shadow genuinely disagreed, or the test would pass for the wrong reason.

Verified by mutation, not assumed:

| mutation | result |
|---|---|
| make shadow perturb enforcement | 2 tests fail |
| rename the wiring line so no caller supplies it | wiring guard fails |

That second one guards the failure ADR-0021 records for the enforcing pair: optional deps nobody supplies are indistinguishable at runtime from a feature that was never built. Worse for shadow, whose whole output is a coverage number — unwired, it reports "0 observed" and reads as "nothing crossed".

## Scope and hygiene

- No payload field, like `boundary_receipts.jsonl` and for the same reason.
- Every fixture synthetic (`candidate-remote`, `candidate-local`, `financial`).
- **No policy packs.** Per ADR-0019 those are control-plane, and an example here would ship MIT and couldn't be withdrawn.
- Enforcement, redaction and purpose are untouched. `ALLOW_REDACTED` still refuses.
- Corrects ADR-0021's own "reusing that pattern is cheap" — the conclusion held, the stated mechanism didn't.

## Test status

Privacy suite 73 pass; gates green (`audit-cli-commands`, business-content, fixtures, lsp-tools, in-flight). Full suite: 10,063 pass, 4 fail — 3 in `tokenEfficiency`, **reproduced on stashed clean main**, and 1 in `extensionClient` that passes 3/3 in isolation on this branch (full-suite load flake, untouched by this change).