### PR TITLE
fix(connectors): the Todoist connector reads fields the v1 API does not send

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -30,7 +30,7 @@ verified (which is how this line came to be written).
 ## Active
 
 - 2026-08-19 `fix/todoist-v1-field-shape` — the Todoist connector talks to `api/v1` and its
-  `TodoistTask` / `TodoistProject` interfaces still carry REST v2 field names, so six declared
+  `TodoistTask` / `TodoistProject` interfaces still carry REST v2 field names, so eight declared
   fields are `undefined` on the wire. Measured live: an errand the operator really did complete
   graded `unknown`/`open-recent` instead of `confirmed`, because `observeTask` reads
   `is_completed` where v1 sends `checked`; and `Date.parse(created_at)` is NaN (v1 sends

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,15 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `fix/todoist-v1-field-shape` — the Todoist connector talks to `api/v1` and its
+  `TodoistTask` / `TodoistProject` interfaces still carry REST v2 field names, so six declared
+  fields are `undefined` on the wire. Measured live: an errand the operator really did complete
+  graded `unknown`/`open-recent` instead of `confirmed`, because `observeTask` reads
+  `is_completed` where v1 sends `checked`; and `Date.parse(created_at)` is NaN (v1 sends
+  `added_at`), so the `Date.now()` fallback resets every errand's age on every run and the
+  14-day `stale-unactioned` horizon is unreachable. Touches `src/connectors/todoist.ts`,
+  `src/recipes/tools/todoist.ts` outputSchemas, and the connector/butler test fixtures —
+  collides with any Todoist, Butler-observation or connector-shape work. — this session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-19 `fix/todoist-v1-field-shape` — the Todoist connector talks to `api/v1` and its
   `TodoistTask` / `TodoistProject` interfaces still carry REST v2 field names, so eight declared
   fields are `undefined` on the wire. Measured live: an errand the operator really did complete
@@ -37,9 +41,7 @@ verified (which is how this line came to be written).
   `added_at`), so the `Date.now()` fallback resets every errand's age on every run and the
   14-day `stale-unactioned` horizon is unreachable. Touches `src/connectors/todoist.ts`,
   `src/recipes/tools/todoist.ts` outputSchemas, and the connector/butler test fixtures —
-  collides with any Todoist, Butler-observation or connector-shape work. — this session
-
-## Recently closed (informal log, prune periodically)
+  collides with any Todoist, Butler-observation or connector-shape work. — this session — merged as #1459
 
 - 2026-08-17 `fix/business-content-gate-reads-code` — `audit-business-content` read tracked MARKDOWN only, so the ADR-0019 licensing boundary was unenforced everywhere a string actually ships: UI components, CLI output, YAML, JSON. Its own header already conceded it cannot see code. Widens to tracked source/config text and excludes the gate + its allowlist BY EXACT PATH (they must contain the vocabulary; 20 of 20 pre-existing non-markdown hits were those two files). Measured: no new findings, allowlist unchanged at 8 entries. Touches `scripts/audit-business-content.mjs` only. — merged as #1440
 

--- a/src/connectors/__tests__/todoist.test.ts
+++ b/src/connectors/__tests__/todoist.test.ts
@@ -12,6 +12,8 @@ import {
   vi,
 } from "vitest";
 
+import { todoistV1Task } from "./todoistV1Fixture.js";
+
 // ── real-store sandbox ────────────────────────────────────────────────────────
 
 /**
@@ -48,25 +50,18 @@ afterAll(() => {
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * Delegates to the ONE recorded v1 shape.
+ *
+ * It used to hand-write a REST v2 body — `is_completed`, `created_at`, `url`,
+ * `order`, `comment_count`, `creator_id` — none of which the v1 API sends. Every
+ * test in this file passed against it, including the `describe("Todoist API v1
+ * …")` block the migration itself added, because the fixture agreed with the
+ * code's wrong assumption rather than with the API. See
+ * `todoistV1Fixture.ts` for what that cost.
+ */
 function makeFakeTask(overrides: Partial<Record<string, unknown>> = {}) {
-  return {
-    id: "task1",
-    content: "Buy milk",
-    description: "",
-    project_id: "proj1",
-    section_id: null,
-    parent_id: null,
-    order: 1,
-    priority: 1,
-    due: null,
-    labels: [],
-    is_completed: false,
-    created_at: "2026-01-01T00:00:00Z",
-    url: "https://todoist.com/task/task1",
-    comment_count: 0,
-    creator_id: "user1",
-    ...overrides,
-  };
+  return todoistV1Task(overrides);
 }
 
 function mockFetch(
@@ -172,7 +167,10 @@ describe("TodoistConnector.getTasks", () => {
 
     const result = await conn.getTasks();
     expect(result).toHaveLength(2);
-    expect(result[0]!.content).toBe("Buy milk");
+    // Compared against the fixture rather than a restated literal: this test is
+    // about pass-through, and a hardcoded string here only asserts that two
+    // copies of the fixture agree.
+    expect(result[0]?.content).toBe(tasks[0]?.content);
   });
 
   it("passes projectId as query param", async () => {

--- a/src/connectors/__tests__/todoistV1Fixture.ts
+++ b/src/connectors/__tests__/todoistV1Fixture.ts
@@ -1,0 +1,174 @@
+/**
+ * The Todoist v1 wire shape — ONE fixture, shared by every test that mocks it.
+ *
+ * ## Why this file exists
+ *
+ * The connector moved to `api/v1` (REST v2 answers 410 Gone) and its TypeScript
+ * interfaces kept the v2 field names. Nothing caught it for nine days, because
+ * every test hand-wrote its own task body using the same v2 names the code
+ * expected. A mock that agrees with the code's wrong assumption proves the code
+ * agrees with itself.
+ *
+ * The consequence was not cosmetic. `observeTask` read `is_completed`, which v1
+ * does not send, so an errand the operator really had completed graded
+ * `unknown` / `open-recent` instead of `confirmed` — the Butler trust channel
+ * could not report a completion at all. It read `created_at` too, which v1 also
+ * does not send, so `Date.parse` returned NaN and the "unparseable" fallback
+ * substituted `Date.now()`, resetting every errand's age on every run and
+ * putting the 14-day `stale-unactioned` horizon permanently out of reach.
+ *
+ * So: one shape, in one place. Two hand-written shapes is how they drifted.
+ *
+ * ## Where the key names come from
+ *
+ * Captured from the live `GET /api/v1/tasks/{id}`, `GET /api/v1/projects` and
+ * `GET /api/v1/labels` on 2026-08-19 — **key names only**. The response bodies
+ * were never recorded and must never be: a real Todoist account's task content
+ * is the operator's errands, and this repository is world-readable. Every value
+ * below is synthetic; only the set of keys is evidence.
+ *
+ * `TODOIST_V1_TASK_KEYS` is exported so a test can assert the fixture still
+ * carries the full observed key set. That guard is worth exactly what it says
+ * and no more: it detects a fixture drifting from the recorded shape, not the
+ * API drifting from the recording. Re-capture when Todoist versions the API.
+ */
+
+/**
+ * Every key the live v1 task object carried, sorted.
+ *
+ * Note what is ABSENT and was declared: `is_completed`, `created_at`, `url`,
+ * `order`, `comment_count`, `creator_id`, `assignee_id`, `assigner_id`.
+ */
+export const TODOIST_V1_TASK_KEYS = [
+  "added_at",
+  "added_by_uid",
+  "assigned_by_uid",
+  "checked",
+  "child_order",
+  "completed_at",
+  "completed_by_uid",
+  "completed_count",
+  "content",
+  "day_order",
+  "deadline",
+  "description",
+  "due",
+  "duration",
+  "id",
+  "is_collapsed",
+  "is_deleted",
+  "labels",
+  "note_count",
+  "parent_id",
+  "postponed_count",
+  "priority",
+  "project_id",
+  "responsible_uid",
+  "section_id",
+  "updated_at",
+  "user_id",
+] as const;
+
+/**
+ * A v1 task body as the API actually sends it.
+ *
+ * Deliberately a plain `Record` rather than the connector's `TodoistTask`: a
+ * fixture typed as the interface it is meant to catch drifting cannot catch it
+ * drifting. The compiler would have accepted the old v2 body against the old
+ * v2 interface, which is precisely what happened.
+ */
+export function todoistV1Task(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    added_at: "2026-01-01T00:00:00.000000Z",
+    added_by_uid: "10000001",
+    assigned_by_uid: null,
+    checked: false,
+    child_order: 1,
+    completed_at: null,
+    completed_by_uid: null,
+    completed_count: 0,
+    content: "example task",
+    day_order: -1,
+    deadline: null,
+    description: "",
+    due: null,
+    duration: null,
+    id: "task1",
+    is_collapsed: false,
+    is_deleted: false,
+    labels: [],
+    note_count: 0,
+    parent_id: null,
+    postponed_count: 0,
+    priority: 1,
+    project_id: "proj1",
+    responsible_uid: null,
+    section_id: null,
+    updated_at: "2026-01-01T00:00:00.000000Z",
+    user_id: "10000001",
+    ...overrides,
+  };
+}
+
+/** A completed v1 task: `checked` true and a `completed_at` stamp. */
+export function todoistV1CompletedTask(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return todoistV1Task({
+    checked: true,
+    completed_at: "2026-01-02T00:00:00.000000Z",
+    completed_by_uid: "10000001",
+    completed_count: 1,
+    ...overrides,
+  });
+}
+
+/**
+ * A v1 project body.
+ *
+ * Note the asymmetry, which is real and not a transcription slip: projects DO
+ * carry `created_at`, tasks carry `added_at`. Declaring `created_at` on the
+ * task interface was therefore plausible enough to survive review.
+ */
+export function todoistV1Project(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    access: null,
+    can_assign_tasks: false,
+    can_comment: true,
+    child_order: 0,
+    color: "charcoal",
+    created_at: "2026-01-01T00:00:00.000000Z",
+    creator_uid: "10000001",
+    default_order: 0,
+    description: "",
+    id: "proj1",
+    inbox_project: true,
+    is_archived: false,
+    is_collapsed: false,
+    is_deleted: false,
+    is_favorite: false,
+    is_frozen: false,
+    is_shared: false,
+    name: "Example project",
+    order_key: "a",
+    parent_id: null,
+    public_access: null,
+    public_key: null,
+    role: null,
+    updated_at: "2026-01-01T00:00:00.000000Z",
+    view_style: "list",
+    ...overrides,
+  };
+}
+
+/** Wrap items in the v1 list envelope. Single-resource endpoints do not use it. */
+export function todoistV1List(
+  results: unknown[],
+  nextCursor: string | null = null,
+): Record<string, unknown> {
+  return { results, next_cursor: nextCursor };
+}

--- a/src/connectors/__tests__/todoistV1Shape.test.ts
+++ b/src/connectors/__tests__/todoistV1Shape.test.ts
@@ -1,0 +1,280 @@
+/**
+ * The connector against the shape the v1 API actually sends.
+ *
+ * ## The bug these tests reproduce
+ *
+ * `TODOIST_BASE` moved to `api/v1` when REST v2 started answering 410 Gone. The
+ * response interfaces did not move with it. Six declared fields do not exist on
+ * the v1 wire, and two of them are read to make a decision:
+ *
+ *   is_completed → the live field is `checked`
+ *   created_at   → the live field is `added_at`
+ *
+ * Measured live on 2026-08-19: a Butler errand the operator had genuinely
+ * completed (`checked: true`, `completed_at` set) came back from
+ * `patchwork butler observe` as `unknown` / `open-recent`. The observation
+ * channel could not report a completion, so no filing could ever earn trust —
+ * and it failed *quietly*, reporting "3 observed, 0 unavailable" the whole time.
+ *
+ * The `created_at` half is worse for being invisible. `Date.parse(undefined)` is
+ * NaN, and the guard against an unparseable stamp substitutes `Date.now()`. That
+ * guard is right about 1970 and wrong here: it converted a schema mismatch into
+ * "this errand was created just now", on every run, so the 14-day
+ * `stale-unactioned → junk` horizon can never be reached. The rule that turns
+ * silence into a negative was dead and nothing said so.
+ *
+ * ## Why the existing tests could not catch it
+ *
+ * `todoist.test.ts` mocks fetch with a hand-written body carrying the v2 names —
+ * including inside the `describe("Todoist API v1 …")` block added by the
+ * migration itself. And `todoistObservation.test.ts` doubles the *connector*,
+ * returning an already-mapped `{kind:"observed", completed, createdAt}`: its
+ * seam starts one layer below where the bug lives. Both suites were green
+ * throughout.
+ *
+ * So every test here drives real bytes through `observeTask` / `getTasks` /
+ * `getProjects` / `getLabels` from the shared v1 fixture.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  TODOIST_V1_TASK_KEYS,
+  todoistV1CompletedTask,
+  todoistV1List,
+  todoistV1Project,
+  todoistV1Task,
+} from "./todoistV1Fixture.js";
+
+/**
+ * Token storage resolves under PATCHWORK_HOME. `TODOIST_API_KEY` short-circuits
+ * it, but a stray real-store read is the failure mode this connector's other
+ * suite documents at length, so the sandbox is set regardless.
+ */
+const SANDBOX_HOME = mkdtempSync(join(os.tmpdir(), "todoist-v1-shape-"));
+
+beforeEach(() => {
+  process.env.PATCHWORK_HOME = SANDBOX_HOME;
+  process.env.TODOIST_API_KEY = "test-token";
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.TODOIST_API_KEY;
+  // Re-point at the sandbox rather than deleting: with PATCHWORK_HOME unset the
+  // token store resolves to the developer's real ~/.patchwork, and this
+  // connector's other suite documents a live credential deleted exactly that
+  // way. Overriding HOME is not a substitute — os.homedir() falls back to the
+  // passwd entry, so a HOME-based sandbox is a check that cannot fail.
+  process.env.PATCHWORK_HOME = SANDBOX_HOME;
+});
+
+afterAll(() => {
+  rmSync(SANDBOX_HOME, { recursive: true, force: true });
+});
+
+function mockJson(body: unknown, ok = true, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+    headers: { get: () => null },
+  }) as unknown as typeof fetch;
+}
+
+async function connector() {
+  const { TodoistConnector } = await import("../todoist.js");
+  return new TodoistConnector();
+}
+
+// ── the fixture is the recorded shape ────────────────────────────────────────
+
+describe("the v1 fixture matches what was captured from the live API", () => {
+  it("carries exactly the observed key set", () => {
+    // Guards the fixture, not the API. If someone "tidies" a key out of the
+    // fixture to make a test pass, the tests below stop meaning anything.
+    expect(Object.keys(todoistV1Task()).sort()).toEqual([
+      ...TODOIST_V1_TASK_KEYS,
+    ]);
+  });
+
+  it("does not carry the v2 names the interface used to declare", () => {
+    const task = todoistV1Task();
+    for (const absent of [
+      "is_completed",
+      "created_at",
+      "url",
+      "order",
+      "comment_count",
+      "creator_id",
+      "assignee_id",
+      "assigner_id",
+    ]) {
+      expect(task).not.toHaveProperty(absent);
+    }
+  });
+});
+
+// ── observeTask: the decision path ───────────────────────────────────────────
+
+describe("observeTask reads the fields v1 actually sends", () => {
+  it("reports a completed task as completed", async () => {
+    // THE regression. Before the fix this returns completed:false, and a real
+    // operator completion grades `unknown` / `open-recent` forever.
+    mockJson(todoistV1CompletedTask());
+
+    const result = await (await connector()).observeTask("task1");
+
+    expect(result).toMatchObject({ kind: "observed", completed: true });
+  });
+
+  it("reports an open task as open", async () => {
+    mockJson(todoistV1Task());
+
+    const result = await (await connector()).observeTask("task1");
+
+    expect(result).toMatchObject({ kind: "observed", completed: false });
+  });
+
+  it("takes createdAt from added_at, not a fabricated now", async () => {
+    // The staleness horizon is measured from this. Substituting Date.now()
+    // makes every errand permanently "recent", so `stale-unactioned` — the
+    // branch that converts silence into a negative — becomes unreachable.
+    mockJson(todoistV1Task({ added_at: "2026-01-01T00:00:00.000000Z" }));
+
+    const result = await (await connector()).observeTask("task1");
+
+    expect(result.kind).toBe("observed");
+    if (result.kind !== "observed") throw new Error("expected an observation");
+    expect(result.createdAt).toBe(Date.parse("2026-01-01T00:00:00.000000Z"));
+  });
+
+  it("omits createdAt rather than inventing one when added_at is unusable", async () => {
+    // Two wrong answers were available and both are harms. Zero reads as 1970,
+    // which the horizon grades `junk` — a negative manufactured from a parse
+    // failure. `Date.now()` reads as brand new, which is what masked this bug
+    // for nine days. Neither is an observation of age, so we report none: the
+    // grader answers `not-observed` on the staleness branch, while `completed`
+    // is still checked FIRST and a real completion survives.
+    mockJson(todoistV1Task({ added_at: "not-a-date" }));
+
+    const result = await (await connector()).observeTask("task1");
+
+    expect(result.kind).toBe("observed");
+    if (result.kind !== "observed") throw new Error("expected an observation");
+    expect(result.createdAt).toBeUndefined();
+  });
+
+  it("still confirms a completion whose added_at is unusable", async () => {
+    mockJson(todoistV1CompletedTask({ added_at: "not-a-date" }));
+
+    const result = await (await connector()).observeTask("task1");
+
+    expect(result).toMatchObject({ kind: "observed", completed: true });
+  });
+});
+
+// ── the end-to-end path the operator actually runs ───────────────────────────
+
+describe("a real completion survives the whole observation chain", () => {
+  it("grades a checked:true task as confirmed", async () => {
+    // observeTask → observeTodoistErrands → gradeErrandOutcome, with a real v1
+    // body at the top. This is the chain `patchwork butler observe` runs, and
+    // the one that returned `unknown` against a genuinely completed errand.
+    mockJson(todoistV1CompletedTask());
+
+    const { observeTodoistErrands } = await import(
+      "../../butler/todoistObservation.js"
+    );
+    const { gradeErrandOutcome } = await import(
+      "../../butler/errandOutcomeGrader.js"
+    );
+
+    const run = await observeTodoistErrands(await connector(), [
+      { taskId: "task1", ref: "todoist.create_task:task1", recipe: "errands" },
+    ]);
+
+    expect(run.unavailable).toEqual([]);
+    const observation = run.observations[0];
+    if (!observation) throw new Error("expected an observation");
+    expect(gradeErrandOutcome(observation, { now: Date.now() })).toEqual({
+      disposition: "confirmed",
+      reason: "completed",
+    });
+  });
+
+  it("an old open task still reaches the staleness horizon", async () => {
+    // The other half: with createdAt read correctly, silence can once again
+    // become a negative. A fabricated `Date.now()` makes this row `open-recent`
+    // for ever.
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    mockJson(todoistV1Task({ added_at: sixtyDaysAgo.toISOString() }));
+
+    const { observeTodoistErrands } = await import(
+      "../../butler/todoistObservation.js"
+    );
+    const { gradeErrandOutcome } = await import(
+      "../../butler/errandOutcomeGrader.js"
+    );
+
+    const run = await observeTodoistErrands(await connector(), [
+      { taskId: "task1", ref: "todoist.create_task:task1" },
+    ]);
+    const observation = run.observations[0];
+    if (!observation) throw new Error("expected an observation");
+
+    expect(
+      gradeErrandOutcome(
+        { ...observation, watchedSince: sixtyDaysAgo.getTime() },
+        { now: Date.now() },
+      ),
+    ).toEqual({ disposition: "junk", reason: "stale-unactioned" });
+  });
+});
+
+// ── the list endpoints ───────────────────────────────────────────────────────
+
+describe("list endpoints against real v1 bodies", () => {
+  it("getTasks unwraps the envelope and preserves the v1 keys", async () => {
+    mockJson(todoistV1List([todoistV1Task(), todoistV1Task({ id: "task2" })]));
+
+    const tasks = await (await connector()).getTasks();
+
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0]).toHaveProperty("checked");
+    expect(tasks[0]).toHaveProperty("added_at");
+  });
+
+  it("getProjects unwraps the envelope", async () => {
+    mockJson(todoistV1List([todoistV1Project()]));
+
+    const projects = await (await connector()).getProjects();
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toHaveProperty("child_order");
+  });
+
+  it("getLabels unwraps the envelope like its siblings", async () => {
+    // It did not. `getLabels` was the one list endpoint the v1 migration
+    // missed, so it returned `{results, next_cursor}` typed as an array — every
+    // caller's `.length` is undefined and `.map` throws. Latent rather than
+    // live only because nothing calls it yet, which is not a reason to leave it.
+    mockJson(todoistV1List([]));
+
+    const labels = await (await connector()).getLabels();
+
+    expect(Array.isArray(labels)).toBe(true);
+  });
+});

--- a/src/connectors/todoist.ts
+++ b/src/connectors/todoist.ts
@@ -71,7 +71,7 @@ export interface TodoistDue {
  *
  * These names are v1's, not REST v2's, and the difference is not cosmetic. The
  * base URL moved to v1 when v2 started answering 410 Gone; this interface did
- * not move with it, so for nine days it declared six fields the wire never
+ * not move with it, so for nine days it declared EIGHT fields the wire never
  * sent. Two of them were read to make a decision:
  *
  *   `is_completed` → v1 sends `checked` (plus `completed_at`)
@@ -82,7 +82,7 @@ export interface TodoistDue {
  * trust. A blind `res.json() as Promise<TodoistTask>` cast reports nothing when
  * it is wrong: the fields simply arrive `undefined`.
  *
- * The others — `url`, `order`, `comment_count`, `creator_id`, `assignee_id`,
+ * The other six — `url`, `order`, `comment_count`, `creator_id`, `assignee_id`,
  * `assigner_id` — are removed rather than renamed where v1 has no counterpart.
  * `url` in particular never existed on v1: Todoist exposes no task permalink,
  * which is why the outcome join key had to be generalised to `<tool>:<id>`.

--- a/src/connectors/todoist.ts
+++ b/src/connectors/todoist.ts
@@ -1,5 +1,8 @@
 /**
- * Todoist connector — manage tasks and projects via the Todoist REST API v2.
+ * Todoist connector — manage tasks and projects via the Todoist unified API v1.
+ *
+ * REST v2 answers 410 Gone. The base URL moved to v1; the response interfaces
+ * below moved with it on 2026-08-19, nine days later — see `TodoistTask`.
  *
  * Auth: API token (personal or app token).
  *   - Env var: TODOIST_API_KEY overrides stored token for CI/headless use.
@@ -63,6 +66,31 @@ export interface TodoistDue {
   timezone?: string;
 }
 
+/**
+ * A task as the v1 API sends it.
+ *
+ * These names are v1's, not REST v2's, and the difference is not cosmetic. The
+ * base URL moved to v1 when v2 started answering 410 Gone; this interface did
+ * not move with it, so for nine days it declared six fields the wire never
+ * sent. Two of them were read to make a decision:
+ *
+ *   `is_completed` → v1 sends `checked` (plus `completed_at`)
+ *   `created_at`   → v1 sends `added_at`
+ *
+ * `observeTask` read both, so a Butler errand the operator had genuinely
+ * completed graded `unknown` / `open-recent` and no filing could ever earn
+ * trust. A blind `res.json() as Promise<TodoistTask>` cast reports nothing when
+ * it is wrong: the fields simply arrive `undefined`.
+ *
+ * The others — `url`, `order`, `comment_count`, `creator_id`, `assignee_id`,
+ * `assigner_id` — are removed rather than renamed where v1 has no counterpart.
+ * `url` in particular never existed on v1: Todoist exposes no task permalink,
+ * which is why the outcome join key had to be generalised to `<tool>:<id>`.
+ *
+ * Key set captured from the live API on 2026-08-19; the shared test fixture
+ * (`__tests__/todoistV1Fixture.ts`) carries the same set and is asserted
+ * against it.
+ */
 export interface TodoistTask {
   id: string;
   content: string;
@@ -70,32 +98,75 @@ export interface TodoistTask {
   project_id: string;
   section_id: string | null;
   parent_id: string | null;
-  order: number;
+  /** v1's ordering field. Was declared `order`, which v1 does not send. */
+  child_order: number;
+  day_order: number;
   priority: number;
   due: TodoistDue | null;
+  deadline: unknown | null;
+  duration: unknown | null;
   labels: string[];
-  is_completed: boolean;
-  created_at: string;
-  url: string;
-  assignee_id?: string | null;
-  assigner_id?: string | null;
-  comment_count: number;
-  creator_id: string;
+  /** Completion flag. Was declared `is_completed`, which v1 does not send. */
+  checked: boolean;
+  completed_at: string | null;
+  completed_by_uid: string | null;
+  completed_count: number;
+  /** Creation stamp. Was declared `created_at`, which v1 does not send. */
+  added_at: string;
+  added_by_uid: string | null;
+  updated_at: string;
+  assigned_by_uid?: string | null;
+  responsible_uid?: string | null;
+  user_id: string;
+  note_count: number;
+  postponed_count: number;
+  is_collapsed: boolean;
+  is_deleted: boolean;
 }
 
+/**
+ * A project as the v1 API sends it.
+ *
+ * Same migration, same miss: `order` is `child_order`, `is_inbox_project` is
+ * `inbox_project`, `is_team_inbox` does not exist, and there is no `url`.
+ *
+ * Note the asymmetry with `TodoistTask`, which is real rather than a
+ * transcription slip: projects DO carry `created_at`; tasks carry `added_at`.
+ * That is a large part of why the task interface's `created_at` looked right.
+ */
 export interface TodoistProject {
   id: string;
   name: string;
   color: string;
+  description: string;
   parent_id: string | null;
-  order: number;
+  child_order: number;
+  default_order: number;
+  order_key: string;
   is_favorite: boolean;
-  is_inbox_project: boolean;
-  is_team_inbox: boolean;
+  inbox_project: boolean;
   is_shared: boolean;
-  url: string;
+  is_archived: boolean;
+  is_collapsed: boolean;
+  is_deleted: boolean;
+  is_frozen: boolean;
+  can_assign_tasks: boolean;
+  can_comment: boolean;
+  view_style: string;
+  created_at: string;
+  updated_at: string;
+  creator_uid: string;
 }
 
+/**
+ * A label as the v1 API sends it.
+ *
+ * DELIBERATELY LEFT AS DECLARED. The account used to capture the task and
+ * project shapes has no labels, so `GET /labels` returned an empty list and
+ * there is no observed item shape to correct this against. Rewriting it from
+ * the pattern of its siblings would be a guess wearing the same clothes as the
+ * measurements above, and this file is a demonstration of what that costs.
+ */
 export interface TodoistLabel {
   id: string;
   name: string;
@@ -344,10 +415,26 @@ export class TodoistConnector extends BaseConnector {
    * Additive on purpose. Changing `getTask` would alter behaviour for every
    * existing caller to serve one new one.
    */
+  /**
+   * Read one task's current state for the Butler observation channel.
+   *
+   * `createdAt` is OPTIONAL, and that is the fix for the subtler half of the
+   * v1 field mismatch. It previously read `created_at` — absent on v1 — so
+   * `Date.parse` returned NaN and the guard below substituted `Date.now()`.
+   * The guard is right that 0 would be read as 1970 and graded `junk`; it was
+   * wrong to answer with a fabricated timestamp instead, because "created just
+   * now" is what the staleness horizon measures, and refreshing it on every
+   * run put `stale-unactioned` permanently out of reach. Silently: the channel
+   * reported a clean observation throughout.
+   *
+   * Omitting it is the honest third answer. The grader checks `completed`
+   * FIRST, so a real completion still confirms; only the age-based branch
+   * withholds, which is exactly what "we could not read its age" means.
+   */
   async observeTask(
     id: string,
   ): Promise<
-    | { kind: "observed"; completed: boolean; createdAt: number }
+    | { kind: "observed"; completed: boolean; createdAt?: number }
     | { kind: "deleted" }
     | { kind: "unavailable"; reason: string }
   > {
@@ -366,13 +453,15 @@ export class TodoistConnector extends BaseConnector {
       if (result.error.code === "not_found") return { kind: "deleted" };
       return { kind: "unavailable", reason: result.error.code };
     }
-    const createdAt = Date.parse(result.data.created_at);
+    const createdAt = Date.parse(result.data.added_at);
     return {
       kind: "observed",
-      completed: result.data.is_completed === true,
-      // An unparseable timestamp must not become 0 — that is 1970, which the
-      // staleness horizon would read as infinitely old and grade `junk`.
-      createdAt: Number.isFinite(createdAt) ? createdAt : Date.now(),
+      completed: result.data.checked === true,
+      // An unparseable stamp yields NO age rather than a made-up one. Zero
+      // reads as 1970 and grades `junk` — a negative manufactured from a parse
+      // failure. `Date.now()` reads as brand new, which is what hid the v1
+      // field rename for nine days. Neither is an observation of age.
+      ...(Number.isFinite(createdAt) ? { createdAt } : {}),
     };
   }
 
@@ -546,7 +635,11 @@ export class TodoistConnector extends BaseConnector {
           status: res.status,
         });
       }
-      return res.json() as Promise<TodoistLabel[]>;
+      // `unwrapList`, like its siblings. This was the one list endpoint the v1
+      // migration missed, so it returned the raw `{ results, next_cursor }`
+      // envelope typed as an array: `.length` undefined, `.map` a TypeError.
+      // Latent rather than live only because nothing calls it yet.
+      return unwrapList<TodoistLabel>(await res.json());
     });
     if ("error" in result) throw new Error(result.error.message);
     return result.data;

--- a/src/recipes/tools/__tests__/todoist.test.ts
+++ b/src/recipes/tools/__tests__/todoist.test.ts
@@ -12,6 +12,11 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import {
+  todoistV1Project,
+  todoistV1Task,
+} from "../../../connectors/__tests__/todoistV1Fixture.js";
+
 // ── Connector mock ────────────────────────────────────────────────────────────
 // The tool module `await import("../../connectors/todoist.js")` lazily, so the
 // mock must be hoisted (vi.mock is hoisted automatically) and expose
@@ -67,25 +72,10 @@ describe("todoist recipe-step tools", () => {
     });
 
     it("calls getTasks(projectId, filter, limit) and returns its JSON", async () => {
-      const tasks = [
-        {
-          id: "1",
-          content: "Write tests",
-          description: "",
-          project_id: "p1",
-          section_id: null,
-          parent_id: null,
-          order: 1,
-          priority: 1,
-          due: null,
-          labels: [],
-          is_completed: false,
-          created_at: "t",
-          url: "https://todoist.com/showTask?id=1",
-          comment_count: 0,
-          creator_id: "c1",
-        },
-      ];
+      // The shared v1 shape, not a hand-written one. The body this file used to
+      // declare carried REST v2 names the API does not send — the same invented
+      // shape that let the connector's own bug survive nine days of green tests.
+      const tasks = [todoistV1Task({ id: "1", content: "Write tests" })];
       getTasks.mockResolvedValue(tasks);
 
       const tool = getTool("todoist.list_tasks");
@@ -116,23 +106,13 @@ describe("todoist recipe-step tools", () => {
     });
 
     it("calls createTask(content, projectId, description, dueString, priority, labels) and returns its JSON", async () => {
-      const created = {
+      const created = todoistV1Task({
         id: "9",
         content: "Ship it",
         description: "now",
-        project_id: "p1",
-        section_id: null,
-        parent_id: null,
-        order: 1,
         priority: 4,
-        due: null,
         labels: ["Work"],
-        is_completed: false,
-        created_at: "t",
-        url: "https://todoist.com/showTask?id=9",
-        comment_count: 0,
-        creator_id: "c1",
-      };
+      });
       createTask.mockResolvedValue(created);
 
       const tool = getTool("todoist.create_task");
@@ -204,20 +184,7 @@ describe("todoist recipe-step tools", () => {
     });
 
     it("calls getProjects() with no args and returns its JSON", async () => {
-      const projects = [
-        {
-          id: "p1",
-          name: "Inbox",
-          color: "grey",
-          parent_id: null,
-          order: 0,
-          is_favorite: false,
-          is_inbox_project: true,
-          is_team_inbox: false,
-          is_shared: false,
-          url: "https://todoist.com/showProject?id=p1",
-        },
-      ];
+      const projects = [todoistV1Project({ id: "p1", name: "Inbox" })];
       getProjects.mockResolvedValue(projects);
 
       const tool = getTool("todoist.list_projects");

--- a/src/recipes/tools/todoist.ts
+++ b/src/recipes/tools/todoist.ts
@@ -1,6 +1,12 @@
 /**
  * Todoist tools — list/create/close tasks and list projects via the Todoist
- * REST API v2 connector.
+ * unified API v1 connector.
+ *
+ * The `outputSchema` blocks below describe the v1 wire shape. They previously
+ * described REST v2's, which meant every one of them advertised fields the API
+ * does not send (`is_completed`, `created_at`, `url`, …) to recipe authors
+ * writing `{{steps.x.…}}` references. Nothing type-checks a tool's declared
+ * output against what it returns — these are assertions on trust.
  *
  * Self-registering tool module for the recipe tool registry. Mirrors the
  * positional signatures of `TodoistConnector` (src/connectors/todoist.ts):
@@ -56,17 +62,19 @@ registerTool({
         project_id: { type: "string" },
         section_id: { type: ["string", "null"] },
         parent_id: { type: ["string", "null"] },
-        order: { type: "number" },
+        child_order: { type: "number" },
         priority: { type: "number" },
         due: { type: ["object", "null"] },
+        deadline: { type: ["object", "null"] },
         labels: { type: "array", items: { type: "string" } },
-        is_completed: { type: "boolean" },
-        created_at: { type: "string" },
-        url: { type: "string" },
-        assignee_id: { type: ["string", "null"] },
-        assigner_id: { type: ["string", "null"] },
-        comment_count: { type: "number" },
-        creator_id: { type: "string" },
+        checked: { type: "boolean" },
+        completed_at: { type: ["string", "null"] },
+        added_at: { type: "string" },
+        updated_at: { type: "string" },
+        added_by_uid: { type: ["string", "null"] },
+        responsible_uid: { type: ["string", "null"] },
+        assigned_by_uid: { type: ["string", "null"] },
+        note_count: { type: "number" },
       },
     },
   },
@@ -136,15 +144,17 @@ registerTool({
       project_id: { type: "string" },
       section_id: { type: ["string", "null"] },
       parent_id: { type: ["string", "null"] },
-      order: { type: "number" },
+      child_order: { type: "number" },
       priority: { type: "number" },
       due: { type: ["object", "null"] },
+      deadline: { type: ["object", "null"] },
       labels: { type: "array", items: { type: "string" } },
-      is_completed: { type: "boolean" },
-      created_at: { type: "string" },
-      url: { type: "string" },
-      comment_count: { type: "number" },
-      creator_id: { type: "string" },
+      checked: { type: "boolean" },
+      completed_at: { type: ["string", "null"] },
+      added_at: { type: "string" },
+      updated_at: { type: "string" },
+      added_by_uid: { type: ["string", "null"] },
+      note_count: { type: "number" },
     },
   },
   riskDefault: "medium",
@@ -308,13 +318,16 @@ registerTool({
         id: { type: "string" },
         name: { type: "string" },
         color: { type: "string" },
+        description: { type: "string" },
         parent_id: { type: ["string", "null"] },
-        order: { type: "number" },
+        child_order: { type: "number" },
         is_favorite: { type: "boolean" },
-        is_inbox_project: { type: "boolean" },
-        is_team_inbox: { type: "boolean" },
+        inbox_project: { type: "boolean" },
         is_shared: { type: "boolean" },
-        url: { type: "string" },
+        is_archived: { type: "boolean" },
+        view_style: { type: "string" },
+        created_at: { type: "string" },
+        updated_at: { type: "string" },
       },
     },
   },

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -612,6 +612,53 @@ describe("computePendingConfirmations (the confirm queue)", () => {
     expect(pending[0]?.title).toBeUndefined();
   });
 
+  it("headlines a Todoist filing with its content, not the 'a new issue' placeholder", () => {
+    // `title` is GitHub's field name. Todoist sends `content` and has never
+    // sent `title` — so every Butler errand reached this queue with
+    // `title: undefined`, and the dashboard rendered its fallback string
+    // literally: `{p.title ?? "a new issue"}`. The operator was asked to rule
+    // on "a new issue" — a placeholder, with the wrong noun, about a task.
+    //
+    // This is the one screen whose entire job is letting a human judge an
+    // action, and it showed them nothing about the action. Same defect family
+    // as the `is_completed`/`created_at` reads: a field name from a different
+    // API, arriving `undefined`, with no error anywhere.
+    writeFileSync(
+      path.join(workersDir, "errands.worker.yaml"),
+      "id: errands\nname: Errands\nrecipe: run-errands\nowns:\n  - tasks\nautonomyCeiling: 4\n",
+    );
+    new RecipeRunLog({ dir }).appendDirect({
+      taskId: "run-todoist",
+      recipeName: "run-errands",
+      trigger: "recipe",
+      status: "done",
+      createdAt: 0,
+      doneAt: 0,
+      durationMs: 1,
+      stepResults: [
+        {
+          id: "s1",
+          tool: "todoist.create_task",
+          status: "ok",
+          durationMs: 1,
+          // The v1 wire shape: `content`, no `title`, and no `url` at all.
+          output: { id: "task-1", content: "Renew the parking permit" },
+        },
+      ],
+    });
+
+    const pending = computePendingConfirmations({
+      workersDir,
+      patchworkDir: dir,
+    });
+    const errand = pending.find((p) => p.recipeName === "run-errands");
+    expect(errand).toBeDefined();
+    expect(errand?.title).toBe("Renew the parking permit");
+    expect(formatPendingConfirmations(pending)).toContain(
+      '"Renew the parking permit"',
+    );
+  });
+
   it("formats the queue with the exact confirm command (and an empty-state)", () => {
     expect(formatPendingConfirmations([])).toMatch(/No filings awaiting/);
     seedFiling(URL, 0, "Login test failing on main");

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -491,6 +491,32 @@ export interface PendingConfirmation {
  * confirmation — they earn trust on their own). In practice today only issue
  * filings (`github.create_issue`) carry a captured URL.
  */
+/**
+ * The human-readable label of a filed action, in the order services spell it.
+ *
+ * `title` alone is GitHub's spelling. Todoist has never sent it — its field is
+ * `content` — so every Butler errand arrived here with `title: undefined` and
+ * the dashboard rendered its own fallback verbatim: the operator was asked to
+ * rule on "a new issue", a placeholder carrying no information about the errand
+ * and the wrong noun for it. That is the one screen whose entire job is letting
+ * a human judge an action.
+ *
+ * The list grows only when a connector is SHOWN to use a different name. Adding
+ * plausible-looking candidates (`summary`, `name`, `subject`) on the theory that
+ * some service might use them is how a field that does not exist gets read in
+ * the first place — see this connector's own `is_completed`.
+ */
+function deriveFilingTitle(
+  out: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!out) return undefined;
+  for (const field of ["title", "content"] as const) {
+    const v = out[field];
+    if (typeof v === "string" && v.trim()) return v;
+  }
+  return undefined;
+}
+
 export function computePendingConfirmations(
   opts: RunWorkerShadowOpts = {},
 ): PendingConfirmation[] {
@@ -532,10 +558,7 @@ export function computePendingConfirmations(
       const ref = url
         ? undefined
         : { tool: step.tool, id: actionKey.slice(step.tool.length + 1) };
-      const title =
-        out && typeof out.title === "string" && out.title.trim()
-          ? (out.title as string)
-          : undefined;
+      const title = deriveFilingTitle(out);
       const disp = store.getDisposition(actionKey);
       if (disp === "confirmed" || disp === "junk") continue; // already actioned
       // unknown / no record → pending. Dedup by key, keep the newest filing.


### PR DESCRIPTION
## The measurement that found it

`patchwork butler observe` was run to capture the before/after that #1319 requires — the first time a Butler filing could earn trust from a real operator confirmation. The operator had completed one of the three outstanding errands. The channel reported:

```
[butler] observed 3, could not read 0.
[butler] graded 3: 0 confirmed, 0 junk, 3 unknown.
```

Not a connection failure, not a missing observation. It read live state for all three and reported the completed one as still open.

## Cause

`TODOIST_BASE` moved to `api/v1` on 2026-08-10, because REST v2 answers 410 Gone. The response interfaces did not move with it, and the cast is blind — `res.json() as Promise<TodoistTask>` — so a declared field the wire never sends arrives `undefined` with no error anywhere.

Six fields were wrong. Two of them are read to make a decision.

| declared | v1 actually sends | read by |
|---|---|---|
| `is_completed` | `checked` (+ `completed_at`) | `observeTask` — **the trust decision** |
| `created_at` | `added_at` | `observeTask` — **the staleness horizon** |
| `url` | *(absent — Todoist has no task permalink)* | outputSchema only |
| `order` | `child_order` | outputSchema only |
| `comment_count` | `note_count` | outputSchema only |
| `creator_id` | `added_by_uid` | outputSchema only |

**`is_completed`** meant `completed` was `false` for every task, forever. A completed errand could never reach `confirmed`, so the observation channel could not do the one thing it exists to do — and it looked healthy the whole time.

**`created_at`** is the subtler half. `Date.parse(undefined)` is NaN, so the guard against an unparseable stamp substituted `Date.now()`. That guard is right that `0` reads as 1970 and would be graded `junk`; answering with a fabricated timestamp instead was wrong. Every errand's age reset to zero on every run, putting the 14-day `stale-unactioned → junk` horizon permanently out of reach. The rule that converts silence into a negative was dead, and nothing said so.

`createdAt` is now **optional** and omitted when unreadable. That is the honest third answer: the grader checks `completed` first, so a real completion still confirms; only the age-based branch withholds, which is exactly what "we could not read its age" means.

## Also fixed

- `TodoistProject`: `order`→`child_order`, `is_inbox_project`→`inbox_project`, no `is_team_inbox`, no `url`.
- The three recipe-tool `outputSchema` blocks, which advertised the v2 names to recipe authors writing `{{steps.x.…}}` references. Nothing type-checks a declared tool output against what it returns — these are assertions on trust, and they were false.
- `getLabels` — the one list endpoint the v1 migration missed. It returned the raw `{results, next_cursor}` envelope typed as an array: `.length` undefined, `.map` a TypeError. Latent rather than live only because nothing calls it yet.

`TodoistLabel` is **deliberately left alone**. The account used to capture the other shapes has no labels, so `GET /labels` returned an empty list and there is no observed item shape to correct it against. Rewriting it from the pattern of its siblings would be a guess wearing the same clothes as the measurements — which is how this happened.

## Why no test caught it

Every suite hand-wrote its own task body using the v2 names the code expected — **including inside the `describe("Todoist API v1 …")` block the migration itself added.** A mock that agrees with the code's wrong assumption proves only that the code agrees with itself.

And `todoistObservation.test.ts` doubles the *connector*, returning an already-mapped `{kind:"observed", completed, createdAt}` — its seam starts one layer below where the bug lives.

**202 tests passed before this change and pass after it, unchanged.** They are invariant to both the bug and the fix.

So there is now **one** fixture, `src/connectors/__tests__/todoistV1Fixture.ts`, carrying the key set captured from the live API, and both existing suites delegate to it. Two hand-written shapes is how they drifted.

Only key *names* were recorded. The response bodies were not and must not be: a real account's task content is the operator's errands and this repo is world-readable. Every value in the fixture is synthetic.

## Verification that could fail

Five mutations, each with an assert-guard confirming it actually applied, each turning the new suite red:

| mutation | tests failed |
|---|---|
| read `is_completed` again | 3 |
| read `created_at` again | 2 |
| restore the `Date.now()` fallback | 1 |
| un-unwrap `getLabels` | 1 |
| drop a key from the recorded fixture | 2 |

Then end to end against the live API — same three errands, same command:

| | before | after |
|---|---|---|
| `butler observe` | 0 confirmed, 0 junk, 3 unknown | **1 confirmed**, 0 junk, 2 unknown |
| rows that would become evidence | 0 | 1 |

The confirmation landed on the one task that is actually complete, and the two genuinely-open errands stayed `unknown`/`open-recent` — so the channel discriminates rather than blanket-confirming. Still shadow-only: `outcome-log.jsonl` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)