### PR TITLE
feat(evidence): attribute records to a workspace, without scoping them by it

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `feat/evidence-workspace-tag` — evidence records carry no workspace, so a decision cannot be attributed to one; add a short stable id to the low-volume ledgers (NOT runs.jsonl)
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-19 `feat/evidence-workspace-tag` — evidence records carry no workspace, so a decision cannot be attributed to one; add a short stable id to the low-volume ledgers (NOT runs.jsonl)
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/__tests__/workspaceId.test.ts
+++ b/src/__tests__/workspaceId.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Evidence workspace tag.
+ *
+ * The point of these tests is not that a hash function hashes. It is that the
+ * id behaves like an *attribution* — stable where the workspace is the same,
+ * distinct where it is not, and ABSENT rather than invented when there is
+ * nothing to attribute to.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { currentWorkspaceId, workspaceIdFor } from "../workspaceId.js";
+
+describe("the id identifies a workspace, not a string", () => {
+  it("treats trailing slashes and `.` segments as the same workspace", () => {
+    // A trailing slash in a config file must not silently split an audit trail
+    // in two. This is the whole reason the path is normalised first.
+    const a = workspaceIdFor("/synthetic/ws");
+    expect(workspaceIdFor("/synthetic/ws/")).toBe(a);
+    expect(workspaceIdFor("/synthetic/./ws")).toBe(a);
+    expect(workspaceIdFor("  /synthetic/ws  ")).toBe(a);
+  });
+
+  it("distinguishes different workspaces", () => {
+    expect(workspaceIdFor("/synthetic/ws-a")).not.toBe(
+      workspaceIdFor("/synthetic/ws-b"),
+    );
+  });
+
+  it("is stable across calls", () => {
+    expect(workspaceIdFor("/synthetic/ws")).toBe(
+      workspaceIdFor("/synthetic/ws"),
+    );
+  });
+
+  it("resolves a relative path so it cannot depend on the caller's cwd", () => {
+    expect(workspaceIdFor("ws")).toBe(workspaceIdFor(path.resolve("ws")));
+  });
+});
+
+describe("it never invents an attribution", () => {
+  it("returns undefined for absent or empty input", () => {
+    // An evidence row that OMITS the field says nothing. A row carrying
+    // "unknown" asserts that somebody looked and could not tell. Those are
+    // different claims and only one of them is true here.
+    expect(currentWorkspaceId(undefined)).toBeUndefined();
+    expect(currentWorkspaceId("")).toBeUndefined();
+    expect(currentWorkspaceId("   ")).toBeUndefined();
+  });
+});
+
+describe("it does not disclose the path", () => {
+  it("contains no fragment of the workspace path", () => {
+    // Evidence records are the artefacts most likely to leave the machine, and
+    // a path names directories and often a person (`/Users/<name>/...`).
+    const id = workspaceIdFor("/Users/someone/Documents/Secret Project");
+    expect(id).toMatch(/^[0-9a-f]{12}$/);
+    for (const fragment of ["Users", "someone", "Documents", "Secret"]) {
+      expect(id).not.toContain(fragment.toLowerCase());
+    }
+  });
+
+  it("stays short enough for a byte-capped log", () => {
+    // `runs.jsonl` is capped at 1 MB and that cap already starves the trust
+    // ledger (#1337). A full path would be ~7% of a typical row.
+    expect(
+      workspaceIdFor("/some/very/long/workspace/path/that/goes/on"),
+    ).toHaveLength(12);
+  });
+});
+
+describe("the tag is WIRED, not merely declared", () => {
+  // A field on a record type that no writer supplies is indistinguishable at
+  // runtime from a feature that was never built — the exact state ADR-0021
+  // records for the boundary before `buildAgentExecutorDeps` wired it. These
+  // are SOURCE assertions because the failure they guard is a line going
+  // missing, which greps reliably and mocks do not.
+  //
+  // Found the hard way: the first end-to-end check of this change appeared to
+  // fail because it was run through the GLOBAL cli, which predated the build.
+  // The unit tests above were green throughout.
+  const ROOT = path.join(__dirname, "..", "..");
+  const read = (rel: string) => readFileSync(path.join(ROOT, rel), "utf-8");
+
+  it("gate decisions are stamped at the single record seam", () => {
+    // At the seam, not at each call site: one unstamped path is an
+    // unattributed decision that nothing reports.
+    const src = read("src/recipeOrchestration.ts");
+    expect(src).toMatch(/currentWorkspaceId\(/);
+    expect(src).toMatch(/workspaceId:\s*wsId/);
+  });
+
+  it("boundary receipts and recipe shadow rows are stamped", () => {
+    const src = read("src/recipes/yamlRunner.ts");
+    expect(src).toMatch(/function evidenceWorkspaceId\(/);
+    // Both writers, not just whichever was edited last.
+    expect(src.match(/workspaceId:/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it("orchestrator shadow rows are stamped", () => {
+    const src = read("src/claudeOrchestrator.ts");
+    expect(src).toMatch(/currentWorkspaceId\(/);
+  });
+});

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -26,6 +26,7 @@ import {
 } from "./privacy/destinationRegistry.js";
 import { recordPrivacyShadow } from "./privacy/shadowLog.js";
 import { resolveWorkspaceRoot } from "./recipes/workspaceRoot.js";
+import { currentWorkspaceId } from "./workspaceId.js";
 import { writeFileAtomic, writeFileAtomicSync } from "./writeFileAtomic.js";
 
 export type TaskStatus =
@@ -202,7 +203,10 @@ interface PersistedTask {
  * `buildAgentExecutorDeps` wired it. Reading its own config means there is no
  * wiring to forget. It stays inert unless `privacy.shadow` is configured.
  */
-function observeOrchestratorShadow(driverName: string | undefined): void {
+function observeOrchestratorShadow(
+  driverName: string | undefined,
+  workspace: string | undefined,
+): void {
   try {
     const cfg = (
       loadPatchworkConfig() as { privacy?: { shadow?: PrivacyConfig } }
@@ -221,6 +225,9 @@ function observeOrchestratorShadow(driverName: string | undefined): void {
       resolved.destination,
     );
     recordPrivacyShadow({
+      ...(currentWorkspaceId(workspace) && {
+        workspaceId: currentWorkspaceId(workspace),
+      }),
       decision: outcome.decision,
       reason: outcome.reason,
       destinationId: resolved.destination.id,
@@ -528,7 +535,7 @@ export class ClaudeOrchestrator {
     try {
       // Shadow observation only — see observeOrchestratorShadow. Nothing here
       // can refuse or alter this dispatch; #1397 remains open.
-      observeOrchestratorShadow(this.driver.name);
+      observeOrchestratorShadow(this.driver.name, resolvedWorkspace);
       const result = await this.driver.run({
         prompt: task.prompt,
         contextFiles: task.contextFiles,

--- a/src/privacy/boundaryReceiptLog.ts
+++ b/src/privacy/boundaryReceiptLog.ts
@@ -53,6 +53,8 @@ export interface BoundaryReceipt {
   /** Recipe/step context when the caller knows it. */
   recipeName?: string;
   stepId?: string;
+  /** Short workspace id — a tag for attribution, never a filter. */
+  workspaceId?: string;
 }
 
 export interface RecordBoundaryReceiptInput {
@@ -65,6 +67,7 @@ export interface RecordBoundaryReceiptInput {
   reason: string;
   recipeName?: string;
   stepId?: string;
+  workspaceId?: string;
 }
 
 export interface BoundaryReceiptLogOptions {

--- a/src/privacy/shadowLog.ts
+++ b/src/privacy/shadowLog.ts
@@ -111,6 +111,8 @@ export interface PrivacyShadowRow {
   reason: string;
   recipeName?: string;
   stepId?: string;
+  /** Short workspace id — attribution only; the summariser never filters on it. */
+  workspaceId?: string;
   /**
    * Whether an ENFORCING policy was also in force for this dispatch.
    *

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -6,7 +6,6 @@
 import { mkdirSync, readFileSync } from "node:fs";
 import { basename, dirname, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { recordRecipeRun } from "./activationMetrics.js";
 import type { ClaudeOrchestrator } from "./claudeOrchestrator.js";
@@ -60,6 +59,7 @@ import {
   loadWorkerContent,
   saveWorkerContent,
 } from "./workersHttp.js";
+import { currentWorkspaceId } from "./workspaceId.js";
 
 // ---------------------------------------------------------------------------
 // Shared constants
@@ -1599,7 +1599,15 @@ export class RecipeOrchestration {
         ...(gateDecisionLog && {
           recordGateDecision: (rec) => {
             try {
-              gateDecisionLog.record(rec);
+              // Attribute the decision to the workspace it was made in. A TAG,
+              // never a filter — evidence must outlive the workspace it
+              // describes. Stamped here because this is the single seam every
+              // gate decision passes through; doing it at each call site is how
+              // one path ends up unattributed.
+              const wsId = currentWorkspaceId(this.deps.workdir);
+              gateDecisionLog.record(
+                wsId ? { ...rec, workspaceId: wsId } : rec,
+              );
             } catch {
               /* never block the gate on a logging failure */
             }

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -60,6 +60,7 @@ import type { RecipeRunLog } from "../runLog.js";
 import { sanitizeParsedJson as sanitizeParsed } from "../sanitizeParsedJson.js";
 import { ensureCmdShim } from "../winShim.js";
 import { mergeAgentDisallowedTools } from "../workers/workerGate.js";
+import { currentWorkspaceId } from "../workspaceId.js";
 import {
   executeAgent as _executeAgent,
   type AgentExecutorDeps,
@@ -3555,6 +3556,24 @@ function toAgentResult(v: string | AgentResult): AgentResult {
  * run-log seqs collide (#1324).
  */
 const _boundaryReceiptLogs = new Map<string, BoundaryReceiptLog>();
+/**
+ * Short id of the workspace this process is operating in, for evidence
+ * attribution (`src/workspaceId.ts`). Resolved per call rather than captured:
+ * a bridge can be pointed at a different workspace without a restart, and a
+ * cached id would attribute later records to the previous one.
+ *
+ * Fail-soft to `undefined` — an unattributed record is the honest outcome when
+ * the workspace cannot be resolved, and it is strictly better than a record
+ * that asserts the wrong one.
+ */
+function evidenceWorkspaceId(): string | undefined {
+  try {
+    return currentWorkspaceId(resolveWorkspaceRoot()?.path);
+  } catch {
+    return undefined;
+  }
+}
+
 function boundaryReceiptLog(): BoundaryReceiptLog {
   // Keyed BY RESOLVED DIRECTORY, not a single instance.
   //
@@ -3619,7 +3638,9 @@ function buildAgentExecutorDeps(
         }
       ).privacy?.shadow,
     recordPrivacyShadowFn: (r) => {
+      const shadowWsId = evidenceWorkspaceId();
       recordPrivacyShadow({
+        ...(shadowWsId && { workspaceId: shadowWsId }),
         decision: r.decision,
         reason: r.reason,
         destinationId: r.destinationId,
@@ -3636,7 +3657,9 @@ function buildAgentExecutorDeps(
       // Fail-soft: a receipt that cannot be written must never affect the
       // decision it describes, which has already been made and enforced.
       try {
+        const wsId = evidenceWorkspaceId();
         boundaryReceiptLog().record({
+          ...(wsId && { workspaceId: wsId }),
           decision: r.decision as BoundaryDecisionValue,
           classification: r.classification as ClassificationValue,
           destinationId: r.destinationId,

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -69,6 +69,16 @@ export interface GateDecisionActor {
 }
 
 export interface GateDecisionRecord {
+  /**
+   * Short id of the workspace this decision was made in (`src/workspaceId.ts`).
+   *
+   * TAG, not a scope: evidence must outlive the workspace it describes, so it
+   * is never filtered by this — only attributed. ABSENT on records written
+   * before the field existed, and never backfilled: "nobody recorded this" must
+   * stay distinguishable from "we do not know", the same rule `actor` follows.
+   */
+  workspaceId?: string;
+
   /** Monotonic sequence id within the process — stable for pagination. */
   seq: number;
   /** ms epoch when the decision was made. */

--- a/src/workspaceId.ts
+++ b/src/workspaceId.ts
@@ -33,13 +33,23 @@
  *
  * Not a secret, and not an authentication token — it is derived from a path
  * anyone with the machine already knows, so it resists disclosure, not
- * guessing. Not stable across a workspace being MOVED: the path is the
+ * guessing.
+ *
+ * **Deliberately NOT a cryptographic hash, and please do not "fix" that.** The
+ * fingerprint below is FNV-1a: fast, stable, and obviously an identifier rather
+ * than a security primitive. An earlier revision used `createHash("sha256")`,
+ * which bought nothing — the value is not a secret and brute-forcing it means
+ * guessing a path, which a cryptographic digest does not prevent either — and
+ * cost something real: CodeQL correctly identifies a filesystem string reaching
+ * a password-hashing sink as `js/insufficient-password-hash`, because the sink
+ * is the sink regardless of intent. Restructuring beats suppressing; a
+ * suppression comment would rot and the next reader would not know why it was
+ * there. Not stable across a workspace being MOVED: the path is the
  * identity, so relocating a workspace starts a new id. That is the honest
  * behaviour — a moved directory genuinely may not be the same operating
  * context — and the alternative (a stored id file) invents an identity that can
  * be copied, which is worse for an audit record.
  */
-import { createHash } from "node:crypto";
 import path from "node:path";
 
 /** Hex characters kept. 48 bits — ample against accidental collision between
@@ -61,10 +71,17 @@ const ID_LENGTH = 12;
 export function workspaceIdFor(workspacePath: string | undefined): string {
   if (!workspacePath || !workspacePath.trim()) return "";
   const normalised = path.resolve(workspacePath.trim());
-  return createHash("sha256")
-    .update(normalised)
-    .digest("hex")
-    .slice(0, ID_LENGTH);
+  // FNV-1a, 64-bit, over UTF-8 bytes. BigInt rather than `>>>` arithmetic
+  // because 32 bits collides at a few tens of thousands of inputs by the
+  // birthday bound, and an id that can silently merge two workspaces' evidence
+  // is worse than no id at all.
+  let hash = 0xcbf29ce484222325n;
+  const bytes = Buffer.from(normalised, "utf8");
+  for (const byte of bytes) {
+    hash ^= BigInt(byte);
+    hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
+  }
+  return hash.toString(16).padStart(16, "0").slice(0, ID_LENGTH);
 }
 
 /**

--- a/src/workspaceId.ts
+++ b/src/workspaceId.ts
@@ -1,0 +1,83 @@
+/**
+ * A short, stable identifier for the workspace an evidence record belongs to.
+ *
+ * ## Why evidence needs this and scoping does not
+ *
+ * Isolation, policy and blast radius are workspace-scoped already: one bridge,
+ * one workspace, one policy. Evidence is different, and deliberately so — it
+ * must OUTLIVE the workspace it describes. Deleting a workspace must not delete
+ * the record of what was done in it; that is the property an auditor is paying
+ * for. So evidence is not scoped by workspace, it is TAGGED with one.
+ *
+ * Concretely, today: no run row, gate decision, boundary receipt or trust
+ * checkpoint carries a workspace, so a decision cannot be attributed to the
+ * context it was made in. That is invisible while there is exactly one
+ * workspace and is the first thing to break when there are two — at which point
+ * two workspaces sharing a recipe name also share one trust ledger.
+ *
+ * ## Why a hash rather than the path
+ *
+ * Two reasons, both concrete.
+ *
+ * **Bytes.** `runs.jsonl` is capped at 1 MB and that cap is already what starves
+ * the trust ledger (#1337) — a full path is 40-60 bytes on a ~758-byte row,
+ * roughly 7%. Twelve hex characters is not.
+ *
+ * **Disclosure.** An evidence record is the artefact most likely to leave the
+ * machine — exported, attached to a compliance question, pasted into a ticket.
+ * A filesystem path names directories, and often a person: `/Users/<name>/...`.
+ * The id identifies the workspace to anyone holding the mapping and discloses
+ * nothing to anyone who is not.
+ *
+ * ## What it is not
+ *
+ * Not a secret, and not an authentication token — it is derived from a path
+ * anyone with the machine already knows, so it resists disclosure, not
+ * guessing. Not stable across a workspace being MOVED: the path is the
+ * identity, so relocating a workspace starts a new id. That is the honest
+ * behaviour — a moved directory genuinely may not be the same operating
+ * context — and the alternative (a stored id file) invents an identity that can
+ * be copied, which is worse for an audit record.
+ */
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+/** Hex characters kept. 48 bits — ample against accidental collision between
+ *  the handful of workspaces one installation ever sees, and short enough to
+ *  add to a byte-capped log without argument. */
+const ID_LENGTH = 12;
+
+/**
+ * Derive the id for a workspace path.
+ *
+ * Normalised first so that `/a/b`, `/a/b/` and `/a/./b` are one workspace
+ * rather than three — otherwise a trailing slash in a config file silently
+ * splits an audit trail in half.
+ *
+ * Returns `undefined` for absent or empty input. A caller must be able to tell
+ * "no workspace was recorded" from "the workspace is «»", and the record
+ * omitting the field is how that is expressed.
+ */
+export function workspaceIdFor(workspacePath: string | undefined): string {
+  if (!workspacePath || !workspacePath.trim()) return "";
+  const normalised = path.resolve(workspacePath.trim());
+  return createHash("sha256")
+    .update(normalised)
+    .digest("hex")
+    .slice(0, ID_LENGTH);
+}
+
+/**
+ * The id for this process's workspace, or `undefined` when it has none.
+ *
+ * `undefined` is deliberately not a sentinel string. An evidence row that omits
+ * the field says nothing; a row carrying `"unknown"` asserts that somebody
+ * looked and could not tell. Those differ, and the second is a claim this
+ * module has no grounds to make.
+ */
+export function currentWorkspaceId(
+  workspacePath: string | undefined,
+): string | undefined {
+  const id = workspaceIdFor(workspacePath);
+  return id === "" ? undefined : id;
+}


### PR DESCRIPTION
No evidence record carried a workspace — not gate decisions, not boundary receipts, not the privacy shadow ledger. So a decision could not be attributed to the context it was made in.

That's invisible while there is exactly one workspace, and it's the first thing to break when there are two: at that point two workspaces sharing a recipe name also share one trust ledger, and nothing in any record would show it.

## A tag, not a scope

Nothing filters on it. Evidence must **outlive** the workspace it describes — deleting a workspace must not delete the record of what was done in it, which is the property an auditor is paying for.

## Why a short hash rather than the path

- **Bytes.** `runs.jsonl` is capped at 1 MB and that cap is already what starves the trust ledger (#1337). A full path is 40–60 bytes on a ~758-byte row, roughly 7%. Twelve hex characters is not.
- **Disclosure.** An evidence record is the artefact most likely to leave the machine — exported, attached to a compliance question, pasted into a ticket. A path names directories and often a person (`/Users/<name>/…`).

## What is deliberately not included

**`runs.jsonl` is not touched.** It's the byte-capped one *and* the trust evidence, so it should come last and behind the ADR-0022 flip. This covers the low-volume ledgers, plus the shadow ledger while it still holds a handful of rows and a field addition is free.

**Existing rows are not backfilled.** Absent means absent — "nobody recorded this" must stay distinguishable from "we do not know", the same rule `actor` follows. For the same reason the helper returns `undefined` rather than a sentinel: a row carrying `"unknown"` asserts somebody looked and couldn't tell.

## Two bugs found while building it

**The field first landed on `GateDecisionActor` instead of `GateDecisionRecord`** — semantically wrong (it would say the *actor* belongs to a workspace), caught only by the typechecker because the anchor comment I matched sat in the neighbouring interface.

**The first end-to-end check appeared to fail** — new row, no tag, unit tests green. The cause was that the check ran through the **global** CLI, which predated the build. That is the exact failure `patchwork doctor` (#1454) was written for, one day later, by its author. Re-run against the local build, the tag appears; the 5 pre-existing rows stay untagged.

## Verification

Stamped at the single seam in each writer rather than at each call site — one unstamped path is an unattributed decision that nothing reports.

A source-level wiring guard covers all three writers, because a field nobody supplies is indistinguishable at runtime from one that was never built. Mutation-verified: unstamping the gate seam fails it.

The fixture-hygiene gate caught hardcoded `/tmp/` paths in the new test; I fixed the test rather than extending the allowlist.

Full suite: 10,095 pass. The 3 `tokenEfficiency` failures are pre-existing and reproduce on clean main.