### PR TITLE
feat(privacy): patchwork privacy suggest — a starter shadow config from evidence

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-18 `feat/privacy-shadow-suggest` — `patchwork privacy suggest`: derive a starter privacy.shadow block from the drivers installed recipes actually declare
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-18 `feat/privacy-shadow-suggest` — `patchwork privacy suggest`: derive a starter privacy.shadow block from the drivers installed recipes actually declare
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5318,9 +5318,73 @@ if (process.argv[2] === "members") {
 if (process.argv[2] === "privacy") {
   const args = process.argv.slice(3);
   (async () => {
+    if (args[0] === "suggest") {
+      // Enumerates the destinations this workspace ACTUALLY dispatches to.
+      // Mechanical, not regulatory: per ADR-0019 curated policy content is
+      // control-plane, so the destinations are measured and the
+      // classifications are a placeholder the output tells you to review.
+      const { readdirSync, readFileSync, statSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const { patchworkPath } = await import("./patchworkHome.js");
+      const { suggestShadowConfig, formatSuggestion } = await import(
+        "./privacy/suggestShadowConfig.js"
+      );
+      const counts = new Map<string, number>();
+      let unspecified = 0;
+      const walk = (dir: string): void => {
+        let entries: string[] = [];
+        try {
+          entries = readdirSync(dir);
+        } catch {
+          return;
+        }
+        for (const e of entries) {
+          const full = join(dir, e);
+          let isDir = false;
+          try {
+            isDir = statSync(full).isDirectory();
+          } catch {
+            continue;
+          }
+          if (isDir) {
+            walk(full);
+            continue;
+          }
+          if (!/\.ya?ml$/.test(e)) continue;
+          let text = "";
+          try {
+            text = readFileSync(full, "utf-8");
+          } catch {
+            continue;
+          }
+          // Count agent steps and the drivers they name. A step with no
+          // `driver:` uses the bridge default and is reported separately —
+          // folding it in would under-enumerate the surface.
+          const agents = text.match(/^\s*-?\s*agent:/gm)?.length ?? 0;
+          const named = [...text.matchAll(/^\s*driver:\s*([A-Za-z0-9_-]+)/gm)];
+          for (const m of named) {
+            const d = (m[1] ?? "").toLowerCase();
+            if (d) counts.set(d, (counts.get(d) ?? 0) + 1);
+          }
+          if (agents > named.length) unspecified += agents - named.length;
+        }
+      };
+      walk(patchworkPath("recipes"));
+      const drivers = [...counts.entries()]
+        .map(([driver, count]) => ({ driver, count }))
+        .sort((a, b) => b.count - a.count);
+      const result = suggestShadowConfig({ drivers, unspecified });
+      if (args.includes("--json")) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      } else {
+        process.stdout.write(`${formatSuggestion(result)}\n`);
+      }
+      process.exit(0);
+    }
     if (args[0] !== "shadow") {
       process.stderr.write(
         "Usage: patchwork privacy shadow [--since-days N] [--json]\n" +
+          "       patchwork privacy suggest [--json]\n" +
           "\n" +
           "  Observes boundary decisions WITHOUT enforcing them. Configure a\n" +
           "  candidate policy under `privacy.shadow.destinations` in config.json;\n" +

--- a/src/privacy/__tests__/suggestShadowConfig.test.ts
+++ b/src/privacy/__tests__/suggestShadowConfig.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `patchwork privacy suggest` (ADR-0021).
+ *
+ * The risk in a "starter config" is not that it is wrong — it is that it looks
+ * authoritative. An operator who pastes it is entitled to assume it reflects
+ * what was measured, so the tests below are mostly about what the output must
+ * REFUSE to imply.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  formatSuggestion,
+  suggestShadowConfig,
+} from "../suggestShadowConfig.js";
+
+describe("destinations are derived from evidence", () => {
+  it("splits local-family drivers from everything else", () => {
+    const r = suggestShadowConfig({
+      drivers: [
+        { driver: "claude-code", count: 36 },
+        { driver: "local", count: 7 },
+        { driver: "ollama", count: 1 },
+      ],
+    });
+    expect(r.config.destinations["candidate-local"]?.drivers).toEqual([
+      "local",
+      "ollama",
+    ]);
+    // `claude-code` runs the CLI on this machine but the DATA leaves it, which
+    // is the only sense that matters to an information boundary.
+    expect(r.config.destinations["candidate-remote"]?.drivers).toEqual([
+      "claude-code",
+    ]);
+  });
+
+  it("reports steps with no declared driver instead of folding them in", () => {
+    const r = suggestShadowConfig({
+      drivers: [{ driver: "local", count: 2 }],
+      unspecified: 28,
+    });
+    // Those steps dispatch somewhere too. Omitting them would under-enumerate
+    // the exact surface this command claims to enumerate — and silently, since
+    // the block would look complete.
+    expect(r.notes.join(" ")).toContain("28 agent step(s) declare no driver");
+  });
+});
+
+describe("the output refuses to look authoritative", () => {
+  it("always says the classifications are not advice", () => {
+    const r = suggestShadowConfig({
+      drivers: [{ driver: "claude-code", count: 1 }],
+    });
+    // ADR-0019: curated policy content is regulatory material and belongs in
+    // the control plane. A suggestion that read as guidance would ship that
+    // liability from an MIT repo.
+    const notes = r.notes.join(" ");
+    expect(notes).toContain("NOT advice about your obligations");
+    expect(notes).toContain("measured");
+  });
+
+  it("warns that an all-local workspace will show few crossings", () => {
+    const r = suggestShadowConfig({ drivers: [{ driver: "local", count: 3 }] });
+    // Otherwise a near-empty shadow report reads as a clean bill of health
+    // when it is really a property of the workspace.
+    expect(r.notes.join(" ")).toContain("not a clean bill of health");
+  });
+
+  it("says so when there is nothing to suggest", () => {
+    const r = suggestShadowConfig({ drivers: [] });
+    expect(Object.keys(r.config.destinations)).toHaveLength(0);
+    expect(r.notes.join(" ")).toContain("No drivers found at all");
+  });
+});
+
+describe("it can never turn on enforcement", () => {
+  it("emits privacy.shadow only, never privacy.destinations", () => {
+    const out = formatSuggestion(
+      suggestShadowConfig({ drivers: [{ driver: "claude-code", count: 1 }] }),
+    );
+    const parsed = JSON.parse(
+      out.slice(out.indexOf("{"), out.lastIndexOf("}") + 1),
+    );
+    expect(parsed.privacy.shadow).toBeDefined();
+    // The enforcing key must not appear anywhere in a pasteable block. Someone
+    // following the instructions must not be able to switch enforcement on by
+    // accident — that is the whole reason the two keys are separate.
+    expect(parsed.privacy.destinations).toBeUndefined();
+    expect(out).toContain("never enforces");
+  });
+});

--- a/src/privacy/suggestShadowConfig.ts
+++ b/src/privacy/suggestShadowConfig.ts
@@ -1,0 +1,142 @@
+/**
+ * Derive a STARTER `privacy.shadow` block from the drivers a workspace's
+ * recipes actually declare (ADR-0021).
+ *
+ * ## Why this exists
+ *
+ * Shadow mode was built, wired and shipped, and then collected zero rows —
+ * because turning it on means hand-writing a destination registry against a
+ * schema most operators have never read. The feature was not unadopted because
+ * nobody wanted it; it was unadopted because the first step was homework.
+ *
+ * This does the mechanical half: enumerate the destinations a workspace's
+ * recipes dispatch to. That is genuinely hard by hand across dozens of recipe
+ * files and trivial to compute.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * It does not tell anyone what their policy should be. Per ADR-0019, curated
+ * policy content is regulatory material and belongs in the control plane, not
+ * in this MIT repo — and an operator who pastes a suggestion is entitled to
+ * assume it reflects only what was measured, not advice about their
+ * obligations.
+ *
+ * So the split is: the DESTINATIONS are derived from evidence, and the
+ * CLASSIFICATIONS are a deliberately conservative placeholder the operator is
+ * told, in the output, to review. The one thing worse than no starter config is
+ * one that looks authoritative.
+ */
+import { isLocalFamilyDriver } from "./destinationRegistry.js";
+
+export interface DriverUsage {
+  driver: string;
+  /** How many declaration sites named it. Ordering only; never a policy input. */
+  count: number;
+}
+
+export interface SuggestInput {
+  /** Drivers declared across installed recipes. */
+  drivers: DriverUsage[];
+  /**
+   * How many agent steps declared NO driver and so use the bridge default.
+   *
+   * Reported rather than silently folded in: those steps DO reach a
+   * destination, and a suggestion that omitted them would under-enumerate the
+   * exact surface it claims to enumerate.
+   */
+  unspecified?: number;
+}
+
+export interface SuggestResult {
+  /** Paste-ready value for `privacy.shadow` in config.json. */
+  config: {
+    destinations: Record<
+      string,
+      { type: "local" | "remote"; classifications: string[]; drivers: string[] }
+    >;
+  };
+  /** Things the operator must know before pasting. Never omitted. */
+  notes: string[];
+}
+
+/** Conservative placeholder — reviewed by the operator, not asserted by us. */
+const REMOTE_DEFAULT = ["public", "internal"];
+const LOCAL_DEFAULT = [
+  "public",
+  "internal",
+  "personal",
+  "confidential",
+  "restricted",
+];
+
+export function suggestShadowConfig(input: SuggestInput): SuggestResult {
+  const local: string[] = [];
+  const remote: string[] = [];
+  for (const { driver } of input.drivers) {
+    (isLocalFamilyDriver(driver) ? local : remote).push(driver);
+  }
+
+  const destinations: SuggestResult["config"]["destinations"] = {};
+  if (local.length > 0) {
+    destinations["candidate-local"] = {
+      type: "local",
+      classifications: [...LOCAL_DEFAULT],
+      drivers: local.sort(),
+    };
+  }
+  if (remote.length > 0) {
+    destinations["candidate-remote"] = {
+      type: "remote",
+      classifications: [...REMOTE_DEFAULT],
+      drivers: remote.sort(),
+    };
+  }
+
+  const notes: string[] = [];
+  notes.push(
+    "The DESTINATIONS below are measured — they are the drivers your recipes declare.",
+  );
+  notes.push(
+    "The CLASSIFICATIONS are a conservative placeholder, NOT advice about your obligations. Review them.",
+  );
+  if (input.unspecified && input.unspecified > 0) {
+    notes.push(
+      `${input.unspecified} agent step(s) declare no driver and use the bridge default — ` +
+        "they dispatch somewhere too, and this block does not cover them until you name that driver.",
+    );
+  }
+  if (remote.length === 0) {
+    notes.push(
+      "No remote drivers found. With only local destinations, a shadow run will show few or no crossings — that is a property of this workspace, not a clean bill of health.",
+    );
+  }
+  if (Object.keys(destinations).length === 0) {
+    notes.push(
+      "No drivers found at all. Nothing to suggest; shadow mode would observe nothing.",
+    );
+  }
+  notes.push(
+    "This is `privacy.shadow` — it never enforces. `privacy.destinations` is the enforcing key and is untouched.",
+  );
+  return { config: { destinations }, notes };
+}
+
+export function formatSuggestion(r: SuggestResult): string {
+  const L: string[] = [];
+  L.push("[privacy-suggest] a starting point, derived from your recipes");
+  L.push("");
+  for (const n of r.notes) L.push(`  - ${n}`);
+  L.push("");
+  L.push("  Add to ~/.patchwork/config.json:");
+  L.push("");
+  const body = JSON.stringify({ privacy: { shadow: r.config } }, null, 2)
+    .split("\n")
+    .map((l) => `    ${l}`)
+    .join("\n");
+  L.push(body);
+  L.push("");
+  L.push(
+    "  Then run a recipe with an agent step and `patchwork privacy shadow`.",
+  );
+  return L.join("\n");
+}


### PR DESCRIPTION
Shadow mode shipped and collected **zero rows**. Not because nobody wanted it: turning it on means hand-writing a destination registry against a schema most operators have never read, so the first step was homework. Everything else on the ADR-0021 roadmap is waiting on evidence that setup barrier prevents.

## What it does

The mechanical half — enumerate the destinations a workspace actually dispatches to. Hard by hand across dozens of recipe files, trivial to compute.

Run against this workspace (84 recipes):

```
  - The DESTINATIONS below are measured — they are the drivers your recipes declare.
  - The CLASSIFICATIONS are a conservative placeholder, NOT advice about your obligations. Review them.
  - 28 agent step(s) declare no driver and use the bridge default — they dispatch
    somewhere too, and this block does not cover them until you name that driver.
  - This is `privacy.shadow` — it never enforces. `privacy.destinations` is untouched.
```

Those **28 unspecified steps are reported, not folded in**. They dispatch somewhere too, and a suggestion that quietly omitted them would under-enumerate the exact surface it claims to enumerate — while looking complete. That is the failure mode this whole feature exists to avoid, so it would be a poor place to reproduce it.

`subprocess` / `claude-code` classify as **remote**: the CLI runs on this machine but the data leaves it, which is the only sense an information boundary cares about.

## What it deliberately does not do

It does not tell anyone what their policy should be. Per ADR-0019 curated policy content is regulatory material and belongs in `patchwork-control-plane` — so the **destinations are measured** and the **classifications are a conservative placeholder the output tells you to review**.

The one thing worse than no starter config is one that looks authoritative.

## It cannot switch enforcement on

The emitted block is `privacy.shadow` only. Someone following the paste instructions must not be able to enable enforcement by accident — that is the entire reason the two keys are separate. Verified by mutation: emitting `privacy.destinations` instead fails the guard.

It also warns when a workspace is all-local, because a near-empty shadow report then reads as a clean bill of health when it is really a property of the workspace.

## Why this rather than field labels

Investigating redaction (#1450) showed it and purpose both sit behind a recipe-**schema** change. Committing that — visible to every recipe author, hard to withdraw — to serve a feature with zero recorded usage would be speculative. Removing the adoption barrier is the step that produces the evidence to decide it on.

Privacy suite 79 pass; gates green.