### PR TITLE
fix(recipes): let a fan_out batch declare what it carries (#1466)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,17 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `fix/1466-fanout-data-policy` — #1466. `fan_out` is how a recipe processes a BATCH,
+  and it was the one step that could not declare a classification: the iteration allowlist refuses
+  `do.agent.data_policy`, and there was nowhere else to put it. So in `private-document-digest` the
+  step handling RAW documents N times dispatched at the default `internal` while the step seeing
+  only redacted extracts could be labelled — the wrong way round. Accepts `data_policy` on the
+  fan_out STEP and applies it to every iteration; the iteration allowlist stays an allowlist
+  (refusing it there is correct — same reasoning as `sandbox: true`), and the error now says where
+  the label belongs. Touches `src/recipes/tools/fanOut.ts` and `runNestedAgent` in
+  `src/recipes/yamlRunner.ts` — collides with any fan_out, agent-executor or privacy work.
+  — this session
+
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-19 `fix/1466-fanout-data-policy` — #1466. `fan_out` is how a recipe processes a BATCH,
   and it was the one step that could not declare a classification: the iteration allowlist refuses
   `do.agent.data_policy`, and there was nowhere else to put it. So in `private-document-digest` the
@@ -38,10 +42,7 @@ verified (which is how this line came to be written).
   (refusing it there is correct — same reasoning as `sandbox: true`), and the error now says where
   the label belongs. Touches `src/recipes/tools/fanOut.ts` and `runNestedAgent` in
   `src/recipes/yamlRunner.ts` — collides with any fan_out, agent-executor or privacy work.
-  — this session
-
-
-## Recently closed (informal log, prune periodically)
+  — this session — merged as #1468
 
 - 2026-08-19 `feat/butler-promotion` — the last unbuilt step of Butler phase 2. `outcomeShadowLog.ts`
   says `OutcomeStore.upsert` is "deliberately NOT implemented here"; this implements it, in a

--- a/src/recipes/tools/__tests__/fanOutDataPolicy.test.ts
+++ b/src/recipes/tools/__tests__/fanOutDataPolicy.test.ts
@@ -1,0 +1,182 @@
+/**
+ * `fan_out` and the information boundary (#1466, ADR-0021).
+ *
+ * ## The gap this closes
+ *
+ * `fan_out` is how a recipe processes a BATCH, and a batch of documents is the
+ * highest-volume confidential path in the product. Until now it was the one
+ * step that could not say so: the iteration honours an allowlist of
+ * `prompt`/`driver`/`model`, so `do.agent.data_policy` was refused, and there
+ * was nowhere else to put it.
+ *
+ * The consequence was the wrong way round. In the shipped
+ * `private-document-digest` recipe the `scrub` step handles the RAW documents N
+ * times and could not be labelled; the `digest` step, which sees only redacted
+ * extracts, could. Measured on a three-document run: three rows `assumed`, one
+ * `declared` — and the three assumed ones were the raw passes. Point that
+ * driver at a hosted model and the boundary would have recorded
+ * `internal → remote → ALLOW`, because nothing was able to tell it otherwise.
+ *
+ * ## Why the label goes on the STEP, not inside `do.agent`
+ *
+ * The allowlist inside the iteration stays an allowlist, and that is not
+ * incidental. Its comment records why: an earlier denylist missed `sandbox`,
+ * `tools`, `disallowedTools` and `mcpAccess`, so an author writing
+ * `sandbox: true` would believe the iteration was sandboxed while it silently
+ * was not — a false SAFETY signal, not a dropped option.
+ *
+ * `data_policy` is in exactly that class, which is why it must keep being
+ * refused there rather than quietly accepted. But it differs from the other
+ * rejected options in the way that decides where it belongs: those change HOW a
+ * step runs and are plausibly per-item; this describes WHAT THE DATA IS, and it
+ * is uniform across the iteration by construction. So it is a property of the
+ * batch, declared once on the step, applied to every dispatch.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getTool } from "../../toolRegistry.js";
+import "../index.js";
+
+let tmpDir: string;
+/** Every input `runNestedAgent` was handed, in order. */
+let seen: Array<Record<string, unknown>>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), "fanout-policy-"));
+  seen = [];
+});
+afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+/**
+ * Drive the tool directly.
+ *
+ * Deliberately not through `runYamlRecipe`: the runner hard-wires the privacy
+ * seams to the real config and the real ledger, so an end-to-end assertion here
+ * would read the developer's own `~/.patchwork/config.json` and its result
+ * would depend on whose machine ran it. The contract that actually changed is
+ * the one between `fan_out` and the runner's injected executor, and that is
+ * what these assert.
+ */
+async function runFanOut(
+  params: Record<string, unknown>,
+): Promise<{ ok: boolean; error?: string }> {
+  const tool = getTool("fan_out");
+  if (!tool) throw new Error("fan_out is not registered");
+  try {
+    await tool.execute({
+      params,
+      ctx: {},
+      deps: {
+        logDir: tmpDir,
+        runNestedAgent: async (input: Record<string, unknown>) => {
+          seen.push(input);
+          return { text: "scrubbed", ok: true };
+        },
+      },
+    } as never);
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+const BATCH = {
+  items: '["doc-a","doc-b"]',
+  as: "doc",
+  do: { agent: { prompt: "Scrub {{doc}}", driver: "anthropic" } },
+};
+
+describe("a batch can declare what it carries", () => {
+  it("passes the step's data_policy to every iteration", async () => {
+    const r = await runFanOut({
+      ...BATCH,
+      data_policy: { classification: "confidential" },
+    });
+
+    expect(r.ok).toBe(true);
+    expect(seen).toHaveLength(2);
+    // EVERY dispatch, not just the first. A label applied to iteration 0 and
+    // dropped afterwards would be worse than none: the ledger would show a
+    // confidential row followed by defaults, which reads as a batch that
+    // changed classification halfway through.
+    for (const call of seen) {
+      expect(call.dataPolicy).toEqual({ classification: "confidential" });
+    }
+  });
+
+  it("passes it RAW, so an unrecognised classification fails closed downstream", async () => {
+    // The decision point parses it and refuses a typo rather than defaulting it
+    // to `internal`. Normalising here would swallow that, and a step declaring
+    // `restrickted` would be dispatched as `internal` with a receipt asserting
+    // so — a false-affirmative audit record, which is worse than none.
+    await runFanOut({ ...BATCH, data_policy: { classification: "nonsense" } });
+
+    expect(seen[0]?.dataPolicy).toEqual({ classification: "nonsense" });
+  });
+
+  it("carries categories through as well", async () => {
+    await runFanOut({
+      ...BATCH,
+      data_policy: {
+        classification: "confidential",
+        categories: ["financial"],
+      },
+    });
+
+    expect(seen[0]?.dataPolicy).toEqual({
+      classification: "confidential",
+      categories: ["financial"],
+    });
+  });
+
+  it("sends no dataPolicy at all when none is declared", async () => {
+    // Absence must stay ABSENT, not become an empty object. The decision point
+    // distinguishes "declared" from "assumed" by whether this field is present,
+    // and an empty object would make every undeclared batch claim to be
+    // labelled — the exact false-affirmative the boundary exists to avoid.
+    await runFanOut(BATCH);
+
+    expect(seen[0]).not.toHaveProperty("dataPolicy");
+  });
+});
+
+describe("the iteration allowlist stays an allowlist", () => {
+  it("still refuses data_policy INSIDE do.agent, loudly", async () => {
+    // Regression guard on the reasoning, not just the behaviour. Accepting it
+    // here would be the `sandbox: true` mistake again — an author would
+    // believe the batch was labelled while the runner honoured nothing.
+    const r = await runFanOut({
+      ...BATCH,
+      do: {
+        agent: {
+          prompt: "Scrub {{doc}}",
+          driver: "anthropic",
+          data_policy: { classification: "confidential" },
+        },
+      },
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not supported inside an iteration/);
+    // And it must say where the label DOES belong, or the author is left with
+    // an error naming only prompt/driver/model and no way to comply.
+    expect(r.error).toMatch(/data_policy/);
+  });
+
+  it("still refuses an option it has never heard of", async () => {
+    const r = await runFanOut({
+      ...BATCH,
+      do: { agent: { prompt: "x", driver: "anthropic", sandbox: true } },
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not supported inside an iteration/);
+  });
+});

--- a/src/recipes/tools/fanOut.ts
+++ b/src/recipes/tools/fanOut.ts
@@ -102,6 +102,15 @@ registerTool({
           "What to do when a single iteration fails. `continue` (default) records the error in the aggregate and proceeds; `halt` stops fan_out and the step is marked error. Does NOT apply to a budget refusal, which always halts.",
         default: "continue",
       },
+      data_policy: {
+        type: "object",
+        description:
+          "ADR-0021 classification for the data this batch carries, applied to EVERY iteration's agent dispatch. Declared on the step rather than inside `do.agent` because it describes what the data IS — uniform across the iteration by construction — while the iteration's allowlist governs how each call RUNS. Without it a batch of confidential documents dispatches at the default `internal`, which is the wrong default on the highest-volume path a recipe has.",
+        properties: {
+          classification: { type: "string" },
+          categories: { type: "array", items: { type: "string" } },
+        },
+      },
     },
     required: ["items", "do"],
   },
@@ -193,7 +202,12 @@ registerTool({
           `fan_out: \`do.agent.${unsupported.join("`, `do.agent.")}\` is not supported inside an iteration ` +
             "— only `prompt`, `driver` and `model` are honoured. Judge verdicts, refine loops, " +
             "per-step routing and tool sandboxes are step-level features: move the agent to its " +
-            "own step, or drop the option.",
+            "own step, or drop the option." +
+            (unsupported.includes("data_policy")
+              ? " `data_policy` belongs on the fan_out STEP, not inside `do.agent`: the " +
+                "classification describes the batch and is uniform across the iteration, so it " +
+                "is declared once and applied to every dispatch."
+              : ""),
         );
       }
       toolId = "";
@@ -260,6 +274,15 @@ registerTool({
             driver: agentCfg.driver,
           }),
           ...(typeof agentCfg.model === "string" && { model: agentCfg.model }),
+          // ADR-0021 — the BATCH's declared classification, applied to every
+          // iteration. Passed RAW: an unrecognised classification must reach
+          // `parseDataPolicy` at the decision point so it can fail closed, not
+          // be normalised away here. Absent stays ABSENT rather than becoming
+          // an empty object, because the boundary tells `declared` from
+          // `assumed` by whether this field is present at all.
+          ...(params.data_policy !== undefined && {
+            dataPolicy: params.data_policy,
+          }),
         });
         aggregate.push(
           res.ok

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -906,6 +906,13 @@ export type StepDeps = Required<
     prompt: string;
     driver?: string;
     model?: string;
+    /**
+     * ADR-0021 — the fan_out STEP's declared classification, raw as the author
+     * wrote it. Forwarded to the boundary decision point unparsed so an
+     * unrecognised value fails closed there rather than being normalised into
+     * a default here.
+     */
+    dataPolicy?: unknown;
   }) => Promise<{
     text: string;
     ok: boolean;
@@ -1692,6 +1699,7 @@ export async function runYamlRecipe(
     prompt: string;
     driver?: string;
     model?: string;
+    dataPolicy?: unknown;
   }): Promise<{
     text: string;
     ok: boolean;
@@ -1722,6 +1730,13 @@ export async function runYamlRecipe(
           );
           return merged ? { disallowedTools: merged } : {};
         })(),
+        // Same shape a first-class agent step builds (#1466). Without it the
+        // boundary judged every iteration at the default `internal`, so the
+        // one step in a batch pipeline that handles RAW documents was the one
+        // step whose label it could not be told.
+        ...(input.dataPolicy !== undefined && {
+          boundary: { dataPolicy: input.dataPolicy },
+        }),
       },
       buildAgentExecutorDeps(stepDeps, deps),
     );


### PR DESCRIPTION
Closes #1466.

## The gap

`fan_out` is how a recipe processes a **batch**, and a batch of documents is the highest-volume confidential path in the product. It was the one step that could not say so.

The consequence was exactly the wrong way round. In the shipped `private-document-digest` recipe:

| step | carries | could be labelled? |
|---|---|---|
| `scrub` (fan_out, N iterations) | **the raw documents** | **no** |
| `digest` (plain agent step) | redacted extracts only | yes |

Measured on a three-document run *before* this change: **three rows `assumed`, one `declared`** — and the three assumed ones were the raw passes. Point that step's driver at a hosted model and the boundary would have recorded `internal → remote → ALLOW`, because nothing was able to tell it otherwise.

## The label goes on the STEP, and the iteration allowlist stays an allowlist

Refusing `do.agent.data_policy` **inside** the iteration is correct, and is kept. That allowlist exists because an earlier denylist missed `sandbox`, `tools`, `disallowedTools` and `mcpAccess` — so an author writing `sandbox: true` would believe the iteration was sandboxed while it silently was not. A false *safety* signal, not a dropped option, and `data_policy` is squarely in that class.

What decides where it belongs is that it differs from every other rejected option **in kind**: those change *how* a step runs and are plausibly per-item. This describes *what the data is*, and is uniform across the iteration by construction. So it is a property of the batch — declared once on the step, applied to every dispatch.

```yaml
  - id: scrub
    tool: fan_out
    items: "{{DOC_LIST}}"
    data_policy:
      classification: confidential
    do:
      agent:
        driver: local
        prompt: |
          ...
```

The error message now says that, instead of leaving an author who has just read ADR-0021 with a list of three honoured keys and no way to comply.

Passed **raw** to the decision point, so an unrecognised classification fails closed there rather than being normalised into a default here. And **absent stays absent** — the boundary tells `declared` from `assumed` by whether the field is present, so an empty object would make every undeclared batch claim to be labelled.

## Verification

| mutation | tests red |
|---|---|
| stop passing the label at all | 3 |
| normalise the label instead of passing it raw | 3 |
| send an empty object when nothing is declared | 1 |
| label only the first iteration | 1 |
| quietly accept `data_policy` inside `do.agent` | 1 |

Measured *after*, same recipe, same three documents — all four rows `declared`:

```
confidential  labelSource=declared  -> ALLOW
confidential  labelSource=declared  -> ALLOW
confidential  labelSource=declared  -> ALLOW
internal      labelSource=declared  -> ALLOW
```

That is the recipe's actual data model, visible to the boundary for the first time: `confidential` for the raw passes, `internal` for the digest — and labelling the digest `confidential` too would be safer-looking and less true, since it would say the scrubbing achieved nothing.

**And the detector was proved able to return something other than `ALLOW`, which it never had.** A confidential batch pointed at a remote driver:

```
DECISION=LOCAL_ONLY  reason="confidential" may not leave the machine;
                            a local destination accepts it
```

Note it *routed* rather than refused — a local destination does accept `confidential`. A zero that has never been a one is not evidence; it is now.

Full suite **10168/10168**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)