### PR TITLE
fix(privacy): the shadow report named a problem you could not locate (#1469)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,16 @@ verified (which is how this line came to be written).
 
 ## Active
 
+- 2026-08-19 `fix/1469-shadow-attribution` — #1469. The shadow report said "23 of 29 rows carry a
+  DEFAULTED classification" and gave no way to find WHICH of 80 recipes to go and label. `ShadowRow`
+  already declared `recipeName` and nothing supplied it — declared-but-supplied-nowhere, on a
+  surface the wiring guard does not cover, while the boundary RECEIPT log declares and populates
+  the same field. Populates it from `StepDeps` (already there for the circuit breaker), adds a
+  worst-first per-recipe breakdown, and counts the unattributable remainder rather than dropping
+  it. REMOVES the sibling `stepId`, which nothing can supply at that seam. Touches
+  `src/privacy/shadowLog.ts` and `src/recipes/yamlRunner.ts` — collides with any privacy or
+  agent-executor work. — this session
+
 _Nothing in flight._
 
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-19 `fix/1469-shadow-attribution` — #1469. The shadow report said "23 of 29 rows carry a
   DEFAULTED classification" and gave no way to find WHICH of 80 recipes to go and label. `ShadowRow`
   already declared `recipeName` and nothing supplied it — declared-but-supplied-nowhere, on a
@@ -43,6 +47,7 @@ _Nothing in flight._
 
 
 ## Recently closed (informal log, prune periodically)
+_Nothing in flight._ — merged as #1472
 
 - 2026-08-19 `fix/1467-misplaced-data-policy` — #1467. A `data_policy` declared as a SIBLING of
   `agent:` instead of inside it is read by nothing, and `recipe lint` passed it: the run succeeded

--- a/src/privacy/__tests__/shadowAttribution.test.ts
+++ b/src/privacy/__tests__/shadowAttribution.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The shadow report has to name a problem you can LOCATE (#1469).
+ *
+ * The report's honesty rules are already strong — it leads with the
+ * denominator, refuses a bare crossing count, and says "nothing observed"
+ * rather than "0 crossings" on an empty ledger. It had one gap left, and it was
+ * an actionability gap rather than an honesty one:
+ *
+ *     assumed: 23 of 29 row(s) carry a DEFAULTED classification
+ *
+ * The remedy for an assumed row is to declare a `data_policy` on the step that
+ * produced it. Nothing in the row said which step, or even which recipe — the
+ * complete key set was `at, classification, decision, destinationId,
+ * destinationType, enforcing, labelSource, path, reason`, where `path` is the
+ * dispatch PATH (`recipe-agent-step`), not the recipe. So an operator with 80
+ * installed recipes was told a number and given nothing to act on.
+ *
+ * `ShadowRow` already DECLARED `recipeName` — and nothing supplied it. That is
+ * the "declared but supplied nowhere" pattern the repo's wiring guard exists to
+ * catch, on a surface the guard does not cover. The boundary RECEIPT log
+ * declares `recipeName` and populates it, so the two records describing the
+ * same dispatch disagreed about whether attribution was possible.
+ *
+ * Not a payload concern: a recipe name is not the prompt, is already in
+ * `runs.jsonl`, and is the same class of attribution metadata #1455 established
+ * for evidence records. ADR-0021's "receipts carry no payload" rule is
+ * untouched.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { formatPrivacyShadow, summarisePrivacyShadow } from "../shadowLog.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(os.tmpdir(), "shadow-attr-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function seed(rows: Array<Record<string, unknown>>): void {
+  writeFileSync(
+    join(dir, "privacy_shadow.jsonl"),
+    `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`,
+  );
+}
+
+function row(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    at: 1_787_000_000_000,
+    decision: "ALLOW",
+    reason: "ok",
+    destinationId: "candidate-local",
+    destinationType: "local",
+    classification: "internal",
+    labelSource: "assumed",
+    path: "recipe-agent-step",
+    enforcing: false,
+    ...over,
+  };
+}
+
+describe("assumed rows are attributed to the recipe that produced them", () => {
+  it("counts unlabelled dispatches per recipe", () => {
+    seed([
+      row({ recipeName: "nightly-scout" }),
+      row({ recipeName: "nightly-scout" }),
+      row({ recipeName: "weekly-report" }),
+      row({ recipeName: "labelled-one", labelSource: "declared" }),
+    ]);
+
+    const s = summarisePrivacyShadow({ dir });
+
+    // The whole point: "4 rows, 3 assumed" is a number. This is a to-do list.
+    expect(s.assumedByRecipe).toEqual({
+      "nightly-scout": 2,
+      "weekly-report": 1,
+    });
+  });
+
+  it("does not credit a recipe for its DECLARED rows", () => {
+    seed([
+      row({ recipeName: "mixed" }),
+      row({ recipeName: "mixed", labelSource: "declared" }),
+    ]);
+
+    // A recipe that is half-labelled still has work outstanding, and the count
+    // must be of the work, not of the recipe's total traffic.
+    expect(summarisePrivacyShadow({ dir }).assumedByRecipe).toEqual({
+      mixed: 1,
+    });
+  });
+
+  it("keeps unattributable rows visible rather than dropping them", () => {
+    // Orchestrator dispatches carry no recipe, and rows written before
+    // attribution existed carry none either. Silently omitting them would make
+    // the per-recipe counts add up to less than `assumed` — and a reader who
+    // fixed every recipe listed would find the headline number had not reached
+    // zero, with nothing to explain the remainder.
+    seed([
+      row({ recipeName: "known" }),
+      row({ path: "orchestrator-task", destinationId: "candidate-remote" }),
+      row(),
+    ]);
+
+    const s = summarisePrivacyShadow({ dir });
+
+    expect(s.assumed).toBe(3);
+    expect(s.assumedByRecipe.known).toBe(1);
+    expect(s.assumedUnattributed).toBe(2);
+    // The invariant a reader relies on.
+    expect(
+      Object.values(s.assumedByRecipe).reduce((a, b) => a + b, 0) +
+        s.assumedUnattributed,
+    ).toBe(s.assumed);
+  });
+});
+
+describe("the report tells you where to go", () => {
+  it("lists the recipes with unlabelled dispatches, worst first", () => {
+    // `alpha` sorts FIRST alphabetically and LAST by count. The previous
+    // version of this test used `big`/`small`, where the two orderings agree —
+    // so it passed against an alphabetical sort and proved nothing about
+    // ranking. Caught by mutating the comparator and watching it stay green.
+    seed([
+      row({ recipeName: "alpha" }),
+      row({ recipeName: "zulu" }),
+      row({ recipeName: "zulu" }),
+      row({ recipeName: "zulu" }),
+    ]);
+
+    const out = formatPrivacyShadow(summarisePrivacyShadow({ dir }));
+
+    expect(out).toMatch(/alpha/);
+    expect(out).toMatch(/zulu/);
+    // Worst first, so the one line an operator reads is the one worth acting on.
+    expect(out.indexOf("zulu")).toBeLessThan(out.indexOf("alpha"));
+  });
+
+  it("says how many it cannot attribute, rather than quietly omitting them", () => {
+    seed([row({ recipeName: "known" }), row({ path: "orchestrator-task" })]);
+
+    expect(formatPrivacyShadow(summarisePrivacyShadow({ dir }))).toMatch(
+      /not attributed|no recipe/i,
+    );
+  });
+
+  it("says nothing about recipes when every row is labelled", () => {
+    // A section that renders empty on a healthy system is noise, and noise is
+    // how the honest parts of this report stop being read.
+    seed([row({ recipeName: "good", labelSource: "declared" })]);
+
+    const out = formatPrivacyShadow(summarisePrivacyShadow({ dir }));
+    expect(out).not.toMatch(/unlabelled/i);
+  });
+});
+
+describe("the WIRING, not just the summariser", () => {
+  /**
+   * Everything above tests `summarisePrivacyShadow` against rows a test wrote.
+   * That proves the arithmetic and proves nothing about whether anything ever
+   * PUTS a `recipeName` on a row — and the field was declared and supplied by
+   * nothing for exactly that reason.
+   *
+   * Caught by mutation: deleting the `recipeName` pass-through in
+   * `yamlRunner`'s `recordPrivacyShadowFn` left every test above green.
+   *
+   * So this one drives the real `runYamlRecipe`, with `PATCHWORK_HOME` pointed
+   * at a temp directory so the runner's hard-wired config read and ledger write
+   * both land there. `PATCHWORK_HOME` and not a spy on `os.homedir` — a
+   * namespace spy misses named imports and has previously let a test write to
+   * the developer's real `~/.patchwork`.
+   */
+  it("a real recipe run writes its own name onto the row", async () => {
+    const {
+      mkdirSync,
+      readFileSync,
+      writeFileSync: wf,
+    } = await import("node:fs");
+    const home = join(dir, "home");
+    mkdirSync(home, { recursive: true });
+    wf(
+      join(home, "config.json"),
+      JSON.stringify({
+        privacy: {
+          shadow: {
+            destinations: {
+              "test-local": {
+                type: "local",
+                classifications: ["public", "internal", "confidential"],
+                drivers: ["local"],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const prev = process.env.PATCHWORK_HOME;
+    process.env.PATCHWORK_HOME = home;
+    try {
+      const { runYamlRecipe } = await import("../../recipes/yamlRunner.js");
+      await runYamlRecipe(
+        {
+          name: "a-named-recipe",
+          trigger: { type: "manual" },
+          steps: [{ agent: { prompt: "hi", driver: "local" } }],
+        } as never,
+        {
+          testMode: true,
+          logDir: dir,
+          now: () => new Date("2026-08-19T00:00:00Z"),
+          readFile: () => {
+            throw new Error("nope");
+          },
+          writeFile: () => {},
+          appendFile: () => {},
+          mkdir: () => {},
+          gitLogSince: () => "",
+          gitStaleBranches: () => "",
+          getDiagnostics: () => "",
+          claudeFn: async () => "ok",
+        } as never,
+      );
+
+      const rows = readFileSync(join(home, "privacy_shadow.jsonl"), "utf-8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as { recipeName?: string });
+
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.at(-1)?.recipeName).toBe("a-named-recipe");
+    } finally {
+      // Restore rather than delete: with PATCHWORK_HOME unset the next reader
+      // resolves the developer's real store.
+      if (prev === undefined) delete process.env.PATCHWORK_HOME;
+      else process.env.PATCHWORK_HOME = prev;
+    }
+  });
+});

--- a/src/privacy/shadowLog.ts
+++ b/src/privacy/shadowLog.ts
@@ -109,8 +109,22 @@ export interface PrivacyShadowRow {
   destinationType: "local" | "remote";
   redactCategories?: string[];
   reason: string;
+  /**
+   * Which recipe produced this dispatch (#1469).
+   *
+   * Attribution only — the summariser groups by it, never filters on it. NOT a
+   * payload concern: a recipe name is not the prompt, it is already in
+   * `runs.jsonl`, and it is the same class of metadata #1455 established for
+   * evidence records.
+   *
+   * `stepId` was declared alongside this and supplied by nothing, so it has been
+   * REMOVED rather than left as a second instance of the defect this field
+   * exists to fix. The seam has no step identity to give: the shadow row is
+   * written from `buildAgentExecutorDeps`, which receives `StepDeps` — and that
+   * carries `recipeName` (for the circuit breaker's key) and no step id. Adding
+   * it back means plumbing one, not un-commenting a line.
+   */
   recipeName?: string;
-  stepId?: string;
   /** Short workspace id — attribution only; the summariser never filters on it. */
   workspaceId?: string;
   /**
@@ -178,6 +192,29 @@ export interface PrivacyShadowSummary {
   byPath: Record<string, { observed: number; crossings: number }>;
   /** How many rows carried an ASSUMED classification rather than a declared one. */
   assumed: number;
+  /**
+   * Recipe name -> how many of ITS rows were assumed (#1469).
+   *
+   * The report's job here is not another number but a to-do list: the remedy
+   * for an assumed row is to declare a `data_policy` on the step that produced
+   * it, and without this an operator was told "23 of 29" with 80 installed
+   * recipes to guess between.
+   *
+   * Counts only ASSUMED rows, not the recipe's total traffic — a half-labelled
+   * recipe still has work outstanding and the figure must be of the work.
+   */
+  assumedByRecipe: Record<string, number>;
+  /**
+   * Assumed rows carrying no recipe at all — orchestrator dispatches (which
+   * have no declared-policy channel, #1397) and rows written before attribution
+   * existed.
+   *
+   * Reported rather than dropped so `sum(assumedByRecipe) + assumedUnattributed
+   * === assumed` holds. Omitting them would leave a reader who fixed every
+   * recipe listed staring at a headline that never reached zero, with nothing
+   * to explain the remainder.
+   */
+  assumedUnattributed: number;
   observedPath: string;
   unobservedPaths: readonly string[];
 }
@@ -198,6 +235,8 @@ export function summarisePrivacyShadow(
     enforcingObservations: 0,
     byPath: {},
     assumed: 0,
+    assumedByRecipe: {},
+    assumedUnattributed: 0,
     observedPath: OBSERVED_PATH,
     unobservedPaths: UNOBSERVED_PATHS,
   };
@@ -229,7 +268,19 @@ export function summarisePrivacyShadow(
     const bucket = (summary.byPath[pathKey] ??= { observed: 0, crossings: 0 });
     bucket.observed += 1;
     if (isCrossing) bucket.crossings += 1;
-    if (row.labelSource === "assumed") summary.assumed += 1;
+    if (row.labelSource === "assumed") {
+      summary.assumed += 1;
+      // Attribute where we can, COUNT where we cannot. Dropping the
+      // unattributable rows would break `sum(byRecipe) + unattributed ===
+      // assumed`, and a reader who fixed every recipe listed would be left with
+      // a headline that never reached zero and nothing to explain it.
+      const rn = typeof row.recipeName === "string" ? row.recipeName : "";
+      if (rn) {
+        summary.assumedByRecipe[rn] = (summary.assumedByRecipe[rn] ?? 0) + 1;
+      } else {
+        summary.assumedUnattributed += 1;
+      }
+    }
     if (row.enforcing) summary.enforcingObservations += 1;
     summary.byDecision[row.decision] =
       (summary.byDecision[row.decision] ?? 0) + 1;
@@ -293,6 +344,30 @@ export function formatPrivacyShadow(s: PrivacyShadowSummary): string {
     L.push(
       `  assumed:    ${s.assumed} of ${s.observed} row(s) carry a DEFAULTED classification, not a declared one`,
     );
+    // The to-do list (#1469). Without it this section states a number and the
+    // remedy — declare a `data_policy` on the step that produced the row — has
+    // no address: an operator was left guessing between every installed recipe.
+    const ranked = Object.entries(s.assumedByRecipe).sort(
+      (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+    );
+    if (ranked.length > 0) {
+      L.push(
+        "  unlabelled dispatches by recipe (declare `data_policy` on the step):",
+      );
+      // Worst first, so the one line an operator actually reads is the one
+      // worth acting on.
+      for (const [name, n] of ranked) {
+        L.push(`    ${String(n).padStart(5)}  ${name}`);
+      }
+    }
+    if (s.assumedUnattributed > 0) {
+      // Named, not omitted. Orchestrator dispatches have no declared-policy
+      // channel (#1397) and pre-attribution rows carry no recipe, so this
+      // remainder is not fixable by labelling and must not read as if it were.
+      L.push(
+        `    ${String(s.assumedUnattributed).padStart(5)}  (not attributed to a recipe — orchestrator dispatches and rows written before attribution)`,
+      );
+    }
   }
   if (s.enforcingObservations > 0) {
     L.push(

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -3656,6 +3656,16 @@ function buildAgentExecutorDeps(
       const shadowWsId = evidenceWorkspaceId();
       recordPrivacyShadow({
         ...(shadowWsId && { workspaceId: shadowWsId }),
+        // Which recipe produced this (#1469). Taken from StepDeps rather than
+        // added to the executor's callback shape: the decision point has no
+        // recipe in scope and giving it one would widen a privacy seam to carry
+        // identity it does not need. `recipeName` is already here for the
+        // circuit breaker's key.
+        //
+        // Attribution only — the summariser groups by it and never filters on
+        // it, and it is absent for callers that build StepDeps without a scope,
+        // which the report counts and names rather than dropping.
+        ...(stepDeps.recipeName && { recipeName: stepDeps.recipeName }),
         decision: r.decision,
         reason: r.reason,
         destinationId: r.destinationId,


### PR DESCRIPTION
Closes #1469.

```
assumed: 23 of 29 row(s) carry a DEFAULTED classification
```

The remedy for an assumed row is to declare a `data_policy` on the step that produced it. **Nothing in the row said which step — or even which recipe.**

The complete key set was `at, classification, decision, destinationId, destinationType, enforcing, labelSource, path, reason`, where `path` is the dispatch *path* (`recipe-agent-step`), not the recipe. An operator with 80 installed recipes was handed a number and nothing to act on.

`ShadowRow` already **declared** `recipeName`, and nothing supplied it — declared-but-supplied-nowhere, on a surface the wiring guard does not cover. Meanwhile the boundary *receipt* log declares the same field and populates it, so two records describing one dispatch disagreed about whether attribution was even possible.

Not a payload concern: a recipe name is not the prompt, it is already in `runs.jsonl`, and it is the class of attribution metadata #1455 established for evidence records. ADR-0021's "receipts carry no payload" is untouched.

## What it does

Populates `recipeName` from `StepDeps` — where it already lives for the circuit breaker's key — rather than widening the executor's callback shape to carry identity the decision point does not need.

Adds a **worst-first** per-recipe breakdown, and **counts** the unattributable remainder rather than dropping it:

```
  assumed:    25 of 35 row(s) carry a DEFAULTED classification, not a declared one
  unlabelled dispatches by recipe (declare `data_policy` on the step):
        1  privacy-shadow-heartbeat
       24  (not attributed to a recipe — orchestrator dispatches and rows written before attribution)
```

Orchestrator dispatches have no declared-policy channel (#1397) and pre-attribution rows carry no recipe. Omitting them would break `sum(byRecipe) + unattributed === assumed` and leave a reader who fixed every recipe listed staring at a headline that never reached zero, with nothing to explain the remainder.

**Removes `stepId`**, declared beside `recipeName` and suppliable by nothing — the row is written from `buildAgentExecutorDeps`, which receives `StepDeps`, and that carries no step identity. Leaving it would be a second instance of the defect this change exists to fix.

## Verification — including two of my own tests that were worthless

Five mutations. Three bit immediately: dropping unattributable rows, counting declared rows against a recipe, hiding the remainder from the report.

**Two did not, and both were defects in the tests rather than the code:**

| mutation | why it stayed green | fix |
|---|---|---|
| sort alphabetically instead of worst-first | fixture used `big`/`small` — names where the two orderings **agree** | refixtured to `alpha`/`zulu`, where they disagree |
| stop passing `recipeName` from `StepDeps` | every test drove the summariser over rows **the test itself wrote** — hand-injected deps prove the logic, never the path | added a test that drives the real `runYamlRecipe` with `PATCHWORK_HOME` at a temp dir and asserts the row **on disk** carries the name |

Both mutations now fail. The second is the one that mattered: without it the entire feature could have been deleted from the runner and every test would still have passed.

`PATCHWORK_HOME` rather than a spy on `os.homedir` — a namespace spy misses named imports and has previously let a test write to the developer's real `~/.patchwork`.

## Live

A real run wrote `recipeName: private-document-digest`. Running the deliberately-unlabelled heartbeat put `1  privacy-shadow-heartbeat` at the top of the breakdown.

**Known and accepted:** the heartbeat declares no `data_policy` *on purpose* — it exists to report the assumed ratio honestly — so it will always appear in this list. An opt-out was considered and rejected: a way for a recipe to hide from a coverage report is exactly what erodes one.

Full suite **10175/10175**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)