### PR TITLE
fix(recipes): refuse a data_policy declared where nothing reads it (#1467)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -32,6 +32,17 @@ verified (which is how this line came to be written).
 _Nothing in flight._
 
 ## Recently closed (informal log, prune periodically)
+- 2026-08-19 `fix/1467-misplaced-data-policy` — #1467. A `data_policy` declared as a SIBLING of
+  `agent:` instead of inside it is read by nothing, and `recipe lint` passed it: the run succeeded
+  and the boundary row came out `assumed`, indistinguishable from a step that declared nothing.
+  Reproduced end to end before fixing. Now a lint ERROR naming the remedy, following the
+  `compoundSteps.ts` precedent (lint and runtime verdicts must not drift). Exempts the two correct
+  placements — inside `agent:`, and on a `fan_out` step (#1466). Touches
+  `src/recipes/validation.ts` plus a new `src/recipes/dataPolicyPlacement.ts` — collides with any
+  recipe-validation or privacy work. Was stacked on #1468 and has been rebased onto main now that
+  it merged; the ORDER mattered — landing this lint rule first would have made a `fan_out` step
+  with `data_policy` pass lint while the runtime still ignored it, which is the exact silent
+  failure the rule exists to prevent. — this session
 
 - 2026-08-19 `fix/1466-fanout-data-policy` — #1466. `fan_out` is how a recipe processes a BATCH,
   and it was the one step that could not declare a classification: the iteration allowlist refuses

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,9 +29,6 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
-
-## Recently closed (informal log, prune periodically)
 - 2026-08-19 `fix/1467-misplaced-data-policy` — #1467. A `data_policy` declared as a SIBLING of
   `agent:` instead of inside it is read by nothing, and `recipe lint` passed it: the run succeeded
   and the boundary row came out `assumed`, indistinguishable from a step that declared nothing.
@@ -43,6 +40,9 @@ _Nothing in flight._
   it merged; the ORDER mattered — landing this lint rule first would have made a `fan_out` step
   with `data_policy` pass lint while the runtime still ignored it, which is the exact silent
   failure the rule exists to prevent. — this session
+
+## Recently closed (informal log, prune periodically)
+
 
 - 2026-08-19 `fix/1466-fanout-data-policy` — #1466. `fan_out` is how a recipe processes a BATCH,
   and it was the one step that could not declare a classification: the iteration allowlist refuses

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-19 `fix/1467-misplaced-data-policy` — #1467. A `data_policy` declared as a SIBLING of
   `agent:` instead of inside it is read by nothing, and `recipe lint` passed it: the run succeeded
   and the boundary row came out `assumed`, indistinguishable from a step that declared nothing.
@@ -39,9 +44,7 @@ verified (which is how this line came to be written).
   recipe-validation or privacy work. Was stacked on #1468 and has been rebased onto main now that
   it merged; the ORDER mattered — landing this lint rule first would have made a `fan_out` step
   with `data_policy` pass lint while the runtime still ignored it, which is the exact silent
-  failure the rule exists to prevent. — this session
-
-## Recently closed (informal log, prune periodically)
+  failure the rule exists to prevent. — this session — merged as #1471
 
 
 - 2026-08-19 `fix/1466-fanout-data-policy` — #1466. `fan_out` is how a recipe processes a BATCH,

--- a/src/recipes/__tests__/dataPolicyPlacement.test.ts
+++ b/src/recipes/__tests__/dataPolicyPlacement.test.ts
@@ -1,0 +1,141 @@
+/**
+ * A `data_policy` declared where nothing reads it (#1467).
+ *
+ * The bug, reproduced end to end before it was fixed: declaring the block as a
+ * sibling of `agent:` instead of inside it produced `✓ Valid recipe (0
+ * warnings)`, a successful run, and a boundary row reading
+ * `labelSource: "assumed"` — identical to a step that declared nothing.
+ *
+ * These tests are about the ERROR being raised, and about it being raised in
+ * exactly the wrong places and no others. A rule that fires on a correct
+ * placement is worse than no rule: it teaches authors to ignore it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { misplacedDataPolicy } from "../dataPolicyPlacement.js";
+import { validateRecipeDefinition } from "../validation.js";
+
+describe("placements that are correct and must stay silent", () => {
+  it("inside agent: — the one the runner reads", () => {
+    expect(
+      misplacedDataPolicy({
+        id: "s",
+        agent: { prompt: "x", data_policy: { classification: "confidential" } },
+      }),
+    ).toBeNull();
+  });
+
+  it("on a fan_out step — the batch's classification (#1466)", () => {
+    expect(
+      misplacedDataPolicy({
+        id: "s",
+        tool: "fan_out",
+        items: "[]",
+        do: { agent: { prompt: "x" } },
+        data_policy: { classification: "confidential" },
+      }),
+    ).toBeNull();
+  });
+
+  it("a step with no data_policy at all", () => {
+    expect(misplacedDataPolicy({ id: "s", agent: { prompt: "x" } })).toBeNull();
+    expect(misplacedDataPolicy({ id: "s", tool: "file.read" })).toBeNull();
+  });
+
+  it("things that are not steps", () => {
+    expect(misplacedDataPolicy(null)).toBeNull();
+    expect(misplacedDataPolicy("nope")).toBeNull();
+    expect(misplacedDataPolicy([])).toBeNull();
+  });
+});
+
+describe("the misplacement that shipped", () => {
+  it("flags a step-level data_policy alongside agent:, and says where it goes", () => {
+    const r = misplacedDataPolicy({
+      id: "digest",
+      data_policy: { classification: "internal" },
+      agent: { prompt: "x", driver: "local" },
+    });
+
+    expect(r).not.toBeNull();
+    // The message has to name the remedy. An author who has just read ADR-0021,
+    // written the block one level out and been told only "invalid" has nothing
+    // to act on — and the correct nesting is one level in from where a reader
+    // of the step naturally puts it.
+    expect(r?.message).toMatch(/INSIDE `agent:`/);
+    // And it must say what happens if they leave it, because "ignored" and
+    // "defaults to internal" are different warnings and only the second
+    // conveys the risk.
+    expect(r?.message).toMatch(/internal/);
+  });
+
+  it("flags it on a step that makes no agent dispatch at all", () => {
+    const r = misplacedDataPolicy({
+      id: "w",
+      tool: "file.write",
+      data_policy: { classification: "confidential" },
+    });
+
+    expect(r).not.toBeNull();
+    expect(r?.message).toMatch(/no agent dispatch/);
+  });
+});
+
+describe("recipe lint refuses it", () => {
+  function lintWithStep(step: Record<string, unknown>) {
+    return validateRecipeDefinition({
+      apiVersion: "patchwork.sh/v1",
+      name: "t",
+      description: "t",
+      trigger: { type: "manual" },
+      steps: [step],
+    });
+  }
+
+  it("is an ERROR, not a warning", () => {
+    // A warning would be the wrong severity for a dropped safety declaration:
+    // `recipe lint` exits 0 on warnings, so CI and the dashboard install panel
+    // would both go green on a recipe whose classification is inert.
+    const res = lintWithStep({
+      id: "digest",
+      data_policy: { classification: "confidential" },
+      agent: { prompt: "x", driver: "local" },
+    });
+
+    const hit = res.issues.find((i) => i.code === "data-policy-misplaced");
+    expect(hit).toBeDefined();
+    expect(hit?.level).toBe("error");
+    expect(hit?.path).toBe("steps.0.data_policy");
+    expect(res.valid).toBe(false);
+  });
+
+  it("stays silent on the correct nesting", () => {
+    const res = lintWithStep({
+      id: "digest",
+      agent: {
+        prompt: "x",
+        driver: "local",
+        data_policy: { classification: "confidential" },
+      },
+    });
+
+    expect(
+      res.issues.filter((i) => i.code === "data-policy-misplaced"),
+    ).toEqual([]);
+  });
+
+  it("stays silent on a fan_out step", () => {
+    const res = lintWithStep({
+      id: "scrub",
+      tool: "fan_out",
+      items: '["a"]',
+      do: { agent: { prompt: "x", driver: "local" } },
+      data_policy: { classification: "confidential" },
+    });
+
+    expect(
+      res.issues.filter((i) => i.code === "data-policy-misplaced"),
+    ).toEqual([]);
+  });
+});

--- a/src/recipes/dataPolicyPlacement.ts
+++ b/src/recipes/dataPolicyPlacement.ts
@@ -1,0 +1,101 @@
+/**
+ * Where an ADR-0021 `data_policy` may be declared, and where it is read.
+ *
+ * ## The failure this closes
+ *
+ * `data_policy` must be nested INSIDE `agent:` on an agent step — that is what
+ * `yamlRunner` reads (`agentCfg.data_policy`) and what ADR-0021's example
+ * shows. Declared one level up, as a sibling of `agent:`, it was **silently
+ * ignored**: `recipe lint` reported `✓ Valid recipe (0 warnings)`, the run
+ * succeeded, and the boundary row came out `labelSource: "assumed"` —
+ * indistinguishable from a step that declared nothing at all.
+ *
+ * Observed, not theorised: declared at step level on two real recipes, both
+ * linted clean, ran one, and all four resulting rows were `assumed`. Moving the
+ * block inside `agent:` produced `declared` on the same step.
+ *
+ * ## Why this one deserves an error rather than a warning
+ *
+ * The thing being silently dropped is a SAFETY declaration, and the two mental
+ * models disagree in the direction that permits: the author believes the step
+ * is labelled `confidential`; the runtime believes it declared nothing and
+ * defaults it to `internal`.
+ *
+ * It is also the field where being wrong is invisible in the output. An ignored
+ * `prompt` or `driver` changes what the step does and you notice within
+ * seconds. An ignored `data_policy` changes only a row in a ledger nobody reads
+ * until an audit — which is precisely when it is too late to notice.
+ *
+ * ## The precedent this follows
+ *
+ * `compoundSteps.ts` exists because a compound step on the flat runner passed
+ * lint AND reported a successful run whose body never executed. Its header
+ * states the principle: lint and runtime are shared so "authoring-time and
+ * run-time verdicts cannot drift — that drift is the failure this module exists
+ * to close."
+ *
+ * This is that same drift, on the privacy surface.
+ *
+ * ## And the contrast that makes it clearly a bug
+ *
+ * The SAME misplacement one level deeper already fails loudly: `fan_out`
+ * refuses `do.agent.data_policy` with an explicit error, because its allowlist
+ * treats an unrecognised agent option as a potential false safety signal. So
+ * the codebase already considers a misplaced `data_policy` worth refusing —
+ * just not in this position. Two placements, one author error, opposite
+ * handling.
+ */
+
+/** Steps whose tool reads a step-level `data_policy`. */
+const TOOLS_THAT_READ_STEP_LEVEL_POLICY = new Set(["fan_out"]);
+
+export interface MisplacedDataPolicy {
+  /** Why it is wrong here, and where it belongs. */
+  message: string;
+  /** Dotted path for the lint issue. */
+  key: "data_policy";
+}
+
+/**
+ * Report a `data_policy` declared where nothing will read it.
+ *
+ * Returns `null` when the placement is fine, which is the common case:
+ *
+ *   - inside `agent:` on an agent step — read by `yamlRunner`;
+ *   - on a `fan_out` step — read by the tool and applied to every iteration
+ *     (#1466). The classification describes the batch, so it is declared once
+ *     on the step rather than per item.
+ *
+ * Everything else is a step-level `data_policy` no code path consults.
+ */
+export function misplacedDataPolicy(step: unknown): MisplacedDataPolicy | null {
+  if (!step || typeof step !== "object" || Array.isArray(step)) return null;
+  const rec = step as Record<string, unknown>;
+  if (rec.data_policy === undefined) return null;
+
+  const tool = typeof rec.tool === "string" ? rec.tool : undefined;
+  if (tool && TOOLS_THAT_READ_STEP_LEVEL_POLICY.has(tool)) return null;
+
+  const hasAgent =
+    rec.agent !== undefined &&
+    typeof rec.agent === "object" &&
+    !Array.isArray(rec.agent);
+
+  if (hasAgent) {
+    return {
+      key: "data_policy",
+      message:
+        "`data_policy` is declared on the step, where nothing reads it — it must be nested INSIDE `agent:`. " +
+        "Left here it is silently ignored and the step dispatches at the default `internal` classification, " +
+        "which is the opposite of what declaring it was meant to achieve.",
+    };
+  }
+
+  return {
+    key: "data_policy",
+    message:
+      "`data_policy` is declared on a step that makes no agent dispatch, so nothing reads it. " +
+      "It belongs inside `agent:` on an agent step, or on a `fan_out` step (where it applies to every iteration). " +
+      "A classification on a step that never talks to a model describes nothing.",
+  };
+}

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -3,6 +3,7 @@ import cron from "node-cron";
 import { createAjv2020, type ErrorObject } from "../ajv2020.js";
 import { FLAG_SCHEMA_LINT, isEnabled } from "../featureFlags.js";
 import { unsupportedKeysOf, unsupportedStepMessage } from "./compoundSteps.js";
+import { misplacedDataPolicy } from "./dataPolicyPlacement.js";
 import {
   defaultDeprecationWarn,
   normalizeRecipeForRuntime,
@@ -252,6 +253,25 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
               code: "flat-compound-step-unsupported",
             });
           }
+        }
+      }
+    }
+
+    // ADR-0021 — a `data_policy` declared where nothing reads it (#1467).
+    // Checked on the RAW step, before normalisation, and on BOTH runners: the
+    // misplacement is an authoring mistake and neither runner is more likely to
+    // make the author notice, because both silently ignore it.
+    if (Array.isArray(rawRecipe?.steps)) {
+      const rawSteps = rawRecipe!.steps as unknown[];
+      for (let i = 0; i < rawSteps.length; i++) {
+        const bad = misplacedDataPolicy(rawSteps[i]);
+        if (bad) {
+          issues.push({
+            level: "error",
+            message: `Step ${i + 1}: ${bad.message}`,
+            path: `steps.${i}.${bad.key}`,
+            code: "data-policy-misplaced",
+          });
         }
       }
     }


### PR DESCRIPTION
Closes #1467.

## The bug, reproduced by making it

`data_policy` must be nested **inside** `agent:` — that is what `yamlRunner` reads (`agentCfg.data_policy`) and what ADR-0021's example shows. Declared one level up, as a sibling of `agent:`:

```yaml
  - id: digest
    data_policy:               # <- accepted by lint, read by nothing
      classification: internal
    agent:
      driver: local
      prompt: ...
```

`patchwork recipe lint` reports `✓ Valid recipe (0 warnings)`. The run succeeds. The boundary row comes out `labelSource: "assumed"` — **indistinguishable from a step that declared nothing at all.**

Found by writing it that way on two real recipes, both linting clean, running one, and checking the ledger rather than trusting the tick: all four rows `assumed`. Moving the block inside `agent:` produced `declared` on the same step.

## Why an error, not a warning

The thing being dropped is a **safety declaration**, and the two mental models disagree in the direction that permits — the author believes the step is labelled `confidential`, the runtime believes it declared nothing and defaults to `internal`.

It is also the one field where being wrong is invisible in the output. An ignored `prompt` or `driver` changes what the step does and you notice in seconds. An ignored `data_policy` changes only a row in a ledger nobody reads until an audit.

And `recipe lint` exits 0 on warnings, so a warning would leave CI *and* the dashboard install panel green on a recipe whose classification is inert.

## The precedent, and the contrast that settles it

`compoundSteps.ts` exists because a compound step on the flat runner passed lint **and** reported a successful run whose body never executed. Its header states the principle: lint and runtime are shared so *"authoring-time and run-time verdicts cannot drift — that drift is the failure this module exists to close."* This is that drift, on the privacy surface.

And the **same misplacement one level deeper already failed loudly**: `fan_out` refuses `do.agent.data_policy`, because its allowlist treats an unrecognised agent option as a potential false safety signal. The codebase already considered a misplaced `data_policy` worth refusing — just not in this position. Two placements, one author error, opposite handling.

## What it must not flag

Both correct placements are exempt: inside `agent:`, and on a `fan_out` step where it describes the batch (#1468). **A rule that fires on a correct placement is worse than no rule** — it teaches authors to ignore it.

## Verification

| mutation | tests red |
|---|---|
| downgrade the issue to a warning | 1 |
| drop the fan_out exemption (false alarm on a correct placement) | 2 |
| also flag the correct nesting inside `agent:` | 2 |
| drop the remedy from the message | 1 |

Then against real data, **in this order because the order is the point**:

1. the rule was shown to **fire** — reintroducing the exact mistake into a real recipe produced the error;
2. only then swept across **103 recipes** (all repo templates plus every locally installed one) for false positives: **zero**.

An earlier version of that sweep reported zero from a stale `dist/` — a check that could not fail, because the build step had died at shell-parse time. It was redone against a build proven to contain the rule.

Full suite **10177/10177**.

## Ordering note

This was stacked on #1468 and is now rebased onto main. The order mattered: landing this lint rule *first* would have made a `fan_out` step with `data_policy` pass lint while the runtime still ignored it — the exact silent failure the rule exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)