### PR TITLE
fix(privacy): suggest ignored the bridge default driver

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `fix/privacy-suggest-default-driver` — privacy suggest ignored the configured default driver, so its unspecified-steps note was wrong in both directions
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-19 `fix/privacy-suggest-default-driver` — privacy suggest ignored the configured default driver, so its unspecified-steps note was wrong in both directions
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5373,7 +5373,21 @@ if (process.argv[2] === "privacy") {
       const drivers = [...counts.entries()]
         .map(([driver, count]) => ({ driver, count }))
         .sort((a, b) => b.count - a.count);
-      const result = suggestShadowConfig({ drivers, unspecified });
+      // The bridge default is where every driver-less agent step goes, so the
+      // suggestion is incomplete without it.
+      let defaultDriver: string | undefined;
+      try {
+        const { loadConfig } = await import("./patchworkConfig.js");
+        const d = (loadConfig() as { driver?: unknown }).driver;
+        if (typeof d === "string" && d.trim()) defaultDriver = d.trim();
+      } catch {
+        // Unreadable config — the note says so rather than assuming.
+      }
+      const result = suggestShadowConfig({
+        drivers,
+        unspecified,
+        ...(defaultDriver && { defaultDriver }),
+      });
       if (args.includes("--json")) {
         process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
       } else {

--- a/src/privacy/__tests__/suggestShadowConfig.test.ts
+++ b/src/privacy/__tests__/suggestShadowConfig.test.ts
@@ -45,6 +45,59 @@ describe("destinations are derived from evidence", () => {
   });
 });
 
+describe("the bridge default driver is a real destination", () => {
+  it("says the default is covered when a recipe already names it", () => {
+    const r = suggestShadowConfig({
+      drivers: [{ driver: "local", count: 7 }],
+      unspecified: 28,
+      defaultDriver: "local",
+    });
+    // The first version warned these were UNCOVERED whenever any existed —
+    // needless alarm when the default is already in the block, which is the
+    // common case and was the live one on the workspace this shipped against.
+    expect(r.notes.join(" ")).toContain("this block covers them");
+    expect(r.config.destinations["candidate-local"]?.drivers).toEqual([
+      "local",
+    ]);
+  });
+
+  it("ADDS the default when no recipe names it", () => {
+    const r = suggestShadowConfig({
+      drivers: [{ driver: "local", count: 2 }],
+      unspecified: 5,
+      defaultDriver: "claude-code",
+    });
+    // The genuinely dangerous direction: a live remote destination that appears
+    // in no recipe file, so a scan of recipes alone misses it entirely.
+    expect(r.config.destinations["candidate-remote"]?.drivers).toEqual([
+      "claude-code",
+    ]);
+    expect(r.notes.join(" ")).toContain("ADDED below");
+  });
+
+  it("does not duplicate a default that is already present", () => {
+    const r = suggestShadowConfig({
+      drivers: [{ driver: "local", count: 3 }],
+      unspecified: 1,
+      defaultDriver: "LOCAL",
+    });
+    // Case-insensitive: `driver: LOCAL` in config.json is the same destination.
+    expect(r.config.destinations["candidate-local"]?.drivers).toEqual([
+      "local",
+    ]);
+  });
+
+  it("admits it when the default could not be read", () => {
+    const r = suggestShadowConfig({
+      drivers: [{ driver: "local", count: 1 }],
+      unspecified: 4,
+    });
+    // "could not be read" is a different claim from "there is none", and the
+    // operator needs to know which they are looking at.
+    expect(r.notes.join(" ")).toContain("could not be read from config.json");
+  });
+});
+
 describe("the output refuses to look authoritative", () => {
   it("always says the classifications are not advice", () => {
     const r = suggestShadowConfig({

--- a/src/privacy/suggestShadowConfig.ts
+++ b/src/privacy/suggestShadowConfig.ts
@@ -45,6 +45,17 @@ export interface SuggestInput {
    * exact surface it claims to enumerate.
    */
   unspecified?: number;
+  /**
+   * The bridge default driver (`driver` in config.json), which is where every
+   * `unspecified` step actually goes.
+   *
+   * Without it the note about those steps is wrong in BOTH directions: it warns
+   * they are uncovered when the default is already in the block (needless
+   * alarm), and it under-states the gap when the default appears in no recipe
+   * at all — the case where the suggestion genuinely misses a live destination.
+   * Neither is acceptable in output whose entire job is enumerating a surface.
+   */
+  defaultDriver?: string;
 }
 
 export interface SuggestResult {
@@ -72,8 +83,18 @@ const LOCAL_DEFAULT = [
 export function suggestShadowConfig(input: SuggestInput): SuggestResult {
   const local: string[] = [];
   const remote: string[] = [];
+  const seen = new Set<string>();
   for (const { driver } of input.drivers) {
+    seen.add(driver);
     (isLocalFamilyDriver(driver) ? local : remote).push(driver);
+  }
+
+  // The default driver is a real destination whether or not any recipe names
+  // it — every step that omits `driver:` dispatches there.
+  const dflt = input.defaultDriver?.trim().toLowerCase();
+  const defaultAlreadyCovered = dflt ? seen.has(dflt) : false;
+  if (dflt && !defaultAlreadyCovered) {
+    (isLocalFamilyDriver(dflt) ? local : remote).push(dflt);
   }
 
   const destinations: SuggestResult["config"]["destinations"] = {};
@@ -100,10 +121,19 @@ export function suggestShadowConfig(input: SuggestInput): SuggestResult {
     "The CLASSIFICATIONS are a conservative placeholder, NOT advice about your obligations. Review them.",
   );
   if (input.unspecified && input.unspecified > 0) {
-    notes.push(
-      `${input.unspecified} agent step(s) declare no driver and use the bridge default — ` +
-        "they dispatch somewhere too, and this block does not cover them until you name that driver.",
-    );
+    if (dflt) {
+      notes.push(
+        `${input.unspecified} agent step(s) declare no driver; they use the bridge default "${dflt}", ` +
+          (defaultAlreadyCovered
+            ? "which a recipe already names, so this block covers them."
+            : "which no recipe names — it has been ADDED below so they are covered."),
+      );
+    } else {
+      notes.push(
+        `${input.unspecified} agent step(s) declare no driver and use the bridge default, which could ` +
+          "not be read from config.json — this block does not cover them until you name that driver.",
+      );
+    }
   }
   if (remote.length === 0) {
     notes.push(


### PR DESCRIPTION
Found by running the command I shipped in #1451 against a real workspace.

Every agent step that omits `driver:` dispatches to the **bridge default** (`driver` in config.json). `privacy suggest` scanned recipe files only, so it never saw it — and its note about those steps was wrong in **both directions**:

| case | old behaviour | why it matters |
|---|---|---|
| default already named by a recipe | warned the steps were **uncovered** | needless alarm about a real config — the live case on the workspace this shipped against (`driver: local`, 28 steps) |
| default named by **no** recipe | **under-stated** the gap | a live destination a recipe scan structurally cannot find; the block looks complete and silently omits somewhere data actually goes |

Neither is acceptable in output whose entire job is enumerating a surface, and whose stated selling point is that it reports what it *cannot* see. The second is the dangerous one.

## Now

Reads `driver` from config.json, adds it when no recipe names it, and says which of the two cases applies:

```
- 28 agent step(s) declare no driver; they use the bridge default "local",
  which a recipe already names, so this block covers them.
```

Also matches case-insensitively, so `driver: LOCAL` isn't treated as a second destination — and when the config can't be read it says **"could not be read"** rather than "there is none". Those are different claims and the operator needs to know which they're looking at.

## Verification

Mutation: removing the add-the-default branch fails the test for the dangerous direction. Privacy suite 83 pass; `audit-cli-commands`, business-content and in-flight gates green.