### PR TITLE
feat(privacy): observe orchestrator dispatch in shadow (#1397)

### DIFF
--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -224,6 +224,26 @@ expressed.
 Until that exists, the honest statement is the one above: this path is
 ungoverned, and the ADR says so.
 
+**Observed in shadow since 2026-08-18 (#1397), still not enforced.** The
+objection above is to asserting a DECLARATION nobody made — it is not an
+objection to looking. `claudeOrchestrator` now records each dispatch to the
+privacy shadow ledger, stamped `path: "orchestrator-task"` and
+`labelSource: "assumed"`, with `enforcing: false`. Nothing refuses, alters or
+delays a task; the scope statement above is unchanged.
+
+This is deliberately the cheap half. The design question — per-task label vs
+workspace default — was being answered from ZERO measurements of how much
+traffic this path actually carries, and the volume should choose it. The
+receipt-shape requirement stands: when enforcement does arrive, `declared` and
+`assumed` must stay distinguishable, which is why the distinction is being
+recorded now rather than retrofitted onto a ledger that already conflated them.
+
+`src/__tests__/boundaryScope.test.ts` pins BOTH sides: no enforcement markers in
+`claudeOrchestrator.ts`, AND the observation call present at the dispatch site.
+A one-sided check would keep passing if the observation were deleted, and the
+report would then show zero orchestrator rows — indistinguishable from a quiet
+path, which is exactly what an unobserved one looks like.
+
 `src/__tests__/boundaryScope.test.ts` pins this to the code. It fails if
 orchestrator dispatch gains a boundary decision — at which point this section is
 wrong and must be updated with it — and it fails equally if the recipe path ever

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `feat/1397-orchestrator-shadow-observation` — #1397: observe (not enforce) orchestrator dispatch in the privacy shadow ledger, with declared-vs-assumed labelling
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-18 `feat/1397-orchestrator-shadow-observation` — #1397: observe (not enforce) orchestrator dispatch in the privacy shadow ledger, with declared-vs-assumed labelling
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/__tests__/boundaryScope.test.ts
+++ b/src/__tests__/boundaryScope.test.ts
@@ -75,6 +75,29 @@ describe("ADR-0021 scope — the boundary covers the recipe agent-step path", ()
     }
   });
 
+  it("orchestrator dispatch IS observed in shadow, though not enforced (#1397)", () => {
+    // The pair above only says orchestrator dispatch is not GOVERNED. On its
+    // own that is one-sided: deleting the shadow observation would keep it
+    // passing, and the privacy report would then show zero orchestrator rows —
+    // indistinguishable from a path that is simply quiet. Silence is exactly
+    // what an unobserved path produces, so "observed but not enforced" has to
+    // be pinned from both directions.
+    const orchestrator = read("claudeOrchestrator.ts");
+    // The CALL SITE, not the identifier. `mentions()` is satisfied by the
+    // function's own declaration and its doc comment, so deleting the call
+    // left this guard green — probed, not assumed, and it is the same trap
+    // this file's header records for `recordBoundaryDecisionFn_REMOVED`.
+    expect(
+      /observeOrchestratorShadow\s*\(\s*this\.driver/.test(orchestrator),
+      "claudeOrchestrator.ts no longer CALLS observeOrchestratorShadow at its " +
+        "dispatch point, so `patchwork privacy shadow` will report 0 " +
+        "orchestrator rows and read as coverage rather than absence",
+    ).toBe(true);
+    // And the observation must stay an OBSERVATION: `enforcing: false` is what
+    // keeps the ADR's out-of-scope statement true.
+    expect(orchestrator).toContain("enforcing: false");
+  });
+
   it("the ADR documents the gap rather than leaving the invariant overbroad", () => {
     // The narrowing is the deliverable of #1397. If someone restores the
     // original wording, the code has not changed but the document has started

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -14,6 +14,17 @@ function getConfigDir(): string {
 }
 
 import type { IClaudeDriver } from "./drivers/types.js";
+import { loadConfig as loadPatchworkConfig } from "./patchworkConfig.js";
+import {
+  DEFAULT_CLASSIFICATION,
+  decideBoundary,
+} from "./privacy/dataPolicy.js";
+import {
+  type PrivacyConfig,
+  parseRegistry,
+  resolveDestination,
+} from "./privacy/destinationRegistry.js";
+import { recordPrivacyShadow } from "./privacy/shadowLog.js";
 import { resolveWorkspaceRoot } from "./recipes/workspaceRoot.js";
 import { writeFileAtomic, writeFileAtomicSync } from "./writeFileAtomic.js";
 
@@ -167,6 +178,63 @@ interface PersistedTask {
   allowedTools?: string[];
   disallowedTools?: string[];
   isAutomationTask?: boolean;
+}
+
+/**
+ * Privacy SHADOW observation for orchestrator dispatch (#1397, ADR-0021).
+ *
+ * This path is UNGOVERNED and stays ungoverned: nothing here enforces, refuses,
+ * or alters a dispatch. It records what a candidate policy WOULD have said, so
+ * the question "should this path be governed, and how?" stops being answered
+ * from zero measurements.
+ *
+ * Why observation is allowed where enforcement is not. ADR-0021 leaves this
+ * path out of scope because an orchestrator task has no declared `data_policy`
+ * and no natural place to put one — so enforcing would mean giving every task
+ * the `internal` default and writing an affirmative receipt about a label
+ * nobody supplied. That objection is about ASSERTING A DECLARATION, not about
+ * looking: every row written here is stamped `labelSource: "assumed"`, and the
+ * report renders assumed rows separately rather than as operator intent.
+ *
+ * Deliberately NOT injected as a constructor dep. Optional deps that no caller
+ * supplies are indistinguishable at runtime from a feature that was never
+ * built — the exact state ADR-0021 records for the boundary before
+ * `buildAgentExecutorDeps` wired it. Reading its own config means there is no
+ * wiring to forget. It stays inert unless `privacy.shadow` is configured.
+ */
+function observeOrchestratorShadow(driverName: string | undefined): void {
+  try {
+    const cfg = (
+      loadPatchworkConfig() as { privacy?: { shadow?: PrivacyConfig } }
+    ).privacy?.shadow;
+    if (!cfg) return;
+    const registry = parseRegistry(cfg);
+    const resolved = resolveDestination(
+      registry,
+      driverName,
+      DEFAULT_CLASSIFICATION,
+      {},
+    );
+    if (!resolved) return;
+    const outcome = decideBoundary(
+      { classification: DEFAULT_CLASSIFICATION },
+      resolved.destination,
+    );
+    recordPrivacyShadow({
+      decision: outcome.decision,
+      reason: outcome.reason,
+      destinationId: resolved.destination.id,
+      destinationType: resolved.destination.type,
+      classification: DEFAULT_CLASSIFICATION,
+      path: "orchestrator-task",
+      // Always assumed. There is no declared-policy channel on this path, and
+      // saying otherwise would be the claim ADR-0021 refuses to make.
+      labelSource: "assumed",
+      enforcing: false,
+    });
+  } catch {
+    // Observation must never disturb the dispatch it observes.
+  }
 }
 
 export class ClaudeOrchestrator {
@@ -458,6 +526,9 @@ export class ClaudeOrchestrator {
       this.workspace;
 
     try {
+      // Shadow observation only — see observeOrchestratorShadow. Nothing here
+      // can refuse or alter this dispatch; #1397 remains open.
+      observeOrchestratorShadow(this.driver.name);
       const result = await this.driver.run({
         prompt: task.prompt,
         contextFiles: task.contextFiles,

--- a/src/privacy/__tests__/orchestratorShadow.test.ts
+++ b/src/privacy/__tests__/orchestratorShadow.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Orchestrator dispatch is OBSERVED in the privacy shadow ledger (#1397).
+ *
+ * Drives the REAL `ClaudeOrchestrator` rather than calling the observer
+ * directly. A hand-injected observer proves the logic and never the path, and
+ * the path is the entire question here: this file exists because #1397 is
+ * about a dispatch route that bypasses the boundary, and a test that does not
+ * go through `enqueue` cannot tell whether the call site is wired at all.
+ *
+ * `PATCHWORK_HOME` is redirected rather than spying on a module: a namespace
+ * spy does not reach a named import, and the failure mode is that the test
+ * quietly writes to the operator's real `~/.patchwork`.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ClaudeOrchestrator } from "../../claudeOrchestrator.js";
+import type { ProviderDriver } from "../../drivers/types.js";
+
+let dir: string;
+let prevHome: string | undefined;
+
+function driver(): ProviderDriver {
+  return {
+    name: "anthropic",
+    run: async () => ({ text: "ok", exitCode: 0 }),
+  } as unknown as ProviderDriver;
+}
+
+/** Candidate policy clearing only `public` to a remote — so the default is a crossing. */
+function writeShadowConfig(): void {
+  writeFileSync(
+    path.join(dir, "config.json"),
+    JSON.stringify({
+      privacy: {
+        shadow: {
+          destinations: {
+            "candidate-remote": {
+              type: "remote",
+              classifications: ["public"],
+              drivers: ["anthropic"],
+            },
+          },
+        },
+      },
+    }),
+  );
+}
+
+function rows(): Array<Record<string, unknown>> {
+  try {
+    return readFileSync(path.join(dir, "privacy_shadow.jsonl"), "utf-8")
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "orch-shadow-"));
+  prevHome = process.env.PATCHWORK_HOME;
+  process.env.PATCHWORK_HOME = dir;
+});
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.PATCHWORK_HOME;
+  else process.env.PATCHWORK_HOME = prevHome;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("orchestrator dispatch is observed, never enforced (#1397)", () => {
+  it("records a row through the real enqueue path", async () => {
+    writeShadowConfig();
+    const orch = new ClaudeOrchestrator(driver(), dir, () => {});
+    const id = orch.enqueue({ prompt: "synthetic prompt" });
+    await new Promise((r) => setImmediate(r));
+
+    // The dispatch SUCCEEDED. Observation must not gate anything — if this
+    // ever reads "error", the observer has become an enforcer.
+    expect(orch.getTask(id)?.status).toBe("done");
+
+    const r = rows();
+    expect(r).toHaveLength(1);
+    expect(r[0]?.path).toBe("orchestrator-task");
+    // Never "declared": this path has no declared-policy channel, and saying
+    // otherwise asserts operator intent nobody expressed — the exact reason
+    // ADR-0021 kept it out of scope.
+    expect(r[0]?.labelSource).toBe("assumed");
+    expect(r[0]?.enforcing).toBe(false);
+    // It genuinely disagreed, or the assertions above pass for the wrong
+    // reason on a policy that happened to allow everything.
+    expect(r[0]?.decision).not.toBe("ALLOW");
+  });
+
+  it("writes nothing when no candidate policy is configured", async () => {
+    // No config.json at all. Shadow is opt-in; an unconfigured install must
+    // not start accumulating a privacy ledger it never asked for.
+    const orch = new ClaudeOrchestrator(driver(), dir, () => {});
+    orch.enqueue({ prompt: "synthetic prompt" });
+    await new Promise((r) => setImmediate(r));
+    expect(rows()).toHaveLength(0);
+  });
+
+  it("carries no payload — the prompt is never written", async () => {
+    writeShadowConfig();
+    const orch = new ClaudeOrchestrator(driver(), dir, () => {});
+    orch.enqueue({ prompt: "SENTINEL-PROMPT-TEXT" });
+    await new Promise((r) => setImmediate(r));
+
+    const raw = readFileSync(path.join(dir, "privacy_shadow.jsonl"), "utf-8");
+    // An orchestrator prompt is free-form and frequently assembled from
+    // workspace context, so it is the LEAST safe thing in the system to copy
+    // into an audit log.
+    expect(raw).not.toContain("SENTINEL-PROMPT-TEXT");
+  });
+});

--- a/src/privacy/__tests__/privacyShadow.test.ts
+++ b/src/privacy/__tests__/privacyShadow.test.ts
@@ -194,10 +194,21 @@ describe("reporting leads with coverage and never a bare count", () => {
 
     const out = formatPrivacyShadow(s);
     // Coverage precedes the finding, in the output itself and not merely in
-    // documentation: the orchestrator path is ungoverned (#1397), so a count
-    // presented without it invites "my policy is fine" from a partial surface.
-    expect(out.indexOf("NOT observed")).toBeLessThan(out.indexOf("would have"));
-    expect(out).toContain("orchestrator task dispatch");
+    // documentation: a count presented without its denominator invites "my
+    // policy is fine" from a partial surface.
+    //
+    // Both known paths are named even when one has no rows. A path that
+    // vanishes from the report when it is quiet is indistinguishable from one
+    // that is fully covered, and silence is exactly what an unobserved path
+    // produces.
+    expect(out).toContain("recipe agent steps");
+    expect(out).toContain("orchestrator tasks");
+    expect(out.indexOf("orchestrator tasks")).toBeLessThan(
+      out.indexOf("would have"),
+    );
+    // Enumerated, never asserted as total (#1397 / ADR-0021's overbroad
+    // invariant, which had to be corrected once already).
+    expect(out).toContain("not proof that no other path exists");
     expect(out).toContain("2 of 3 observed dispatch(es)");
   });
 

--- a/src/privacy/shadowLog.ts
+++ b/src/privacy/shadowLog.ts
@@ -46,12 +46,29 @@ export const SHADOW_LOG_BASENAME = "privacy_shadow.jsonl";
 /** Clip so a runaway reason cannot bloat the ledger. */
 const MAX_REASON = 500;
 
+/** Dispatch paths that can reach a model. Recorded per row, never inferred. */
+export type ShadowPath = "recipe-agent-step" | "orchestrator-task";
+
+export const PATH_LABELS: Record<ShadowPath, string> = {
+  "recipe-agent-step": "recipe agent steps",
+  "orchestrator-task": "orchestrator tasks (runClaudeTask, automation hooks)",
+};
+
 /**
- * The path the boundary DOES observe. Recorded on every row rather than
- * assumed by the reader, so a future second observed path is a data change
- * and not a silent redefinition of what the denominator counted.
+ * Whether the classification on a row was DECLARED by an operator or ASSUMED
+ * by the runtime.
+ *
+ * This is the difference between a measurement and a claim about intent.
+ * `orchestrator-task` has no declared-policy channel at all (ADR-0021), so
+ * every one of its rows is assumed — and a recipe step with no `data_policy`
+ * is assumed too, since `internal` there is a default and not a declaration.
+ * Merging the two would let a report say an operator classified something they
+ * never labelled.
  */
-export const OBSERVED_PATH = "recipe agent steps";
+export type LabelSource = "declared" | "assumed";
+
+/** @deprecated kept so older rows still render; use PATH_LABELS. */
+export const OBSERVED_PATH = PATH_LABELS["recipe-agent-step"];
 
 /**
  * Paths that reach a model WITHOUT passing the decision point.
@@ -64,12 +81,26 @@ export const OBSERVED_PATH = "recipe agent steps";
  * Kept in step with `src/__tests__/boundaryScope.test.ts`, which pins the
  * orchestrator gap to the code.
  */
-export const UNOBSERVED_PATHS = [
-  "orchestrator task dispatch (runClaudeTask, automation hooks) — ADR-0021 scope, #1397",
-] as const;
+export const UNOBSERVED_PATHS: readonly string[] = [];
+
+/**
+ * Coverage here is ENUMERATED, not proven.
+ *
+ * The list of paths is one someone wrote down. Nothing checks that it is
+ * exhaustive, so "both known paths observed" must never be rendered as "all
+ * model-bound context observed" — that is the overbroad-invariant failure
+ * ADR-0021 already had to correct once, and a coverage report is the worst
+ * place to repeat it.
+ */
+export const COVERAGE_IS_ENUMERATED =
+  "coverage is enumerated from known dispatch paths; it is not proof that no other path exists";
 
 export interface PrivacyShadowRow {
   at: number;
+  /** Which dispatch path produced this. Absent on rows written before paths. */
+  path?: ShadowPath;
+  /** Whether the classification was declared or defaulted. */
+  labelSource?: LabelSource;
   decision: BoundaryDecision;
   classification: Classification;
   /** Category NAMES only — never their contents. */
@@ -141,6 +172,10 @@ export interface PrivacyShadowSummary {
   latest?: number;
   /** How many observations happened while a live policy was also enforcing. */
   enforcingObservations: number;
+  /** Per dispatch path: observed / crossings. The coverage breakdown. */
+  byPath: Record<string, { observed: number; crossings: number }>;
+  /** How many rows carried an ASSUMED classification rather than a declared one. */
+  assumed: number;
   observedPath: string;
   unobservedPaths: readonly string[];
 }
@@ -159,6 +194,8 @@ export function summarisePrivacyShadow(
     byDecision: {},
     byDestination: {},
     enforcingObservations: 0,
+    byPath: {},
+    assumed: 0,
     observedPath: OBSERVED_PATH,
     unobservedPaths: UNOBSERVED_PATHS,
   };
@@ -183,7 +220,14 @@ export function summarisePrivacyShadow(
       continue;
     if (opts.since !== undefined && row.at < opts.since) continue;
     summary.observed += 1;
-    if (row.decision !== "ALLOW") summary.crossings += 1;
+    const isCrossing = row.decision !== "ALLOW";
+    if (isCrossing) summary.crossings += 1;
+    // Rows predating the `path` field came from the only path that existed.
+    const pathKey = row.path ?? "recipe-agent-step";
+    const bucket = (summary.byPath[pathKey] ??= { observed: 0, crossings: 0 });
+    bucket.observed += 1;
+    if (isCrossing) bucket.crossings += 1;
+    if (row.labelSource === "assumed") summary.assumed += 1;
     if (row.enforcing) summary.enforcingObservations += 1;
     summary.byDecision[row.decision] =
       (summary.byDecision[row.decision] ?? 0) + 1;
@@ -213,8 +257,14 @@ export function summarisePrivacyShadow(
 export function formatPrivacyShadow(s: PrivacyShadowSummary): string {
   const L: string[] = [];
   L.push("[privacy-shadow] coverage");
-  L.push(`  observed:   ${s.observed} dispatch(es) on ${s.observedPath}`);
+  for (const key of Object.keys(PATH_LABELS) as ShadowPath[]) {
+    const b = s.byPath[key];
+    L.push(
+      `  ${(b ? "observed" : "no rows").padEnd(10)} ${String(b?.observed ?? 0).padStart(5)}  ${PATH_LABELS[key]}`,
+    );
+  }
   for (const p of s.unobservedPaths) L.push(`  NOT observed: ${p}`);
+  L.push(`  (${COVERAGE_IS_ENUMERATED})`);
 
   if (s.observed === 0) {
     // Deliberately NOT "0 crossings" — that asserts a clean result from an
@@ -233,6 +283,15 @@ export function formatPrivacyShadow(s: PrivacyShadowSummary): string {
       ? `${new Date(s.earliest).toISOString()} → ${new Date(s.latest).toISOString()}`
       : "(unknown)";
   L.push(`  window:     ${span}`);
+  if (s.assumed > 0) {
+    // Never presented as a footnote. An assumed classification is the runtime's
+    // default, not an operator's statement, and a report that blurs the two
+    // asserts intent nobody expressed — the specific failure ADR-0021 names as
+    // the reason orchestrator dispatch was left out of scope in the first place.
+    L.push(
+      `  assumed:    ${s.assumed} of ${s.observed} row(s) carry a DEFAULTED classification, not a declared one`,
+    );
+  }
   if (s.enforcingObservations > 0) {
     L.push(
       `  note:       ${s.enforcingObservations} observed while a live policy was ALSO enforcing`,
@@ -264,6 +323,6 @@ export function formatPrivacyShadow(s: PrivacyShadowSummary): string {
   L.push(
     "  hypotheticals about the candidate policy in `privacy.shadow`, over the",
   );
-  L.push("  observed path only.");
+  L.push("  dispatch paths listed above and no others.");
   return L.join("\n");
 }

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -95,6 +95,8 @@ export interface AgentExecutorDeps {
     destinationId: string;
     destinationType: "local" | "remote";
     classification: Classification;
+    path?: "recipe-agent-step" | "orchestrator-task";
+    labelSource?: "declared" | "assumed";
     categories?: string[];
     redactCategories?: string[];
     enforcing: boolean;
@@ -349,6 +351,11 @@ function observeShadowBoundary(
       destinationId: shadow.destination.id,
       destinationType: shadow.destination.type,
       classification: shadow.classification,
+      path: "recipe-agent-step",
+      // `internal` from an absent `data_policy` is a DEFAULT, not a
+      // declaration. Recording it as declared would let the report claim an
+      // operator classified something they never labelled.
+      labelSource: input.boundary?.dataPolicy ? "declared" : "assumed",
       ...(shadow.categories && { categories: shadow.categories }),
       ...(shadow.redactCategories && {
         redactCategories: shadow.redactCategories,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -3626,6 +3626,8 @@ function buildAgentExecutorDeps(
         destinationType: r.destinationType,
         classification: r.classification,
         enforcing: r.enforcing,
+        ...(r.path && { path: r.path }),
+        ...(r.labelSource && { labelSource: r.labelSource }),
         ...(r.categories && { categories: r.categories }),
         ...(r.redactCategories && { redactCategories: r.redactCategories }),
       });


### PR DESCRIPTION
ADR-0021 leaves orchestrator dispatch **ungoverned, and it stays ungoverned** — nothing here refuses, alters or delays a task. It is now *observed*.

## The ADR's objection was never to looking

It is to asserting a **declaration nobody made**. Wiring the enforcing decision in would give every orchestrator task the `internal` default and write an affirmative receipt about a label no operator supplied — a check that runs, always says fine, and manufactures intent.

So every row from this path carries `labelSource: "assumed"` and `enforcing: false`, and the report renders assumed rows separately rather than as operator intent.

## Why observation before design

The open question is the declared-policy channel — per-task label vs workspace default — and it was being answered from **zero measurements** of how much traffic this path actually carries. The volume should choose it.

The receipt-shape requirement is unchanged, and is exactly why `declared` vs `assumed` is recorded *now* rather than retrofitted later onto a ledger that already conflated them.

## `labelSource` applies to both paths

A recipe step with no `data_policy` gets `internal` **by default**, which is also not a declaration. The previous row shape would have reported it as one. That's a correctness fix to the existing path, not just scaffolding for the new one.

```
[privacy-shadow] coverage
  observed       1  recipe agent steps
  observed       2  orchestrator tasks (runClaudeTask, automation hooks)
  (coverage is enumerated from known dispatch paths; it is not proof that no other path exists)
  assumed:    2 of 3 row(s) carry a DEFAULTED classification, not a declared one
```

That parenthetical is deliberate: the path list is enumerated by hand, so "both known paths observed" must never render as "all model-bound context observed" — the overbroad-invariant failure this ADR already had to correct once.

## The guard, and the bug I found in my own guard

`boundaryScope.test.ts` now pins **both sides**: no enforcement markers in `claudeOrchestrator.ts`, *and* the observation call present at the dispatch site. A one-sided guard keeps passing when the observation is deleted — and the report then shows zero orchestrator rows, which is indistinguishable from a quiet path.

**Probed, not assumed:** my first version used the file's existing `mentions()` helper and **passed with the call deleted**, because the function's own declaration and doc comment satisfy a whole-identifier match. It asserts the call site now. That is the same trap this file's header already records for `recordBoundaryDecisionFn_REMOVED` — I walked into it one function over.

## Test path

The behavioural test drives the **real** `ClaudeOrchestrator` through `enqueue`, not the observer directly: hand-injected deps prove the logic and never the path, and the path is the entire subject of #1397. It also asserts the dispatch still succeeds (an observer that gates is an enforcer), that an unconfigured install writes nothing, and that the prompt never reaches the ledger — orchestrator prompts are free-form and assembled from workspace context, so they are the least safe thing in the system to copy into an audit log.

Full suite: 10,068 pass, 3 fail — all `tokenEfficiency`, reproduced on stashed clean main.