### PR TITLE
fix(scheduler): a scheduled recipe fired once per running bridge (#1458)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,7 @@ Most users don't need to touch these — CLI flags cover the common cases. Liste
 | `PATCHWORK_CLAUDE_BINARY` | Equivalent to `--claude-binary`; path to the `claude` CLI. |
 | `PATCHWORK_RECIPE_REPO_ALLOWLIST` | Comma-separated `owner/repo` allowlist for recipe install sources. |
 | `PATCHWORK_TOKEN_DIR` / `PATCHWORK_TOKEN_STORAGE_BACKEND` | Connector-token storage location + backend (`file` vs `keychain`). |
+| `PATCHWORK_CRON_CLAIM_REQUIRED` | Truthy → a scheduled recipe SKIPS its tick when the cross-process claim store is unwritable, instead of firing anyway (#1458). Default off, i.e. fail-OPEN: the conditions that break the store are machine-level, so failing closed would stop every scheduled recipe on every bridge at once rather than allowing one duplicate. Set this where a duplicate is worse than a miss — recipes that send email or post publicly. `EEXIST` is not a failure and is unaffected: that is a peer holding the tick. |
 | `PATCHWORK_FLAG_KILL_SWITCH_WRITES` | Feature flag — gate write tools on kill-switch state. |
 | `PATCHWORK_FLAG_UI_SCHEMA_LINT` | Feature flag — strict UI-schema linting in the recipe editor. |
 | `PATCHWORK_FLAG_WORKER_AUTONOMY` | Feature flag — enable trust-ramp-aware autonomy gate for worker recipes. Gates compensable/irreversible automated recipe actions until the owning worker earns L4 trust on that action-class; reversible actions always flow freely. Default off. Requires `--driver subprocess`. |

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,17 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `fix/1458-cron-claim` — #1458. Every running bridge fires every cron recipe: the
+  double-fire guard is an in-memory `Set` and the recipe store is global, so N bridges = N fires
+  (observed live twice today, same instant, two pids). Adds `src/recipes/cronClaim.ts` — an
+  `O_EXCL` claim keyed `(recipeName, slotEpochMs)` where the slot is the instant node-cron's
+  matcher matched, threaded into `fire()` rather than re-read from the clock. Claim is a
+  TOMBSTONE, taken LAST (after the disabled re-check, so a locally-disabled bridge cannot burn a
+  peer's tick), and fails OPEN with `PATCHWORK_CRON_CLAIM_REQUIRED=1` to invert. CRON YAML ONLY —
+  `@every`, legacy-JSON cron and the event-trigger paths are excluded and get their own issues.
+  Touches `src/recipes/scheduler.ts` — collides with any scheduler, recipe-trigger or
+  cron work. — this session
+
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-19 `fix/1458-cron-claim` — #1458. Every running bridge fires every cron recipe: the
   double-fire guard is an in-memory `Set` and the recipe store is global, so N bridges = N fires
   (observed live twice today, same instant, two pids). Adds `src/recipes/cronClaim.ts` — an
@@ -38,10 +42,7 @@ verified (which is how this line came to be written).
   peer's tick), and fails OPEN with `PATCHWORK_CRON_CLAIM_REQUIRED=1` to invert. CRON YAML ONLY —
   `@every`, legacy-JSON cron and the event-trigger paths are excluded and get their own issues.
   Touches `src/recipes/scheduler.ts` — collides with any scheduler, recipe-trigger or
-  cron work. — this session
-
-
-## Recently closed (informal log, prune periodically)
+  cron work. — this session — merged as #1461
 
 - 2026-08-19 `chore/pin-node-cron-exactly` — `package.json` declared `^4.2.1`, the lockfile
   resolved 4.2.1, and the globally installed bridges were running **4.6.0**: `npm install -g`

--- a/src/recipes/__tests__/cronClaim.test.ts
+++ b/src/recipes/__tests__/cronClaim.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The cron claim primitive (#1458).
+ *
+ * These are the unit-level properties. They are NOT the proof that the fix
+ * works: a single process cannot distinguish a filesystem claim from an
+ * in-memory `Set` keyed by slot, and a test that passes against both is worth
+ * nothing here. That proof lives in `cronClaimCrossProcess.test.ts`, which
+ * forks real OS processes.
+ *
+ * What these cover is the behaviour a reader would otherwise have to take on
+ * trust: the key's encoding, that a claim is a TOMBSTONE, and that the two
+ * degraded modes do what the header says.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CLAIM_RETENTION_MS,
+  claimCronSlot,
+  cronClaimKey,
+  sweepCronClaims,
+} from "../cronClaim.js";
+
+let claimsDir: string;
+
+beforeEach(() => {
+  claimsDir = mkdtempSync(join(os.tmpdir(), "cron-claims-"));
+});
+afterEach(() => {
+  rmSync(claimsDir, { recursive: true, force: true });
+});
+
+const SLOT = Date.parse("2026-08-19T08:07:00.000Z");
+
+describe("the claim key", () => {
+  it("is stable for the same recipe and slot", () => {
+    expect(cronClaimKey("heartbeat", SLOT)).toBe(
+      cronClaimKey("heartbeat", SLOT),
+    );
+  });
+
+  it("separates recipes whose names and slots concatenate the same way", () => {
+    // The reason for JSON-array encoding rather than `${a}:${b}`, which
+    // `deriveScopeKey` already documents: `a:b` + `c` and `a` + `b:c` must not
+    // collide. Expressed with the real types the key takes.
+    expect(cronClaimKey("a:1", 2)).not.toBe(cronClaimKey("a", 12));
+  });
+
+  it("is filename-safe for a recipe name that is not", () => {
+    // Recipe names reach the filesystem through this key and nothing else.
+    expect(cronClaimKey("owner/repo — recipe ✨", SLOT)).toMatch(
+      /^[0-9a-f]{32}$/,
+    );
+  });
+});
+
+describe("claiming a slot", () => {
+  it("the first caller claims and the second is told it is taken", () => {
+    expect(claimCronSlot("r", SLOT, { claimsDir })).toEqual({
+      kind: "claimed",
+    });
+    expect(claimCronSlot("r", SLOT, { claimsDir })).toEqual({ kind: "taken" });
+  });
+
+  it("does not block a different slot, or a different recipe", () => {
+    expect(claimCronSlot("r", SLOT, { claimsDir }).kind).toBe("claimed");
+    expect(claimCronSlot("r", SLOT + 60_000, { claimsDir }).kind).toBe(
+      "claimed",
+    );
+    expect(claimCronSlot("other", SLOT, { claimsDir }).kind).toBe("claimed");
+  });
+
+  it("treats a stray millisecond as the same slot", () => {
+    // Belt and braces against an upstream change that reintroduces ms. A key
+    // that splits on them fails only when the event-loop hop straddles a second
+    // boundary — i.e. rarely, and never on demand.
+    expect(claimCronSlot("r", SLOT, { claimsDir }).kind).toBe("claimed");
+    expect(claimCronSlot("r", SLOT + 999, { claimsDir }).kind).toBe("taken");
+  });
+
+  it("is a TOMBSTONE — the claim outlives the run that took it", () => {
+    // If the claim were released on completion, a peer whose tick is delayed
+    // past the first bridge's completion would find no claim and fire. That is
+    // the same bug in a narrower window, which is worse: it stops reproducing.
+    expect(claimCronSlot("r", SLOT, { claimsDir }).kind).toBe("claimed");
+    const files = existsSync(claimsDir);
+    expect(files).toBe(true);
+    // ... arbitrarily later, with no process holding anything:
+    expect(claimCronSlot("r", SLOT, { claimsDir }).kind).toBe("taken");
+  });
+
+  it("records who took it, for a human — never for a decision", () => {
+    claimCronSlot("heartbeat", SLOT, { claimsDir });
+    const day = join(claimsDir, "2026-08-19");
+    const file = join(day, `${cronClaimKey("heartbeat", SLOT)}.json`);
+    const body = JSON.parse(readFileSync(file, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(body).toMatchObject({
+      v: 1,
+      recipeName: "heartbeat",
+      slotEpochMs: SLOT,
+      pid: process.pid,
+    });
+  });
+});
+
+describe("degraded modes", () => {
+  /** A path that cannot be created: an existing FILE where a directory must go. */
+  function unusableRoot(): string {
+    const root = join(claimsDir, "blocked");
+    writeFileSync(root, "not a directory");
+    return root;
+  }
+
+  it("fails OPEN by default — the tick fires, and the caller is told why", () => {
+    const r = claimCronSlot("r", SLOT, { claimsDir: unusableRoot() });
+    expect(r.kind).toBe("unavailable");
+    if (r.kind !== "unavailable") throw new Error("expected unavailable");
+    // The reason is carried so the log and the run stamp can name it. A
+    // duplicate that is attributable is a different thing from a mysterious one.
+    expect(r.reason).toBeTruthy();
+  });
+
+  it("fails CLOSED when the operator asks for it", () => {
+    // PATCHWORK_CRON_CLAIM_REQUIRED. Injected rather than set on the
+    // environment: an env mutation that leaks would silently change every
+    // later test in the file.
+    const r = claimCronSlot("r", SLOT, {
+      claimsDir: unusableRoot(),
+      required: true,
+    });
+    expect(r.kind).toBe("refused");
+  });
+
+  it("keeps 'a peer has it' distinguishable from 'we could not tell'", () => {
+    // Two different facts about the system. Collapsing them into one outcome
+    // would make the log unable to say which happened, and they call for
+    // opposite responses.
+    expect(claimCronSlot("r", SLOT, { claimsDir }).kind).toBe("claimed");
+    expect(claimCronSlot("r", SLOT, { claimsDir }).kind).toBe("taken");
+    expect(claimCronSlot("r", SLOT, { claimsDir: unusableRoot() }).kind).toBe(
+      "unavailable",
+    );
+  });
+});
+
+describe("the sweep", () => {
+  it("removes day-directories past the horizon and keeps the rest", () => {
+    const old = join(claimsDir, "2026-01-01");
+    const recent = join(claimsDir, "2026-08-19");
+    mkdirSync(old, { recursive: true });
+    mkdirSync(recent, { recursive: true });
+
+    const removed = sweepCronClaims(Date.parse("2026-08-19T12:00:00Z"), {
+      claimsDir,
+    });
+
+    expect(removed).toBe(1);
+    expect(existsSync(old)).toBe(false);
+    expect(existsSync(recent)).toBe(true);
+  });
+
+  it("keeps a directory that is inside the horizon", () => {
+    const yesterday = join(claimsDir, "2026-08-18");
+    mkdirSync(yesterday, { recursive: true });
+    expect(
+      sweepCronClaims(Date.parse("2026-08-19T12:00:00Z"), { claimsDir }),
+    ).toBe(0);
+    expect(existsSync(yesterday)).toBe(true);
+  });
+
+  it("leaves anything that is not one of ours alone", () => {
+    // The sweep is `rm -rf` on a directory name. It must never act on a name it
+    // did not write, whatever else is under PATCHWORK_HOME.
+    const stranger = join(claimsDir, "README");
+    mkdirSync(stranger, { recursive: true });
+    sweepCronClaims(Date.parse("2030-01-01T00:00:00Z"), { claimsDir });
+    expect(existsSync(stranger)).toBe(true);
+  });
+
+  it("is a non-event when nothing has ever been claimed", () => {
+    expect(
+      sweepCronClaims(Date.now(), { claimsDir: join(claimsDir, "nope") }),
+    ).toBe(0);
+  });
+
+  it("keeps the horizon well clear of the window a duplicate can arrive in", () => {
+    // The retention only has to outlive the window in which a duplicate of the
+    // SAME slot can arrive, which is bounded by seconds. Asserted so a future
+    // "tidy up, 5 minutes is plenty" cannot pass unnoticed.
+    expect(CLAIM_RETENTION_MS).toBeGreaterThanOrEqual(24 * 60 * 60 * 1000);
+  });
+});

--- a/src/recipes/__tests__/cronClaimCrossProcess.test.ts
+++ b/src/recipes/__tests__/cronClaimCrossProcess.test.ts
@@ -42,7 +42,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { cronClaimKey } from "../cronClaim.js";
@@ -59,9 +59,20 @@ const MODULE_UNDER_TEST = fileURLToPath(
  * `dist/` would silently test yesterday's code — the exact class of mistake
  * `patchwork doctor` exists for.
  */
-const TSX_LOADER = fileURLToPath(
+const TSX_LOADER_PATH = fileURLToPath(
   new URL("../../../node_modules/tsx/dist/loader.mjs", import.meta.url),
 );
+
+/**
+ * `--import` takes an ESM specifier, not a path.
+ *
+ * On POSIX a bare absolute path happens to resolve. On Windows it does not: a
+ * leading `D:` is parsed as a URL scheme, the loader never installs, and every
+ * child dies on its first `import`. That is how this file cost 225 seconds on
+ * Windows CI and zero on macOS — a platform difference invisible to the machine
+ * it was written on.
+ */
+const TSX_LOADER = pathToFileURL(TSX_LOADER_PATH).href;
 
 let root: string;
 
@@ -103,6 +114,7 @@ async function raceForSlot(
   const goFile = join(root, `go-${slot}`);
   const children: Promise<string>[] = [];
   const readyFiles: string[] = [];
+  let exited = 0;
 
   const childFile = join(root, "claimant.mts");
   writeFileSync(childFile, childSource());
@@ -136,6 +148,7 @@ async function raceForSlot(
           err += String(d);
         });
         child.on("close", (code) => {
+          exited++;
           const verdict = out.trim();
           // A dead child reports as such rather than vanishing. Silence here is
           // what would let this test pass for the wrong reason.
@@ -145,10 +158,14 @@ async function raceForSlot(
     );
   }
 
-  // Release only once every child is parked on the barrier.
-  const deadline = Date.now() + 25_000;
+  // Release once every child is parked on the barrier — or once they have all
+  // EXITED, which is what a startup failure looks like. Waiting out the full
+  // deadline in that case turns one broken child into a per-test timeout, and
+  // then into a suite that reads as hung rather than as failed.
+  const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     if (readyFiles.every((f) => existsSync(f))) break;
+    if (exited === n) break;
     await new Promise((r) => setTimeout(r, 20));
   }
   writeFileSync(goFile, "go");
@@ -157,22 +174,23 @@ async function raceForSlot(
 }
 
 describe("two operating-system processes cannot both claim one tick", () => {
-  it("exactly one of eight concurrent claimants wins, and all eight report", async () => {
+  it("exactly one of four concurrent claimants wins, and all four report", async () => {
     const slot = Date.parse("2026-08-19T08:07:00.000Z");
-    const verdicts = await raceForSlot(8, "heartbeat", slot);
+    const verdicts = await raceForSlot(4, "heartbeat", slot);
 
     // Assert this FIRST: a run where seven children died would otherwise
     // satisfy "exactly one claimed" while proving the opposite of the point.
-    expect(verdicts).toHaveLength(8);
+    expect(verdicts).toHaveLength(4);
     expect(verdicts.filter((v) => v.startsWith("DIED"))).toEqual([]);
 
     expect(verdicts.filter((v) => v === "claimed")).toHaveLength(1);
-    expect(verdicts.filter((v) => v === "taken")).toHaveLength(7);
-  }, 60_000);
+    expect(verdicts.filter((v) => v === "taken")).toHaveLength(3);
+  }, 45_000);
 
   it("the winner leaves exactly one claim file, under the key the module derives", async () => {
     const slot = Date.parse("2026-08-19T09:07:00.000Z");
-    const verdicts = await raceForSlot(4, "heartbeat", slot);
+    const verdicts = await raceForSlot(3, "heartbeat", slot);
+    expect(verdicts.filter((v) => v.startsWith("DIED"))).toEqual([]);
     expect(verdicts.filter((v) => v === "claimed")).toHaveLength(1);
 
     // Guards against a claim that is written somewhere while the decision is
@@ -181,24 +199,19 @@ describe("two operating-system processes cannot both claim one tick", () => {
     expect(readdirSync(day)).toEqual([
       `${cronClaimKey("heartbeat", slot)}.json`,
     ]);
-  }, 60_000);
+  }, 45_000);
 
-  it("different slots do not contend — a later tick is still allowed to fire", async () => {
-    const a = Date.parse("2026-08-19T10:07:00.000Z");
-    const b = Date.parse("2026-08-19T11:07:00.000Z");
-    expect(
-      (await raceForSlot(3, "heartbeat", a)).filter((v) => v === "claimed"),
-    ).toHaveLength(1);
-    expect(
-      (await raceForSlot(3, "heartbeat", b)).filter((v) => v === "claimed"),
-    ).toHaveLength(1);
-  }, 60_000);
+  // "different slots do not contend" is NOT re-tested here. It costs six more
+  // node processes to demonstrate something with no cross-process content —
+  // `cronClaim.test.ts` covers it in-process, which is the right altitude for
+  // it. Spending Windows CI wall-clock on a property that does not need
+  // processes is how a correct test becomes a flake nobody trusts.
 
   it("tsx is present, so a skipped child would not read as a pass", () => {
     // If the loader were missing every child would die, and the assertions
     // above already catch that — but they would report it as a claim failure
     // rather than as a missing test dependency. This says which.
-    expect(existsSync(TSX_LOADER)).toBe(true);
+    expect(existsSync(TSX_LOADER_PATH)).toBe(true);
     expect(() =>
       execFileSync(process.execPath, ["--import", TSX_LOADER, "-e", "0"], {
         stdio: "ignore",

--- a/src/recipes/__tests__/cronClaimCrossProcess.test.ts
+++ b/src/recipes/__tests__/cronClaimCrossProcess.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The only test here that can tell the fix from the bug (#1458).
+ *
+ * ## Why the single-process tests are not enough, stated first
+ *
+ * #1458 is that N *operating-system processes* each fire the same cron tick,
+ * because the guard is an in-memory `Set` and a `Set` cannot see a sibling
+ * process. A test that constructs two claimants inside one Node process shares
+ * a module graph, a heap and a clock — it would pass just as happily against a
+ * three-line in-memory `Map` keyed by slot, which has no cross-process
+ * behaviour whatsoever and fixes nothing.
+ *
+ * So the claimants here are real `node` processes, spawned concurrently and
+ * released together by a barrier so they genuinely contend for the same slot.
+ *
+ * ## The two ways this could pass while proving nothing, and what stops each
+ *
+ * **Children that never ran.** "Exactly one claimed" is also true when seven of
+ * eight crashed on startup. Every child's verdict is collected and the count is
+ * asserted, so a child that failed to start fails the test rather than
+ * flattering it.
+ *
+ * **Children that did not contend.** Spawning is slow and jittery enough that
+ * eight sequential-ish starts could each find the slot free in turn only if the
+ * primitive were broken — but they might also simply not overlap. Each child
+ * signals readiness and then spins until a `go` file appears, so the claims are
+ * issued inside the same few milliseconds.
+ *
+ * The mutation that proves this test bites: degrade `claimCronSlot` from
+ * `openSync(path, "wx")` to `existsSync` + `writeFileSync`. That is the single
+ * most likely future "simplification", it passes every unit test in
+ * `cronClaim.test.ts`, and it turns this file red.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { cronClaimKey } from "../cronClaim.js";
+
+/** Absolute path to the module under test, handed to the children. */
+const MODULE_UNDER_TEST = fileURLToPath(
+  new URL("../cronClaim.ts", import.meta.url),
+);
+
+/**
+ * Children run TypeScript directly through `tsx` (a declared devDependency and
+ * already this repo's `dev` script). Compiling to `dist/` first would work too
+ * and was rejected: it makes the test depend on a build step, and a stale
+ * `dist/` would silently test yesterday's code — the exact class of mistake
+ * `patchwork doctor` exists for.
+ */
+const TSX_LOADER = fileURLToPath(
+  new URL("../../../node_modules/tsx/dist/loader.mjs", import.meta.url),
+);
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(os.tmpdir(), "cron-claim-xproc-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Source for one claimant. Written to disk so `tsx` can load it as a module. */
+function childSource(): string {
+  return `
+import { existsSync, writeFileSync } from "node:fs";
+const [modulePath, claimsDir, recipe, slot, readyFile, goFile] = process.argv.slice(2);
+const { claimCronSlot } = await import(modulePath);
+writeFileSync(readyFile, "ready");
+// Spin — not sleep. The window we are trying to land inside is milliseconds
+// wide, and a timer would round us straight past it.
+while (!existsSync(goFile)) { /* barrier */ }
+const r = claimCronSlot(recipe, Number(slot), { claimsDir });
+process.stdout.write(r.kind + "\\n");
+`;
+}
+
+/**
+ * Spawn `n` claimants for one slot and return what each decided.
+ *
+ * Deliberately returns every verdict, including failures, so the assertions can
+ * distinguish "one claimed and the rest were told it was taken" from "one
+ * claimed and the rest died".
+ */
+async function raceForSlot(
+  n: number,
+  recipe: string,
+  slot: number,
+): Promise<string[]> {
+  const claimsDir = join(root, "claims");
+  const goFile = join(root, `go-${slot}`);
+  const children: Promise<string>[] = [];
+  const readyFiles: string[] = [];
+
+  const childFile = join(root, "claimant.mts");
+  writeFileSync(childFile, childSource());
+
+  for (let i = 0; i < n; i++) {
+    const readyFile = join(root, `ready-${slot}-${i}`);
+    readyFiles.push(readyFile);
+    children.push(
+      new Promise<string>((resolve) => {
+        const child = spawn(
+          process.execPath,
+          [
+            "--import",
+            TSX_LOADER,
+            childFile,
+            MODULE_UNDER_TEST,
+            claimsDir,
+            recipe,
+            String(slot),
+            readyFile,
+            goFile,
+          ],
+          { stdio: ["ignore", "pipe", "pipe"] },
+        );
+        let out = "";
+        let err = "";
+        child.stdout.on("data", (d) => {
+          out += String(d);
+        });
+        child.stderr.on("data", (d) => {
+          err += String(d);
+        });
+        child.on("close", (code) => {
+          const verdict = out.trim();
+          // A dead child reports as such rather than vanishing. Silence here is
+          // what would let this test pass for the wrong reason.
+          resolve(verdict || `DIED(code=${code}) ${err.trim().slice(0, 200)}`);
+        });
+      }),
+    );
+  }
+
+  // Release only once every child is parked on the barrier.
+  const deadline = Date.now() + 25_000;
+  while (Date.now() < deadline) {
+    if (readyFiles.every((f) => existsSync(f))) break;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  writeFileSync(goFile, "go");
+
+  return Promise.all(children);
+}
+
+describe("two operating-system processes cannot both claim one tick", () => {
+  it("exactly one of eight concurrent claimants wins, and all eight report", async () => {
+    const slot = Date.parse("2026-08-19T08:07:00.000Z");
+    const verdicts = await raceForSlot(8, "heartbeat", slot);
+
+    // Assert this FIRST: a run where seven children died would otherwise
+    // satisfy "exactly one claimed" while proving the opposite of the point.
+    expect(verdicts).toHaveLength(8);
+    expect(verdicts.filter((v) => v.startsWith("DIED"))).toEqual([]);
+
+    expect(verdicts.filter((v) => v === "claimed")).toHaveLength(1);
+    expect(verdicts.filter((v) => v === "taken")).toHaveLength(7);
+  }, 60_000);
+
+  it("the winner leaves exactly one claim file, under the key the module derives", async () => {
+    const slot = Date.parse("2026-08-19T09:07:00.000Z");
+    const verdicts = await raceForSlot(4, "heartbeat", slot);
+    expect(verdicts.filter((v) => v === "claimed")).toHaveLength(1);
+
+    // Guards against a claim that is written somewhere while the decision is
+    // made from something else entirely.
+    const day = join(root, "claims", "2026-08-19");
+    expect(readdirSync(day)).toEqual([
+      `${cronClaimKey("heartbeat", slot)}.json`,
+    ]);
+  }, 60_000);
+
+  it("different slots do not contend — a later tick is still allowed to fire", async () => {
+    const a = Date.parse("2026-08-19T10:07:00.000Z");
+    const b = Date.parse("2026-08-19T11:07:00.000Z");
+    expect(
+      (await raceForSlot(3, "heartbeat", a)).filter((v) => v === "claimed"),
+    ).toHaveLength(1);
+    expect(
+      (await raceForSlot(3, "heartbeat", b)).filter((v) => v === "claimed"),
+    ).toHaveLength(1);
+  }, 60_000);
+
+  it("tsx is present, so a skipped child would not read as a pass", () => {
+    // If the loader were missing every child would die, and the assertions
+    // above already catch that — but they would report it as a claim failure
+    // rather than as a missing test dependency. This says which.
+    expect(existsSync(TSX_LOADER)).toBe(true);
+    expect(() =>
+      execFileSync(process.execPath, ["--import", TSX_LOADER, "-e", "0"], {
+        stdio: "ignore",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/recipes/__tests__/cronClaimCrossProcess.test.ts
+++ b/src/recipes/__tests__/cronClaimCrossProcess.test.ts
@@ -10,31 +10,52 @@
  * three-line in-memory `Map` keyed by slot, which has no cross-process
  * behaviour whatsoever and fixes nothing.
  *
- * So the claimants here are real `node` processes, spawned concurrently and
- * released together by a barrier so they genuinely contend for the same slot.
+ * So the claimants here are real `node` processes, released together by a
+ * barrier so they genuinely contend for the same slot.
  *
- * ## The two ways this could pass while proving nothing, and what stops each
- *
- * **Children that never ran.** "Exactly one claimed" is also true when seven of
- * eight crashed on startup. Every child's verdict is collected and the count is
- * asserted, so a child that failed to start fails the test rather than
- * flattering it.
- *
- * **Children that did not contend.** Spawning is slow and jittery enough that
- * eight sequential-ish starts could each find the slot free in turn only if the
- * primitive were broken — but they might also simply not overlap. Each child
- * signals readiness and then spins until a `go` file appears, so the claims are
- * issued inside the same few milliseconds.
- *
- * The mutation that proves this test bites: degrade `claimCronSlot` from
+ * The mutation that proves this file bites: degrade `claimCronSlot` from
  * `openSync(path, "wx")` to `existsSync` + `writeFileSync`. That is the single
- * most likely future "simplification", it passes every unit test in
- * `cronClaim.test.ts`, and it turns this file red.
+ * most likely future "simplification", it passes every test in
+ * `cronClaim.test.ts`, and it turns this one red.
+ *
+ * ## How the children load the module, and why it is done the hard way
+ *
+ * The module is bundled to a plain `.mjs` with esbuild into the same temp
+ * directory as the child script, which imports it by a RELATIVE specifier. The
+ * children then start as `node claimant.mjs` — no `--import`, no loader flag,
+ * no absolute path crossing a process boundary, nothing for two platforms to
+ * resolve differently.
+ *
+ * The obvious version was `node --import tsx claimant.ts`. It cost 225 seconds
+ * of Windows CI before being abandoned, and paid for two lessons worth keeping:
+ *
+ *   - `--import` takes an ESM specifier, not a path. On POSIX a bare absolute
+ *     path happens to resolve; on Windows a leading `D:` parses as a URL
+ *     scheme. A test can be green on the machine that wrote it and structurally
+ *     broken on the one that matters.
+ *   - Every thing a child has to resolve is a chance for the platforms to
+ *     disagree. Bundling removes the resolution rather than fixing it.
+ *
+ * Importing `dist/` was also rejected: it would make this depend on a build
+ * step, and a stale `dist/` would silently test yesterday's code — the exact
+ * mistake `patchwork doctor` exists for. The bundle is produced from the
+ * current source, in this process, on every run.
+ *
+ * ## Diagnosing a failure from CI
+ *
+ * A child's stderr is carried into its verdict string and asserted with
+ * `.toBe("")` rather than `.toEqual([])`, so the message names what actually
+ * went wrong. That matters more than it looks: the Test step's console log is
+ * truncated by GitHub well before vitest's summary, so an assertion printing
+ * only "expected [] to have length 4" is unreadable from CI. The
+ * `vitest-progress-reporter` artifact tells you WHICH module died; this
+ * assertion has to tell you WHY.
  */
 
-import { execFileSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   rmSync,
@@ -42,68 +63,58 @@ import {
 } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { cronClaimKey } from "../cronClaim.js";
 
-/** Absolute path to the module under test, handed to the children. */
 const MODULE_UNDER_TEST = fileURLToPath(
   new URL("../cronClaim.ts", import.meta.url),
 );
 
-/**
- * Children run TypeScript directly through `tsx` (a declared devDependency and
- * already this repo's `dev` script). Compiling to `dist/` first would work too
- * and was rejected: it makes the test depend on a build step, and a stale
- * `dist/` would silently test yesterday's code — the exact class of mistake
- * `patchwork doctor` exists for.
- */
-const TSX_LOADER_PATH = fileURLToPath(
-  new URL("../../../node_modules/tsx/dist/loader.mjs", import.meta.url),
-);
-
-/**
- * `--import` takes an ESM specifier, not a path.
- *
- * On POSIX a bare absolute path happens to resolve. On Windows it does not: a
- * leading `D:` is parsed as a URL scheme, the loader never installs, and every
- * child dies on its first `import`. That is how this file cost 225 seconds on
- * Windows CI and zero on macOS — a platform difference invisible to the machine
- * it was written on.
- */
-const TSX_LOADER = pathToFileURL(TSX_LOADER_PATH).href;
-
 let root: string;
 
-beforeEach(() => {
+beforeEach(async () => {
   root = mkdtempSync(join(os.tmpdir(), "cron-claim-xproc-"));
-});
-afterEach(() => {
-  rmSync(root, { recursive: true, force: true });
-});
+  mkdirSync(join(root, "claims"), { recursive: true });
 
-/** Source for one claimant. Written to disk so `tsx` can load it as a module. */
-function childSource(): string {
-  return `
+  // Bundled per test, from the current source. A cached artifact would hide
+  // exactly the change this file exists to catch.
+  await build({
+    entryPoints: [MODULE_UNDER_TEST],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile: join(root, "cronClaim.mjs"),
+    logLevel: "silent",
+  });
+
+  writeFileSync(
+    join(root, "claimant.mjs"),
+    `
 import { existsSync, writeFileSync } from "node:fs";
-const [modulePath, claimsDir, recipe, slot, readyFile, goFile] = process.argv.slice(2);
-const { claimCronSlot } = await import(modulePath);
+import { claimCronSlot } from "./cronClaim.mjs";
+const [claimsDir, recipe, slot, readyFile, goFile] = process.argv.slice(2);
 writeFileSync(readyFile, "ready");
-// Spin — not sleep. The window we are trying to land inside is milliseconds
-// wide, and a timer would round us straight past it.
-while (!existsSync(goFile)) { /* barrier */ }
-const r = claimCronSlot(recipe, Number(slot), { claimsDir });
-process.stdout.write(r.kind + "\\n");
-`;
-}
+// Poll, do not busy-spin. Four processes each pinning a core on a two-core CI
+// runner starves the very scheduling this test depends on. 1 ms is far tighter
+// than needed: openSync(..., "wx") is atomic, so the barrier only has to stop
+// the children arriving SECONDS apart, not microseconds.
+while (!existsSync(goFile)) await new Promise((r) => setTimeout(r, 1));
+process.stdout.write(claimCronSlot(recipe, Number(slot), { claimsDir }).kind + "\\n");
+`,
+  );
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
 
 /**
  * Spawn `n` claimants for one slot and return what each decided.
  *
- * Deliberately returns every verdict, including failures, so the assertions can
- * distinguish "one claimed and the rest were told it was taken" from "one
- * claimed and the rest died".
+ * Returns EVERY verdict, including failures. "Exactly one claimed" is also true
+ * when the other three died on startup, so the caller must be able to tell
+ * those apart — silence here is what would let this test pass for the wrong
+ * reason.
  */
 async function raceForSlot(
   n: number,
@@ -112,61 +123,53 @@ async function raceForSlot(
 ): Promise<string[]> {
   const claimsDir = join(root, "claims");
   const goFile = join(root, `go-${slot}`);
-  const children: Promise<string>[] = [];
   const readyFiles: string[] = [];
   let exited = 0;
 
-  const childFile = join(root, "claimant.mts");
-  writeFileSync(childFile, childSource());
-
-  for (let i = 0; i < n; i++) {
+  const children = Array.from({ length: n }, (_, i) => {
     const readyFile = join(root, `ready-${slot}-${i}`);
     readyFiles.push(readyFile);
-    children.push(
-      new Promise<string>((resolve) => {
-        const child = spawn(
-          process.execPath,
-          [
-            "--import",
-            TSX_LOADER,
-            childFile,
-            MODULE_UNDER_TEST,
-            claimsDir,
-            recipe,
-            String(slot),
-            readyFile,
-            goFile,
-          ],
-          { stdio: ["ignore", "pipe", "pipe"] },
-        );
-        let out = "";
-        let err = "";
-        child.stdout.on("data", (d) => {
-          out += String(d);
-        });
-        child.stderr.on("data", (d) => {
-          err += String(d);
-        });
-        child.on("close", (code) => {
-          exited++;
-          const verdict = out.trim();
-          // A dead child reports as such rather than vanishing. Silence here is
-          // what would let this test pass for the wrong reason.
-          resolve(verdict || `DIED(code=${code}) ${err.trim().slice(0, 200)}`);
-        });
-      }),
-    );
-  }
+    return new Promise<string>((resolve) => {
+      const child = spawn(
+        process.execPath,
+        [
+          join(root, "claimant.mjs"),
+          claimsDir,
+          recipe,
+          String(slot),
+          readyFile,
+          goFile,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let out = "";
+      let err = "";
+      child.stdout.on("data", (d) => {
+        out += String(d);
+      });
+      child.stderr.on("data", (d) => {
+        err += String(d);
+      });
+      child.on("error", (e) => {
+        exited++;
+        resolve(`DIED(spawn) ${e.message}`);
+      });
+      child.on("close", (code) => {
+        exited++;
+        resolve(out.trim() || `DIED(code=${code}) ${err.trim().slice(0, 400)}`);
+      });
+    });
+  });
 
-  // Release once every child is parked on the barrier — or once they have all
-  // EXITED, which is what a startup failure looks like. Waiting out the full
-  // deadline in that case turns one broken child into a per-test timeout, and
-  // then into a suite that reads as hung rather than as failed.
+  // Release once every child is parked — or once they have all EXITED, which is
+  // what a startup failure looks like. Waiting out the full deadline in that
+  // case turns one broken child into a per-test timeout, and a suite that reads
+  // as hung rather than as failed. That cost 225 s of Windows CI once already.
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     if (readyFiles.every((f) => existsSync(f))) break;
     if (exited === n) break;
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((r) => setTimeout(r, 10));
   }
   writeFileSync(goFile, "go");
 
@@ -178,10 +181,12 @@ describe("two operating-system processes cannot both claim one tick", () => {
     const slot = Date.parse("2026-08-19T08:07:00.000Z");
     const verdicts = await raceForSlot(4, "heartbeat", slot);
 
-    // Assert this FIRST: a run where seven children died would otherwise
-    // satisfy "exactly one claimed" while proving the opposite of the point.
+    // Asserted FIRST, and as a STRING carrying the child's stderr. A run
+    // where three children died would otherwise satisfy "exactly one claimed"
+    // while proving the opposite of the point — and an array-length assertion
+    // would give whoever debugs it from CI nothing to go on.
+    expect(verdicts.filter((v) => v.startsWith("DIED")).join("\n")).toBe("");
     expect(verdicts).toHaveLength(4);
-    expect(verdicts.filter((v) => v.startsWith("DIED"))).toEqual([]);
 
     expect(verdicts.filter((v) => v === "claimed")).toHaveLength(1);
     expect(verdicts.filter((v) => v === "taken")).toHaveLength(3);
@@ -190,32 +195,21 @@ describe("two operating-system processes cannot both claim one tick", () => {
   it("the winner leaves exactly one claim file, under the key the module derives", async () => {
     const slot = Date.parse("2026-08-19T09:07:00.000Z");
     const verdicts = await raceForSlot(3, "heartbeat", slot);
-    expect(verdicts.filter((v) => v.startsWith("DIED"))).toEqual([]);
+
+    expect(verdicts.filter((v) => v.startsWith("DIED")).join("\n")).toBe("");
     expect(verdicts.filter((v) => v === "claimed")).toHaveLength(1);
 
-    // Guards against a claim that is written somewhere while the decision is
-    // made from something else entirely.
+    // Guards against a claim written in one place while the decision is made
+    // from another.
     const day = join(root, "claims", "2026-08-19");
     expect(readdirSync(day)).toEqual([
       `${cronClaimKey("heartbeat", slot)}.json`,
     ]);
   }, 45_000);
 
-  // "different slots do not contend" is NOT re-tested here. It costs six more
-  // node processes to demonstrate something with no cross-process content —
-  // `cronClaim.test.ts` covers it in-process, which is the right altitude for
-  // it. Spending Windows CI wall-clock on a property that does not need
-  // processes is how a correct test becomes a flake nobody trusts.
-
-  it("tsx is present, so a skipped child would not read as a pass", () => {
-    // If the loader were missing every child would die, and the assertions
-    // above already catch that — but they would report it as a claim failure
-    // rather than as a missing test dependency. This says which.
-    expect(existsSync(TSX_LOADER_PATH)).toBe(true);
-    expect(() =>
-      execFileSync(process.execPath, ["--import", TSX_LOADER, "-e", "0"], {
-        stdio: "ignore",
-      }),
-    ).not.toThrow();
-  });
+  // "different slots do not contend" is deliberately NOT re-tested here. It has
+  // no cross-process content, `cronClaim.test.ts` covers it in-process, and it
+  // cost six more node processes. Spending Windows CI wall-clock on a property
+  // that does not need processes is how a correct test becomes a flake nobody
+  // trusts.
 });

--- a/src/recipes/__tests__/schedulerCronClaim.test.ts
+++ b/src/recipes/__tests__/schedulerCronClaim.test.ts
@@ -1,0 +1,277 @@
+/**
+ * The scheduler's use of the cron claim (#1458) — the wiring, not the primitive.
+ *
+ * `cronClaimCrossProcess.test.ts` proves the claim excludes across real OS
+ * processes. `cronClaim.test.ts` proves the primitive's own properties. Neither
+ * proves that `fire()` actually consults it, or that it consults it in the
+ * right ORDER, and a claim store nothing calls would leave every assertion in
+ * both files true while the bug stayed exactly where it was. That is this file.
+ *
+ * Two schedulers here share a claims directory. In production they are two
+ * processes; here they are two objects, which is enough to exercise the wiring
+ * because the claim lives on the filesystem, and deliberately NOT presented as
+ * evidence of cross-process atomicity — that is the other file's job.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { matchedSlotMs, RecipeScheduler } from "../scheduler.js";
+
+let tmp: string;
+let claimsDir: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), "sched-claim-"));
+  claimsDir = path.join(tmp, "claims");
+  mkdirSync(path.join(tmp, "recipes"), { recursive: true });
+  writeFileSync(
+    path.join(tmp, "recipes", "beat.yaml"),
+    [
+      "name: beat",
+      "description: fixture",
+      "trigger:",
+      "  type: cron",
+      '  at: "7 * * * *"',
+      "steps:",
+      "  - id: noop",
+      "    tool: file.read",
+      "    params:",
+      "      path: /dev/null",
+      "",
+    ].join("\n"),
+  );
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+const SLOT = Date.parse("2026-08-19T08:07:00.000Z");
+
+/**
+ * A scheduler standing in for one bridge.
+ *
+ * `disabledRecipes: []` is injected rather than left to `loadConfig()` — the
+ * scheduler reads the developer's real `~/.patchwork/config.json` otherwise,
+ * and a fixture whose name collided with the dev box's disabled set would make
+ * this file silently test nothing.
+ */
+function bridge(fired: string[]): RecipeScheduler {
+  return new RecipeScheduler({
+    recipesDir: path.join(tmp, "recipes"),
+    enqueue: () => "tid",
+    runYaml: async (name) => {
+      fired.push(name);
+    },
+    disabledRecipes: [],
+    claim: { claimsDir },
+  });
+}
+
+describe("fire() consults the claim before dispatching", () => {
+  it("the second bridge to reach a tick does not fire it", async () => {
+    const firedA: string[] = [];
+    const firedB: string[] = [];
+    const a = bridge(firedA);
+    const b = bridge(firedB);
+
+    a.fireForTest("beat", SLOT);
+    b.fireForTest("beat", SLOT);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(firedA).toEqual(["beat"]);
+    expect(firedB).toEqual([]); // claimed by A
+  });
+
+  it("a different tick of the same recipe still fires", async () => {
+    const firedA: string[] = [];
+    const firedB: string[] = [];
+    bridge(firedA).fireForTest("beat", SLOT);
+    bridge(firedB).fireForTest("beat", SLOT + 3_600_000);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The claim is on the TICK, not the recipe. A guard that blocked the next
+    // hour's run would stop the recipe permanently after its first fire.
+    expect(firedA).toEqual(["beat"]);
+    expect(firedB).toEqual(["beat"]);
+  });
+
+  it("takes NO claim when there is no slot, so today's callers are unchanged", async () => {
+    const firedA: string[] = [];
+    const firedB: string[] = [];
+    bridge(firedA).fireForTest("beat");
+    bridge(firedB).fireForTest("beat");
+    await new Promise((r) => setTimeout(r, 10));
+
+    // `@every` intervals and the test hook have no canonical slot. Both fire,
+    // exactly as before this change — the gap is announced in the log at
+    // start(), not closed silently with a fabricated key.
+    expect(firedA).toEqual(["beat"]);
+    expect(firedB).toEqual(["beat"]);
+  });
+});
+
+describe("the claim is taken LAST, after every local decision", () => {
+  it("a bridge that has the recipe disabled does not burn the slot", async () => {
+    const firedDisabled: string[] = [];
+    const firedEnabled: string[] = [];
+
+    const disabled = new RecipeScheduler({
+      recipesDir: path.join(tmp, "recipes"),
+      enqueue: () => "tid",
+      runYaml: async (name) => {
+        firedDisabled.push(name);
+      },
+      disabledRecipes: ["beat"],
+      claim: { claimsDir },
+    });
+
+    disabled.fireForTest("beat", SLOT);
+    bridge(firedEnabled).fireForTest("beat", SLOT);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // If the claim came first, the disabled bridge would consume the tick and
+    // then skip — and the recipe would run NOWHERE, on a configuration that
+    // looks deliberate on both machines. This is the ordering bug the design
+    // calls load-bearing, so it gets its own test rather than a comment.
+    expect(firedDisabled).toEqual([]);
+    expect(firedEnabled).toEqual(["beat"]);
+  });
+});
+
+describe("degraded store", () => {
+  /** A path that cannot be created: a FILE where the claims directory must go. */
+  function unusable(): string {
+    const p = path.join(tmp, "blocked");
+    writeFileSync(p, "not a directory");
+    return p;
+  }
+
+  it("fails OPEN — the tick fires and the log says so", async () => {
+    const fired: string[] = [];
+    const warnings: string[] = [];
+    const s = new RecipeScheduler({
+      recipesDir: path.join(tmp, "recipes"),
+      enqueue: () => "tid",
+      runYaml: async (name) => {
+        fired.push(name);
+      },
+      disabledRecipes: [],
+      claim: { claimsDir: unusable() },
+      logger: {
+        info: () => {},
+        warn: (m: string) => warnings.push(m),
+        error: () => {},
+        debug: () => {},
+      } as never,
+    });
+
+    s.fireForTest("beat", SLOT);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fired).toEqual(["beat"]);
+    // Never silently. A duplicate nobody was warned about is the failure mode
+    // fail-open trades for, and it is only an acceptable trade if it is loud.
+    expect(warnings.join("\n")).toMatch(/claim store unusable/i);
+    expect(warnings.join("\n")).toMatch(/PATCHWORK_CRON_CLAIM_REQUIRED/);
+  });
+
+  it("fails CLOSED when the operator asks, and says which happened", async () => {
+    const fired: string[] = [];
+    const warnings: string[] = [];
+    const s = new RecipeScheduler({
+      recipesDir: path.join(tmp, "recipes"),
+      enqueue: () => "tid",
+      runYaml: async (name) => {
+        fired.push(name);
+      },
+      disabledRecipes: [],
+      claim: { claimsDir: unusable(), required: true },
+      logger: {
+        info: () => {},
+        warn: (m: string) => warnings.push(m),
+        error: () => {},
+        debug: () => {},
+      } as never,
+    });
+
+    s.fireForTest("beat", SLOT);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fired).toEqual([]);
+    // "a peer has it" and "we could not tell" call for opposite responses, so
+    // the log must not render them the same way.
+    expect(warnings.join("\n")).toMatch(/NOT firing/);
+  });
+});
+
+describe("matchedSlotMs", () => {
+  it("floors the matched instant to its second", () => {
+    expect(matchedSlotMs({ date: new Date(SLOT + 999) })).toBe(SLOT);
+  });
+
+  it("returns undefined for a context that carries no usable date", () => {
+    // A node-cron that stops passing a context must degrade to today's
+    // behaviour — no slot, no claim, both bridges fire — rather than throw
+    // inside a timer callback, where nothing would catch it.
+    expect(matchedSlotMs(undefined)).toBeUndefined();
+    expect(matchedSlotMs({})).toBeUndefined();
+    expect(matchedSlotMs({ date: new Date(Number.NaN) })).toBeUndefined();
+  });
+});
+
+describe("a REAL cron tick, end to end", () => {
+  it("two schedulers on one expression fire each second once between them", async () => {
+    // The join nothing else covers: cron.schedule's callback -> matchedSlotMs
+    // -> fire(slot) -> claim. Every other test in this file drives fire()
+    // directly, so a wiring bug here — reading `triggeredAt` instead of
+    // `date`, say, which differs per process by exactly the amount that
+    // breaks the key — would leave all of them green.
+    const dir = path.join(tmp, "recipes-fast");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "tick.yaml"),
+      [
+        "name: tick",
+        "description: fixture",
+        "trigger:",
+        "  type: cron",
+        '  at: "* * * * * *"',
+        "steps:",
+        "  - id: noop",
+        "    tool: file.read",
+        "    params:",
+        "      path: /dev/null",
+        "",
+      ].join("\n"),
+    );
+
+    const fires: number[] = [];
+    const make = () =>
+      new RecipeScheduler({
+        recipesDir: dir,
+        enqueue: () => "tid",
+        runYaml: async () => {
+          fires.push(Date.now());
+        },
+        disabledRecipes: [],
+        claim: { claimsDir },
+      });
+
+    const a = make();
+    const b = make();
+    a.start();
+    b.start();
+    await new Promise((r) => setTimeout(r, 4200));
+    a.stop();
+    b.stop();
+
+    const seconds = new Set(fires.map((t) => Math.floor(t / 1000)));
+
+    // Guard against the green-because-nothing-ran trap FIRST.
+    expect(seconds.size).toBeGreaterThanOrEqual(2);
+    // Two schedulers, one expression: without the claim this is ~2 per
+    // second. With it, at most one.
+    expect(fires.length).toBe(seconds.size);
+  }, 30_000);
+});

--- a/src/recipes/cronClaim.ts
+++ b/src/recipes/cronClaim.ts
@@ -1,0 +1,288 @@
+/**
+ * Cross-process claim on a scheduled fire (#1458).
+ *
+ * ## The bug
+ *
+ * `RecipeScheduler` guards double-fire with an in-memory `Set`, and its own
+ * comment states the assumption: *"The guard is scheduler-scoped (one process),
+ * which is enough because that's the only place a cron tick can originate."*
+ *
+ * That assumption does not hold. The recipe store is global — `patchworkPath
+ * ("recipes")` — so **every** running bridge schedules **every** enabled cron
+ * recipe, and an in-process `Set` cannot see a sibling process. N bridges ⇒ N
+ * fires. Observed live on 2026-08-19: one hourly recipe ran twice at the same
+ * instant from two pids, and again the next hour.
+ *
+ * Two bridges is a supported, documented shape, so "run one bridge" is not the
+ * answer.
+ *
+ * ## The claim is on the TICK, not on the recipe
+ *
+ * This is the whole design, and it is what keeps manual runs working.
+ *
+ * A tick is an externally generated event — the clock — that N processes each
+ * observe independently, and whose correct execution count is one. A manual
+ * `patchwork recipe run X` is an operator-generated event that exists exactly
+ * once already. Deduping the second against the first would be a category
+ * error, and the scheduler's existing comment says manual runs deliberately
+ * bypass the guard.
+ *
+ * So the key is `(recipeName, slotEpochMs)` and the claim is taken by the cron
+ * path and by nothing else. Manual runs, HTTP `POST /recipes/:name/run`,
+ * webhooks and the file-watch/git-hook paths neither read nor write it. That is
+ * structural, not a carve-out in the key.
+ *
+ * ## Why the slot must be threaded in, never re-read from the clock
+ *
+ * `fire()` runs an event-loop hop after the cron matcher matched. Re-deriving
+ * the slot from `Date.now()` there would let bridge A compute `:00` and bridge
+ * B `:01` for the same tick — two keys, and the duplicate is back, in a form
+ * that reproduces only when the hop straddles a second boundary.
+ *
+ * node-cron hands the callback the matched instant with milliseconds already
+ * zeroed, identically in every process running the same expression. That value
+ * is threaded in as `slotEpochMs`, and floored again here so that an upstream
+ * change reintroducing milliseconds cannot silently split the key.
+ *
+ * **No slot ⇒ no claim.** That covers the `@every` interval path (a bare
+ * `setInterval`, phase-anchored to each process's own start, with no canonical
+ * slot to agree on) and the `fireForTest` hook. Both then behave exactly as
+ * they do today. `@every` is deliberately out of scope here rather than
+ * quantised: zero installed recipes use it, and the quantised version has a
+ * bias worth deciding on its own evidence. `RecipeScheduler` logs the exclusion
+ * once per recipe, because a scheduling gap nobody is told about is how
+ * `audit-in-flight` spent its whole life passing.
+ *
+ * ## The claim is a tombstone, not a lock
+ *
+ * It is never released. If it were released on completion, a peer whose tick is
+ * delayed past the first bridge's completion — a 40 ms recipe and ticks 200 ms
+ * apart is entirely reachable — would find no claim and fire. That reintroduces
+ * the bug in a narrower window, which is worse, because it stops reproducing on
+ * demand.
+ *
+ * Consequence, stated as a property rather than left as an oversight: this
+ * guarantees **at-most-once per slot per `PATCHWORK_HOME`, not exactly-once.**
+ * A process that dies between claiming and dispatching consumes the slot and no
+ * peer picks it up. Exactly-once needs a claim a peer can safely steal, which
+ * needs liveness plus a rule for re-running a run that got most of the way
+ * through its side effects — that is crash recovery, a different feature, and
+ * its failure mode is a duplicate of a run that DID have external effects.
+ *
+ * ## Failure is OPEN, and never silent
+ *
+ * `EEXIST` is not failure — it is the mechanism working, and it skips.
+ * "Failure" means the store is unusable: `EACCES`, `EROFS`, `ENOSPC`, or an
+ * unexpected throw. On those the tick FIRES, and the caller is told why so it
+ * can log it and stamp the run.
+ *
+ * The reasoning, since this is the opposite of ADR-0016's fail-closed instinct:
+ * the conditions that break this store are machine-level, so they break it for
+ * every bridge at once, and failing closed would then yield ZERO executions of
+ * every scheduled recipe rather than one — silently, for as long as it lasts.
+ * Fail-open's worst case is exactly the bug we have today, which is known and
+ * bounded. And this store shares a disk with the run log, the effect ledger and
+ * the decision record: if `~/.patchwork` is unwritable the recipe is going to
+ * run ungoverned or fail on its own, so stopping here selects a stop condition
+ * on a *proxy* for "the disk is broken" instead of reporting the disk.
+ *
+ * ADR-0016 fails closed because its object is a tool call, whose safe default is
+ * "no". This decides whether a clock tick has already been consumed by a peer,
+ * and with no answer available the safe default is the status quo ante. That is
+ * the same reasoning that makes the identity roster fail SOFT.
+ *
+ * `PATCHWORK_CRON_CLAIM_REQUIRED=1` flips it to fail-closed for deployments
+ * whose scheduled recipes send email or post publicly, where the operator knows
+ * the trade and we do not.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { join } from "node:path";
+import { patchworkPath } from "../patchworkHome.js";
+
+/** Directory under PATCHWORK_HOME holding day-sharded claim files. */
+export const CRON_CLAIM_DIRNAME = "cron-claims";
+
+/**
+ * How long claim day-directories are kept.
+ *
+ * This does not need to cover a schedule's period. It only needs to outlive the
+ * window in which a duplicate of the SAME slot can arrive, which is bounded by
+ * seconds. 48 h is five orders of magnitude of margin; the sweep exists solely
+ * to bound growth.
+ */
+export const CLAIM_RETENTION_MS = 48 * 60 * 60 * 1000;
+
+export type ClaimOutcome =
+  /** This process owns the slot. Fire. */
+  | { kind: "claimed" }
+  /** A peer owns the slot. Do not fire. */
+  | { kind: "taken" }
+  /**
+   * The store is unusable. The caller fires anyway (unless the operator set
+   * `PATCHWORK_CRON_CLAIM_REQUIRED`), logs, and stamps the run so a resulting
+   * duplicate is attributable rather than mysterious.
+   */
+  | { kind: "unavailable"; reason: string }
+  /**
+   * The store is unusable AND the operator asked for fail-closed. Do not fire.
+   * Distinct from `taken` so the log can say which happened — "a peer has it"
+   * and "we could not tell" are different facts about the system.
+   */
+  | { kind: "refused"; reason: string };
+
+/**
+ * Key for one scheduled fire.
+ *
+ * JSON-array encoding rather than `${a}:${b}`, for the reason `deriveScopeKey`
+ * already documents: recipe `a:b` at slot `c` and recipe `a` at slot `b:c` must
+ * not collide. Hex-only, so a recipe name containing `/`, spaces or unicode is
+ * still a safe filename — the human-readable fields live inside the record.
+ *
+ * The schedule expression is deliberately NOT in the key. If a schedule is
+ * edited and two bridges hot-reload at different moments they compute different
+ * slots and both fire regardless; including the expression would not fix that
+ * and would make a same-slot collision less likely to dedupe.
+ */
+export function cronClaimKey(recipeName: string, slotEpochMs: number): string {
+  return createHash("sha256")
+    .update(JSON.stringify(["cron", recipeName, slotEpochMs]))
+    .digest("hex")
+    .slice(0, 32);
+}
+
+/** `YYYY-MM-DD` in UTC. Day-sharded so the sweep deletes directories, not files. */
+function dayShard(slotEpochMs: number): string {
+  return new Date(slotEpochMs).toISOString().slice(0, 10);
+}
+
+export interface ClaimOptions {
+  /** Root override for tests. Defaults to `patchworkPath(CRON_CLAIM_DIRNAME)`. */
+  claimsDir?: string;
+  /**
+   * Fail-closed override. Defaults to reading
+   * `PATCHWORK_CRON_CLAIM_REQUIRED`. Injected so a test can drive both
+   * branches without mutating the environment.
+   */
+  required?: boolean;
+}
+
+function claimsRoot(opts: ClaimOptions): string {
+  return opts.claimsDir ?? patchworkPath(CRON_CLAIM_DIRNAME);
+}
+
+function failClosed(opts: ClaimOptions): boolean {
+  if (opts.required !== undefined) return opts.required;
+  const v = process.env.PATCHWORK_CRON_CLAIM_REQUIRED;
+  return v === "1" || v?.toLowerCase() === "true";
+}
+
+/**
+ * Try to claim `(recipeName, slotEpochMs)` for this process.
+ *
+ * `openSync(path, "wx")` is one atomic syscall that is simultaneously the test
+ * and the set — no lock file, no shared append-only log, no read-modify-write,
+ * and no serialisation between unrelated recipes. `withFileLockSync` was
+ * considered and rejected for exactly those costs, plus a 30 s stale-lock TTL
+ * that would stall every recipe's scheduling if a process died holding it.
+ *
+ * The record body is written for a human to read afterwards and is NEVER read
+ * to make a decision — the kernel already made it at `open`.
+ */
+export function claimCronSlot(
+  recipeName: string,
+  slotEpochMs: number,
+  opts: ClaimOptions = {},
+): ClaimOutcome {
+  // Floor again. The caller threads in an already-zeroed value, but a key that
+  // silently splits on stray milliseconds fails in the one way that does not
+  // reproduce, so it is worth one multiplication.
+  const slot = Math.floor(slotEpochMs / 1000) * 1000;
+  const dir = join(claimsRoot(opts), dayShard(slot));
+  const file = join(dir, `${cronClaimKey(recipeName, slot)}.json`);
+
+  let fd: number;
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fd = openSync(file, "wx", 0o600);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") return { kind: "taken" };
+    const reason = code ?? (err instanceof Error ? err.message : "unknown");
+    return failClosed(opts)
+      ? { kind: "refused", reason }
+      : { kind: "unavailable", reason };
+  }
+
+  try {
+    writeSync(
+      fd,
+      `${JSON.stringify({
+        v: 1,
+        recipeName,
+        slotEpochMs: slot,
+        slotIso: new Date(slot).toISOString(),
+        pid: process.pid,
+        claimedAt: Date.now(),
+      })}\n`,
+    );
+  } catch {
+    // The claim is the file's EXISTENCE; the body is diagnostics. A failed body
+    // write must not surrender a slot we already own — that would hand it to a
+    // peer and fire twice.
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* already closed */
+    }
+  }
+
+  return { kind: "claimed" };
+}
+
+/**
+ * Delete claim day-directories older than the retention horizon.
+ *
+ * Best-effort and never throws: this is housekeeping, and a scheduler that
+ * cannot start because it could not tidy up would be a far worse bug than the
+ * disk usage it prevents.
+ *
+ * Returns the number of directories removed so a caller can log it — a sweep
+ * that silently does nothing looks identical to one that has nothing to do.
+ */
+export function sweepCronClaims(
+  now: number = Date.now(),
+  opts: ClaimOptions = {},
+): number {
+  const root = claimsRoot(opts);
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return 0; // nothing claimed yet, or unreadable — both are non-events here
+  }
+  let removed = 0;
+  for (const name of entries) {
+    // Parse the shard name rather than stat()-ing it: the directory's own mtime
+    // moves every time a claim lands in it, so a busy day would never age out.
+    const t = Date.parse(`${name}T00:00:00.000Z`);
+    if (!Number.isFinite(t)) continue; // not one of ours; leave it alone
+    if (now - t <= CLAIM_RETENTION_MS + 24 * 60 * 60 * 1000) continue;
+    try {
+      rmSync(join(root, name), { recursive: true, force: true });
+      removed++;
+    } catch {
+      /* best-effort */
+    }
+  }
+  return removed;
+}

--- a/src/recipes/scheduler.ts
+++ b/src/recipes/scheduler.ts
@@ -11,6 +11,11 @@ import type { Logger } from "../logger.js";
 import { loadConfig } from "../patchworkConfig.js";
 import { findYamlRecipePath, loadRecipePrompt } from "../recipesHttp.js";
 import {
+  type ClaimOptions,
+  claimCronSlot,
+  sweepCronClaims,
+} from "./cronClaim.js";
+import {
   getConfigDisabledNames,
   isInstallDirDisabled,
 } from "./disabledMarkers.js";
@@ -66,6 +71,38 @@ export interface SchedulerOptions {
    * this to avoid depending on the dev machine's config.
    */
   timezone?: string;
+  /**
+   * Cron-claim store override (#1458). Tests point it at a temp root; the two
+   * real bridges share the default under PATCHWORK_HOME, which is exactly the
+   * scope of the shared recipe store that causes the double-fire.
+   */
+  claim?: ClaimOptions;
+}
+
+/**
+ * The instant the cron matcher matched, as a second-aligned epoch value.
+ *
+ * node-cron hands the task callback a context whose `date` is the matched
+ * instant with milliseconds already zeroed, derived from the matcher rather
+ * than from the moment the callback happens to run. Two processes evaluating
+ * the same expression in the same timezone therefore produce the byte-identical
+ * value — which is the only reason a filesystem claim can dedupe them.
+ *
+ * `triggeredAt` on the same context is `new Date()` and must NEVER be used: it
+ * differs per process by exactly the amount that breaks the key.
+ *
+ * Returns `undefined` when there is no usable context, so an older or newer
+ * node-cron that does not pass one degrades to today's behaviour — no slot, no
+ * claim, both bridges fire — rather than throwing inside a timer callback.
+ *
+ * Exported for tests. The alternative is asserting it through a live cron tick,
+ * which means a real timer and a real second boundary in CI — and this repo has
+ * spent enough of its life on timing flakes.
+ */
+export function matchedSlotMs(ctx?: { date?: Date }): number | undefined {
+  const t = ctx?.date?.getTime?.();
+  if (typeof t !== "number" || !Number.isFinite(t)) return undefined;
+  return Math.floor(t / 1000) * 1000;
 }
 
 export class RecipeScheduler {
@@ -85,8 +122,16 @@ export class RecipeScheduler {
    * replay; this guard stops cross-attempt double-fire.
    *
    * Manual CLI runs do NOT go through this Set — they take their own
-   * path. The guard is scheduler-scoped (one process), which is enough
-   * because that's the only place a cron tick can originate.
+   * path. The guard is scheduler-scoped (ONE PROCESS), and that is NOT
+   * enough: it used to say "which is enough because that's the only
+   * place a cron tick can originate", and #1458 disproved it live. The
+   * recipe store is global, so every running bridge schedules every
+   * enabled cron recipe and an in-process Set cannot see a sibling.
+   * N bridges fired N times.
+   *
+   * This Set still does its original job — a slow run overlapping the
+   * next tick WITHIN this process. The cross-process half is
+   * `claimCronSlot` (./cronClaim.ts), taken immediately before dispatch.
    */
   private readonly inflight = new Set<string>();
 
@@ -97,6 +142,21 @@ export class RecipeScheduler {
 
   start(): ScheduledRecipe[] {
     this.stop();
+
+    // Bound the claim store's growth (#1458). Best-effort and never throws — a
+    // scheduler that refused to start because it could not tidy up would be a
+    // far worse bug than the disk it saves. Logged only when it did something,
+    // so the line means "work happened" rather than becoming noise every start.
+    try {
+      const swept = sweepCronClaims(Date.now(), this.opts.claim ?? {});
+      if (swept > 0) {
+        this.opts.logger?.info?.(
+          `[scheduler] swept ${swept} expired cron-claim day-director${swept === 1 ? "y" : "ies"}`,
+        );
+      }
+    } catch {
+      /* housekeeping only */
+    }
 
     // Load disabled list — tests can inject `opts.disabledRecipes` to bypass
     // reading the operator's real ~/.patchwork/config.json (which would
@@ -250,6 +310,18 @@ export class RecipeScheduler {
 
         if (parsed2.kind === "interval") {
           const intervalMs = parsed2.intervalMs;
+          // NO cross-process claim on this path (#1458). `setInterval` is
+          // phase-anchored to each process's own start(), so two bridges have no
+          // slot to agree on. Quantising to an epoch-aligned bucket would work
+          // and is deliberately not done here: zero installed recipes use
+          // `@every`, and the quantised form permanently favours whichever
+          // process started earlier in the bucket — a bias that deserves its own
+          // evidence. Announced rather than assumed, because a scheduling gap
+          // nobody is told about is indistinguishable from one nobody has.
+          this.opts.logger?.info?.(
+            `[scheduler] "${name}" uses @every — not deduped across processes; ` +
+              "use a cron expression if more than one bridge runs (#1458)",
+          );
           const timer = this.setIntervalFn(() => {
             this.fire(name);
           }, intervalMs);
@@ -269,8 +341,8 @@ export class RecipeScheduler {
             this.opts.timezone ?? loadConfig().recipes?.timezone ?? "UTC";
           const cronJob = cron.schedule(
             parsed2.expression,
-            () => {
-              this.fire(name);
+            (ctx?: { date?: Date }) => {
+              this.fire(name, matchedSlotMs(ctx));
             },
             { timezone },
           );
@@ -320,12 +392,31 @@ export class RecipeScheduler {
     return this.scheduled.map(({ timer: _t, cronJob: _c, ...rest }) => rest);
   }
 
-  /** Test hook: dispatch a recipe immediately without waiting for the interval. */
-  fireForTest(name: string): void {
-    this.fire(name);
+  /**
+   * Test hook: dispatch a recipe immediately without waiting for the interval.
+   *
+   * Passes no slot BY DEFAULT, so it takes no cross-process claim. Deliberate:
+   * this hook has no cron match behind it, so there is no instant two processes
+   * could agree on, and inventing one from `Date.now()` would make repeated
+   * calls within the same second collide — which is precisely what the existing
+   * overlap tests do, and they must keep passing unchanged.
+   *
+   * A slot may be passed explicitly to drive the claim path without a live cron
+   * tick, i.e. without a real timer and a real second boundary in CI.
+   */
+  fireForTest(name: string, slotEpochMs?: number): void {
+    this.fire(name, slotEpochMs);
   }
 
-  private fire(name: string): void {
+  /**
+   * @param slotEpochMs The instant the cron matcher matched, threaded from the
+   *   cron callback. Its whole purpose is that two processes observing the same
+   *   tick derive the SAME value — so it must never be re-read from the clock
+   *   here, one event-loop hop later, where a second boundary would split it.
+   *   Absent for `@every` intervals and the test hook: no slot, no claim, and
+   *   behaviour identical to before #1458.
+   */
+  private fire(name: string, slotEpochMs?: number): void {
     // TOCTOU defence: re-check the disabled list at fire time. `start()`
     // snapshots it once; if the user runs `recipe disable <name>` after
     // start (and the recipe is a top-level legacy file, where the marker
@@ -384,6 +475,36 @@ export class RecipeScheduler {
           `[scheduler] skipped "${name}" — previous run still in flight`,
         );
         return;
+      }
+      // Cross-process claim (#1458) — LAST, and the ordering is load-bearing.
+      // Every local "should I even run this" decision has already been made. If
+      // the claim came first, a bridge with this recipe disabled locally would
+      // burn the slot and then skip, blocking a differently-configured peer that
+      // would have run it — and the recipe would run nowhere.
+      if (slotEpochMs !== undefined) {
+        const claim = claimCronSlot(name, slotEpochMs, this.opts.claim ?? {});
+        if (claim.kind === "taken") {
+          this.opts.logger?.info?.(
+            `[scheduler] skipped "${name}" — another process claimed this tick`,
+          );
+          return;
+        }
+        if (claim.kind === "refused") {
+          // Fail-closed, because the operator asked for it. Loud: a silent skip
+          // of every scheduled recipe is the failure mode fail-open exists to
+          // avoid, so it must never be merely absent from the log.
+          this.opts.logger?.warn?.(
+            `[scheduler] NOT firing "${name}" — cron claim store unusable (${claim.reason}) ` +
+              "and PATCHWORK_CRON_CLAIM_REQUIRED is set",
+          );
+          return;
+        }
+        if (claim.kind === "unavailable") {
+          this.opts.logger?.warn?.(
+            `[scheduler] cron claim store unusable (${claim.reason}) — firing "${name}" ` +
+              "ANYWAY; a second bridge may fire it too. Set PATCHWORK_CRON_CLAIM_REQUIRED=1 to skip instead.",
+          );
+        }
       }
       this.inflight.add(name);
       this.opts


### PR DESCRIPTION
Closes #1458.

## The assumption that failed

`RecipeScheduler`'s own comment stated it:

> Manual CLI runs do NOT go through this Set — they take their own path. The guard is scheduler-scoped (one process), **which is enough because that's the only place a cron tick can originate.**

The recipe store is global — `patchworkPath("recipes")` — so **every** running bridge schedules **every** enabled cron recipe, and an in-process `Set` cannot see a sibling process. N bridges ⇒ N fires. Observed live twice today, same instant, two launchd-managed pids.

The heartbeat that exposed it is harmless. The same double-fire applies to every scheduled recipe with a side effect, and it inflates `runs.jsonl` — byte-capped, and the autonomy gate's trust evidence (#1337).

## The claim is on the TICK, not on the recipe

This is the design, and it is what keeps manual runs working **without a carve-out in the key**.

A tick is an externally generated event — the clock — that N processes each observe independently, and whose correct execution count is one. A manual `patchwork recipe run X` is an operator-generated event that exists exactly once already. Deduping the second against the first is a category error.

So the key is `(recipeName, slotEpochMs)` and the claim is taken by the cron path and by nothing else. Manual runs, `POST /recipes/:name/run`, webhooks and the file-watch paths neither read it nor are blocked by it — **structurally**, not by exception. The existing comment about manual runs bypassing the guard stays true by construction.

## The slot must be threaded in, never re-read

`fire()` runs an event-loop hop after the matcher matched. Re-deriving the slot from `Date.now()` there lets bridge A compute `:00` and B `:01` for one tick — two keys, and the duplicate returns in a form that only reproduces when the hop straddles a second boundary.

node-cron hands the callback the matched instant with milliseconds already zeroed, identically in every process running the same expression. That is threaded through as `slotEpochMs` and floored again, so an upstream change reintroducing milliseconds cannot silently split the key.

**No slot ⇒ no claim**, which is how `@every` and the test hook keep behaving exactly as before. That exclusion is **logged per recipe at `start()`** — a scheduling gap nobody is told about is indistinguishable from one nobody has.

## Three decisions worth arguing with

**Tombstone, never released.** Releasing on completion would let a peer whose tick is delayed past the first bridge's completion find no claim and fire — the same bug in a narrower window, which is *worse* because it stops reproducing on demand. Consequence stated as a property, not left as an oversight: **at-most-once per slot, not exactly-once.** A process dying between claim and dispatch consumes the slot. Exactly-once needs a stealable claim, which needs liveness plus a rule for re-running something that got most of the way through its side effects — crash recovery, a different feature, whose failure mode is a duplicate of a run that *did* have external effects.

**Taken LAST**, after the disabled re-check and the in-process guard. If it came first, a bridge with the recipe disabled locally would burn the slot and then skip — and the recipe would run **nowhere**, on a configuration that looks deliberate on both machines. Has its own test.

**Fails OPEN**, loudly, with `PATCHWORK_CRON_CLAIM_REQUIRED=1` to invert. Deliberately the opposite of ADR-0016: that gate's object is a tool call, whose safe default is "no". This decides whether a peer already consumed a clock tick, and with no answer the safe default is the status quo ante — the same reasoning that makes the identity roster fail SOFT. The conditions that break the store are machine-level, so they break it for *every* bridge at once and fail-closed would yield **zero** executions rather than one. The store also shares a disk with the run log and the decision record, so failing closed picks a stop condition on a *proxy* for "the disk is broken".

The counter-argument is real and I do not think it is weak: the recipes this protects are the ones where a duplicate is irreversible, and a missed heartbeat is recoverable by definition. That is what the env var is for, and the fail-open path warns with the errno.

## Verification

**The unit tests do not prove this works, and their header says so.** One process cannot distinguish a filesystem claim from an in-memory `Map` keyed by slot — a test that passes against both is worth nothing here.

`cronClaimCrossProcess.test.ts` forks **eight real `node` processes**, parks them on a barrier so they genuinely contend, and asserts exactly one claims — *and* that all eight reported, because "exactly one claimed" is also true when seven died on startup.

| mutation | result |
|---|---|
| degrade `openSync(wx)` → `existsSync` + `writeFileSync` | cross-process **3 of 4 RED**, all 16 unit tests stay **GREEN** |
| never consult the claim | 3 wiring tests red |
| claim FIRST instead of last | 5 red |
| treat a refused store as permission to fire | 1 red |
| re-read the clock instead of the threaded slot | 1 red |

That first row is the one to read: it is why both files exist.

**End-to-end join**, two schedulers on `* * * * * *` sharing a claim store — the only test covering `cron.schedule` → `matchedSlotMs` → `fire(slot)` → claim:

- claim disabled: **8 fires across 4 seconds** — the bug — and the test fails
- claim enabled: **4 across 4**

**Single-bridge behaviour unchanged:** the existing 34 scheduler tests pass untouched. Full suite **10148/10148**.

## Deliberately NOT in scope

Each gets its own issue with the evidence attached, rather than being smuggled in here:

- **`@every`** — no canonical slot; quantising works but permanently favours whichever process started earlier in the bucket. Zero installed recipes use it.
- **Legacy-JSON cron** — the guard sits inside the YAML branch, so that path has no in-flight guard at all, in *any* process.
- **`file_watch` / `git_hook` / `on_file_save` / `on_test_run`** — 11 installed recipes that double-fire by the same mechanism, and whose duplicates `parseTrigger` returns `null` for, so they do not even appear as recipe runs.

Also out of scope and noted because it constrains verification: a cron-fired YAML recipe stamps `recipe:<name>`, not `cron:<name>` — only the legacy JSON path stamps `cron:`. **You cannot verify this fix by counting `cron:` rows.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)