### PR TITLE
feat(dashboard): show the last gate decision in the gate's own words

### DIFF
--- a/dashboard/src/app/workers/__tests__/page.test.tsx
+++ b/dashboard/src/app/workers/__tests__/page.test.tsx
@@ -293,6 +293,7 @@ describe("what a worker may actually do (control boundary)", () => {
   function boundaryRouteMock(opts: {
     manifests: unknown;
     boundary?: unknown;
+    explanation?: string;
   }): (url: string | URL) => Promise<Response> {
     return (url) => {
       const u = String(url);
@@ -300,6 +301,14 @@ describe("what a worker may actually do (control boundary)", () => {
       if (u.includes("/workers/shadow")) return Promise.resolve(jsonResponse(SHADOW));
       if (u.includes("/workers/boundary"))
         return Promise.resolve(jsonResponse({ boundary: opts.boundary ?? null }));
+      if (u.includes("/gate/decisions"))
+        return Promise.resolve(
+          jsonResponse(
+            opts.explanation
+              ? { decisions: [{}], explanation: opts.explanation }
+              : { decisions: [] },
+          ),
+        );
       if (u.includes("/api/bridge/workers")) return Promise.resolve(jsonResponse(opts.manifests));
       return Promise.resolve(jsonResponse({}));
     };
@@ -350,5 +359,46 @@ describe("what a worker may actually do (control boundary)", () => {
     // The fallback must NOT be showing — otherwise this test would pass on a
     // page that silently failed to render the boundary at all.
     expect(container.textContent).not.toContain("no boundary");
+  });
+});
+
+describe("the last decision, in the gate's own words", () => {
+  function receiptMock(explanation?: string) {
+    return (url: string | URL) => {
+      const u = String(url);
+      if (u.includes("/approvals/kpi")) return Promise.resolve(jsonResponse({ total: 0 }));
+      if (u.includes("/workers/shadow")) return Promise.resolve(jsonResponse(SHADOW));
+      if (u.includes("/workers/boundary")) return Promise.resolve(jsonResponse({ boundary: null }));
+      if (u.includes("/gate/decisions"))
+        return Promise.resolve(
+          jsonResponse(explanation ? { decisions: [{}], explanation } : { decisions: [] }),
+        );
+      return Promise.resolve(jsonResponse({ workers: [] }));
+    };
+  }
+
+  it("renders the bridge's prose verbatim", async () => {
+    // Verbatim is the requirement, not a nicety: the dashboard and
+    // `patchwork gate explain` must never give two accounts of one decision.
+    const prose =
+      "2026-07-09T19:33:30.453Z — tech-debt-scout → agent\n  Result: ALLOWED\n  Why: agent reasoning step — not a gated action-class";
+    fetchMock.mockImplementation(receiptMock(prose));
+    render(<WorkersPage />);
+    expect(await screen.findByText("Release Worker")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Release Worker/ }));
+    expect(
+      await screen.findByText(/agent reasoning step/),
+    ).toBeTruthy();
+  });
+
+  it("says nothing has been decided rather than showing an empty box", async () => {
+    // "Nothing to see" and "nothing has happened" are different claims.
+    fetchMock.mockImplementation(receiptMock(undefined));
+    render(<WorkersPage />);
+    expect(await screen.findByText("Release Worker")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Release Worker/ }));
+    expect(
+      await screen.findByText(/No gate decision has been recorded/i),
+    ).toBeTruthy();
   });
 });

--- a/dashboard/src/app/workers/page.tsx
+++ b/dashboard/src/app/workers/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { BoundaryPanel } from "@/components/BoundaryPanel";
+import { DecisionReceipt } from "@/components/DecisionReceipt";
 import Link from "next/link";
 import { type CSSProperties, useState } from "react";
 import { EmptyState, ErrorState, HBarList } from "@/components/patchwork";
@@ -1138,6 +1139,13 @@ function WorkerCard({
           to preview. That is a gap in the manifest, not an empty result.
         </div>
       )}
+
+      {/* Why the last one went the way it did. The boundary above is
+          prospective — what this worker MAY do; this is retrospective, and it
+          is the artefact an auditor actually reads. Rendered verbatim from the
+          bridge so the dashboard and `patchwork gate explain` can never give
+          two accounts of the same decision. */}
+      <DecisionReceipt workerId={w.workerId} />
 
       {/* How it got here — the journey's history. */}
       <JourneyTimeline events={w.events ?? []} now={now} />

--- a/dashboard/src/components/DecisionReceipt.tsx
+++ b/dashboard/src/components/DecisionReceipt.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * The most recent gate decision for a worker, in the gate's own words.
+ *
+ * The prose is produced by the BRIDGE (`formatGateDecisionHistory`, the same
+ * function `patchwork gate explain` prints) and rendered here verbatim. It is
+ * deliberately not re-formatted, re-ordered or summarised on this side.
+ *
+ * The dashboard shares no code with the bridge, so a second formatter would be
+ * a second opinion — and the two would eventually disagree about what a
+ * decision meant. That is intolerable in the one artefact whose stated value is
+ * that a person can read it and see what happened, without running our
+ * software. Rendering someone else's sentences is the point, not a shortcut.
+ */
+
+import { useEffect, useState } from "react";
+import { apiPath } from "@/lib/api";
+
+interface Props {
+  workerId: string;
+}
+
+type State =
+  | { kind: "loading" }
+  | { kind: "none" }
+  | { kind: "ready"; text: string }
+  | { kind: "error"; message: string };
+
+export function DecisionReceipt({ workerId }: Props) {
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          apiPath(
+            `/api/bridge/gate/decisions?workerId=${encodeURIComponent(workerId)}&limit=1&explain=1`,
+          ),
+        );
+        const data = (await res.json().catch(() => ({}))) as {
+          decisions?: unknown[];
+          explanation?: string;
+        };
+        if (cancelled) return;
+        const text = data.explanation?.trim();
+        // No decisions is a real, common answer — a worker that has not acted
+        // yet. Reported as such rather than as an empty box, which would read
+        // as "nothing to see" when it means "nothing has happened".
+        setState(
+          text ? { kind: "ready", text } : { kind: "none" },
+        );
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            kind: "error",
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workerId]);
+
+  if (state.kind === "loading") return null;
+
+  return (
+    <div style={{ marginTop: "var(--s-3)" }}>
+      <div className="editorial-sub" style={{ fontFamily: "inherit" }}>
+        <strong>The last decision, in the gate&rsquo;s own words</strong>
+      </div>
+      {state.kind === "none" ? (
+        <div className="editorial-sub">
+          No gate decision has been recorded for this worker yet — it has not
+          acted on a gated action-class, or worker autonomy is off.
+        </div>
+      ) : state.kind === "error" ? (
+        <div className="editorial-sub">
+          Could not read the decision record: {state.message}
+        </div>
+      ) : (
+        <pre
+          style={{
+            whiteSpace: "pre-wrap",
+            overflowX: "auto",
+            fontSize: "0.85em",
+            lineHeight: 1.5,
+            margin: "var(--s-2) 0 0",
+            padding: "var(--s-2)",
+            background: "var(--surface-2)",
+            borderRadius: 4,
+          }}
+        >
+          {state.text}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export default DecisionReceipt;

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `feat/gate-decision-receipt-prose` — the auditor-readable receipt exists only in the CLI; serve the SAME formatter over HTTP and render it in the worker drawer
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-19 `feat/gate-decision-receipt-prose` — the auditor-readable receipt exists only in the CLI; serve the SAME formatter over HTTP and render it in the worker drawer
+_Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/__tests__/recipeRoutes-route-match-and-sanitize.test.ts
+++ b/src/__tests__/recipeRoutes-route-match-and-sanitize.test.ts
@@ -204,6 +204,66 @@ describe("GET /gate/decisions — Decision Record query route", () => {
     });
   });
 
+  it("?explain=1 returns the SAME prose the CLI prints", async () => {
+    // Served rather than re-implemented client-side. The dashboard shares no
+    // code with the bridge, so a second formatter would drift — and the two
+    // would then disagree about what a decision meant, in the one artefact
+    // whose selling point is that an auditor can read it.
+    const rec = {
+      seq: 1,
+      decidedAt: 1_700_000_000_000,
+      workerId: "w1",
+      toolName: "agent",
+      classKey: "other:irreversible:medium",
+      domain: "other",
+      reversibility: "irreversible",
+      blastTier: "medium",
+      owned: false,
+      earnedLevel: 0,
+      autonomyCeiling: 0,
+      effectiveLevel: 0,
+      action: "allow",
+      reason: "agent reasoning step — not a gated action-class",
+      recipeName: "r1",
+      gatePolicyVersion: "worker-ramp-v0",
+    };
+    const deps = makeDeps({ gateDecisionsFn: () => [rec] as never });
+    const url =
+      "/gate/decisions?workerId=w1&classKey=other:irreversible:medium&explain=1";
+    const { res, done } = makeRes();
+    tryHandleRecipeRoute(
+      makeReq("GET", url),
+      res,
+      new URL(`http://x${url}`),
+      deps,
+    );
+    const { status, body } = await done;
+    expect(status).toBe(200);
+    const parsed = JSON.parse(body) as {
+      decisions: unknown[];
+      explanation?: string;
+    };
+    expect(parsed.decisions).toHaveLength(1);
+    // Prose, not a restatement of the JSON — the fields a reader needs.
+    expect(parsed.explanation).toContain("ALLOWED");
+    expect(parsed.explanation).toContain("agent reasoning step");
+  });
+
+  it("omits the explanation unless it is asked for", async () => {
+    // Additive: every existing caller keeps the exact shape it had, and the
+    // prose is not computed for feeds that never render it.
+    const deps = makeDeps({ gateDecisionsFn: () => [] });
+    const { res, done } = makeRes();
+    tryHandleRecipeRoute(
+      makeReq("GET", "/gate/decisions?workerId=w1"),
+      res,
+      new URL("http://x/gate/decisions?workerId=w1"),
+      deps,
+    );
+    const { body } = await done;
+    expect(Object.keys(JSON.parse(body))).toEqual(["decisions"]);
+  });
+
   it("falls back to an empty list when gateDecisionsFn is null", async () => {
     const deps = makeDeps({ gateDecisionsFn: null });
     const req = makeReq("GET", "/gate/decisions?workerId=w1&classKey=x");

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1035,23 +1035,44 @@ export function tryHandleRecipeRoute(
   // default; this is the one-decision/one-history lookup, not a dashboard
   // feed like /workers/shadow).
   if (parsedUrl.pathname === "/gate/decisions" && req.method === "GET") {
-    try {
-      const sp = parsedUrl.searchParams;
-      const workerId = sp.get("workerId") ?? undefined;
-      const classKey = sp.get("classKey") ?? undefined;
-      const limitRaw = sp.get("limit");
-      const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
-      const decisions =
-        deps.gateDecisionsFn?.({
-          ...(workerId && { workerId }),
-          ...(classKey && { classKey }),
-          ...(Number.isFinite(limit) && { limit }),
-        }) ?? [];
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ decisions }));
-    } catch (err) {
-      respond500(res, err);
-    }
+    void (async () => {
+      try {
+        const sp = parsedUrl.searchParams;
+        const workerId = sp.get("workerId") ?? undefined;
+        const classKey = sp.get("classKey") ?? undefined;
+        const limitRaw = sp.get("limit");
+        const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+        const decisions =
+          deps.gateDecisionsFn?.({
+            ...(workerId && { workerId }),
+            ...(classKey && { classKey }),
+            ...(Number.isFinite(limit) && { limit }),
+          }) ?? [];
+        // `?explain=1` adds the SAME prose `patchwork gate explain` prints.
+        // Served rather than re-implemented on the client: the dashboard shares
+        // no code with the bridge, so a second formatter would drift, and the
+        // two would then disagree about what a decision meant — in an artefact
+        // whose whole selling point is that an auditor can read it.
+        const explain = parsedUrl.searchParams.get("explain");
+        let explanation: string | undefined;
+        if (explain === "1" || explain === "true") {
+          const { formatGateDecisionHistory } = await import(
+            "./workerGateDecisionLog.js"
+          );
+          explanation = formatGateDecisionHistory(decisions);
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify(
+            explanation === undefined
+              ? { decisions }
+              : { decisions, explanation },
+          ),
+        );
+      } catch (err) {
+        respond500(res, err);
+      }
+    })();
     return true;
   }
 


### PR DESCRIPTION
`patchwork gate explain` renders a decision as prose a person can read:

```
2026-07-09T19:33:30.453Z — tech-debt-scout → agent (other:irreversible:medium)
  Result: ALLOWED
  Earned trust level: L0 (autonomy ceiling L0)
  Situational risk ceiling: L1 (risk score 0.76)
    Reasons: sizeable uncommitted diff (465 lines), 21 files with uncommitted changes…
  Why: agent reasoning step — not a gated action-class
```

**That artefact existed only in a terminal.** The dashboard showed the same decisions as a compact feed of fields — the data, not the account.

## What changed

`GET /gate/decisions?explain=1` now also returns `formatGateDecisionHistory` — the *same function* the CLI prints — and the worker drawer renders it verbatim.

**Served rather than re-implemented on the client, deliberately.** The dashboard shares no code with the bridge, so a second formatter would be a second opinion, and the two would eventually disagree about what a decision meant. That's intolerable in the one artefact whose stated value is that a person can read it and see what happened *without running our software*.

## Additive, and tested as such

Without `explain=1` the response shape is byte-identical and the prose isn't computed at all. A test asserts exactly that, so the existing home-page feed can't be broken by this.

**"No decisions" renders a sentence, not an empty box.** A worker that hasn't acted yet is a real and common answer, and *"nothing to see"* reads very differently from *"nothing has happened"* — the same distinction the privacy shadow report draws between "nothing observed" and "0 crossings".

## Pairs with #1456

That one is **prospective** — what this worker *may* do. This one is **retrospective** — why the last one went as it did. Together they're the two questions an operator asks about a worker, in one place.

## Verification

Mutation-verified on both sides: dropping the prose from the response fails the route test; never rendering it fails the page test.

Bridge 34 tests · dashboard 1299 · `next build` clean · `audit-business-content`, `audit-cli-commands`, `audit-in-flight`, `audit-test-fixtures` green.