### PR TITLE
fix(privacy): the enforcing ledger could not name the recipe it refused

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-19 `fix/boundary-receipt-attribution` — #1469 attributed the SHADOW ledger to its recipe
   and left the ENFORCING one anonymous: `recordBoundaryDecisionFn` sits 26 lines below
   `recordPrivacyShadowFn` in the same object literal and never passed `recipeName`, though
@@ -39,9 +43,7 @@ verified (which is how this line came to be written).
   LOCAL_ONLY refusal name its remedy; the remedy goes BEFORE the reason because
   `stepObservation`'s 120-char silent-fail cap was amputating it mid-word. Touches
   `src/recipes/yamlRunner.ts` and `src/recipes/agentExecutor.ts` — collides with any privacy,
-  agent-executor or recipe-runner work. — this session
-
-## Recently closed (informal log, prune periodically)
+  agent-executor or recipe-runner work. — this session — merged as #1474
 
 - 2026-08-19 `fix/1469-shadow-attribution` — #1469. The shadow report said "23 of 29 rows carry a
   DEFAULTED classification" and gave no way to find WHICH of 80 recipes to go and label. `ShadowRow`

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,17 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `fix/boundary-receipt-attribution` — #1469 attributed the SHADOW ledger to its recipe
+  and left the ENFORCING one anonymous: `recordBoundaryDecisionFn` sits 26 lines below
+  `recordPrivacyShadowFn` in the same object literal and never passed `recipeName`, though
+  `BoundaryReceipt` has declared the field throughout. So the ledger ADR-0021 calls the audit
+  record — the only one that can say why a step actually failed — could report that a `personal`
+  dispatch was refused without naming which of 80 recipes to fix. Measured first: nine receipts
+  from four live probe runs, three of them LOCAL_ONLY refusals, none attributed. Also makes the
+  LOCAL_ONLY refusal name its remedy; the remedy goes BEFORE the reason because
+  `stepObservation`'s 120-char silent-fail cap was amputating it mid-word. Touches
+  `src/recipes/yamlRunner.ts` and `src/recipes/agentExecutor.ts` — collides with any privacy,
+  agent-executor or recipe-runner work. — this session
 
 ## Recently closed (informal log, prune periodically)
 
@@ -41,13 +51,7 @@ _Nothing in flight._
   worst-first per-recipe breakdown, and counts the unattributable remainder rather than dropping
   it. REMOVES the sibling `stepId`, which nothing can supply at that seam. Touches
   `src/privacy/shadowLog.ts` and `src/recipes/yamlRunner.ts` — collides with any privacy or
-  agent-executor work. — this session
-
-_Nothing in flight._
-
-
-## Recently closed (informal log, prune periodically)
-_Nothing in flight._ — merged as #1472
+  agent-executor work. — this session — merged as #1472
 
 - 2026-08-19 `fix/1467-misplaced-data-policy` — #1467. A `data_policy` declared as a SIBLING of
   `agent:` instead of inside it is read by nothing, and `recipe lint` passed it: the run succeeded

--- a/src/privacy/__tests__/receiptAttribution.test.ts
+++ b/src/privacy/__tests__/receiptAttribution.test.ts
@@ -1,0 +1,219 @@
+/**
+ * A boundary REFUSAL has to name a recipe you can locate, and a remedy you can
+ * take.
+ *
+ * #1469 fixed exactly this on the shadow ledger: `ShadowRow` declared
+ * `recipeName`, nothing supplied it, and an operator with 80 installed recipes
+ * was handed a count with nothing to act on. Its own commentary said the fix
+ * was needed because "the boundary RECEIPT log declares `recipeName` and
+ * populates it, so the two records describing the same dispatch disagreed".
+ *
+ * That reading was half right. `boundaryReceiptLog` DECLARES the field and
+ * populates it WHEN GIVEN ONE — and the only supplier,
+ * `recordBoundaryDecisionFn` in `yamlRunner`, never passes it. It sits 26 lines
+ * below `recordPrivacyShadowFn`, which does. So #1469 attributed the ledger of
+ * HYPOTHETICALS and left the ledger of ENFORCED decisions — the one ADR-0021
+ * calls the audit record, and the only one that can say why a step actually
+ * failed — anonymous.
+ *
+ * Measured before writing this: nine receipts from four probe runs, three of
+ * them LOCAL_ONLY refusals, every one with no `recipeName`.
+ *
+ * The second half is the refusal TEXT. LOCAL_ONLY reads:
+ *
+ *     "personal" may not leave the machine; a local destination accepts it
+ *
+ * — a statement of fact that names a destination the runtime then does not use,
+ * and gives the author no way to reach it. The remedy exists and is one line
+ * (`driver: local` on the step); the message just never said so. DENY is
+ * already honest ("no approval can unlock it") and must NOT acquire a
+ * suggestion, because for DENY there is nothing to suggest.
+ *
+ * Not a payload concern: a recipe name is not the prompt, is already in
+ * `runs.jsonl`, and is the attribution metadata #1455 established for evidence
+ * records. ADR-0021's "receipts carry no payload field" rule is untouched.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dir: string;
+let home: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(os.tmpdir(), "receipt-attr-"));
+  home = join(dir, "home");
+  mkdirSync(home, { recursive: true });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/**
+ * `privacy.destinations` — the ENFORCING key, not `privacy.shadow`. Enabling
+ * one must never enable the other, and a test that reached for the shadow key
+ * here would prove nothing about the receipt log.
+ */
+function writeConfig(opts: { withLocal: boolean }): void {
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify({
+      privacy: {
+        destinations: {
+          ...(opts.withLocal
+            ? {
+                "test-local": {
+                  type: "local",
+                  classifications: ["public", "internal", "personal"],
+                  drivers: ["local"],
+                },
+              }
+            : {}),
+          "test-remote": {
+            type: "remote",
+            classifications: ["public", "internal"],
+            drivers: ["claude", "claude-code", "subprocess"],
+          },
+        },
+      },
+    }),
+  );
+}
+
+type Receipt = {
+  recipeName?: string;
+  decision?: string;
+  classification?: string;
+};
+
+async function runRecipe(
+  name: string,
+  step: Record<string, unknown>,
+): Promise<{ receipts: Receipt[]; text: string }> {
+  const prev = process.env.PATCHWORK_HOME;
+  // PATCHWORK_HOME, not a spy on `os.homedir`: a namespace spy misses named
+  // imports and has previously let a test write to the developer's real
+  // `~/.patchwork`.
+  process.env.PATCHWORK_HOME = home;
+  try {
+    const { runYamlRecipe } = await import("../../recipes/yamlRunner.js");
+    const result = await runYamlRecipe(
+      {
+        name,
+        trigger: { type: "manual" },
+        steps: [{ id: "think", ...step }],
+      } as never,
+      {
+        testMode: true,
+        logDir: dir,
+        now: () => new Date("2026-08-19T00:00:00Z"),
+        readFile: () => {
+          throw new Error("nope");
+        },
+        writeFile: () => {},
+        appendFile: () => {},
+        mkdir: () => {},
+        gitLogSince: () => "",
+        gitStaleBranches: () => "",
+        getDiagnostics: () => "",
+        claudeFn: async () => "ok",
+      } as never,
+    );
+    let receipts: Receipt[] = [];
+    try {
+      receipts = readFileSync(join(home, "boundary_receipts.jsonl"), "utf-8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as Receipt);
+    } catch {
+      receipts = [];
+    }
+    return { receipts, text: JSON.stringify(result) };
+  } finally {
+    // Restore rather than delete: with PATCHWORK_HOME unset the next reader
+    // resolves the developer's real store.
+    if (prev === undefined) delete process.env.PATCHWORK_HOME;
+    else process.env.PATCHWORK_HOME = prev;
+  }
+}
+
+describe("a boundary receipt names the recipe that produced it", () => {
+  it("attributes a REFUSAL — the row where locating the recipe is the point", async () => {
+    writeConfig({ withLocal: true });
+
+    const { receipts } = await runRecipe("personal-to-remote", {
+      agent: {
+        prompt: "hi",
+        driver: "claude-code",
+        data_policy: { classification: "personal" },
+      },
+    });
+
+    const refusal = receipts.find((r) => r.decision === "LOCAL_ONLY");
+    expect(refusal).toBeDefined();
+    // Without this, an auditor reading the enforcing ledger sees that a
+    // `personal` dispatch was stopped and cannot tell which of 80 recipes to go
+    // and fix — the exact complaint #1469 fixed one file over.
+    expect(refusal?.recipeName).toBe("personal-to-remote");
+  });
+
+  it("attributes an ALLOW too, so the ledger is not half-anonymous", async () => {
+    writeConfig({ withLocal: true });
+
+    const { receipts } = await runRecipe("personal-stays-home", {
+      agent: {
+        prompt: "hi",
+        driver: "local",
+        data_policy: { classification: "personal" },
+      },
+    });
+
+    const allowed = receipts.find((r) => r.decision === "ALLOW");
+    expect(allowed).toBeDefined();
+    expect(allowed?.recipeName).toBe("personal-stays-home");
+  });
+});
+
+describe("a refusal names a remedy only when one exists", () => {
+  it("LOCAL_ONLY tells the author how to keep the step on the machine", async () => {
+    writeConfig({ withLocal: true });
+
+    const { text } = await runRecipe("needs-pinning", {
+      agent: {
+        prompt: "hi",
+        driver: "claude-code",
+        data_policy: { classification: "personal" },
+      },
+    });
+
+    expect(text).toMatch(/information boundary/);
+    // The remedy is one line of YAML and the message never said which line.
+    expect(text).toMatch(/driver: local/);
+  });
+
+  it("DENY acquires no suggestion, because there is nothing to suggest", async () => {
+    // No local destination is registered, so nothing on this machine accepts
+    // `personal` and the LOCAL_ONLY branch is unreachable. Telling the author
+    // to pin `driver: local` here would send them to configure a destination
+    // that does not exist — a remedy that reads as authoritative and fails.
+    writeConfig({ withLocal: false });
+
+    const { text } = await runRecipe("nowhere-to-go", {
+      agent: {
+        prompt: "hi",
+        driver: "claude-code",
+        data_policy: { classification: "personal" },
+      },
+    });
+
+    expect(text).toMatch(/information boundary/);
+    expect(text).toMatch(/no approval can unlock it/);
+    expect(text).not.toMatch(/driver: local/);
+  });
+});

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -519,8 +519,38 @@ export async function executeAgent(
     // therefore REFUSED rather than silently sent unredacted. Failing closed on
     // "we know something must be removed and cannot remove it" is the whole
     // point; the alternative sends the data and logs that it should not have.
+    //
+    // Every non-ALLOW decision lands here, not just ALLOW_REDACTED — the
+    // comment above explains one branch of a condition that covers five, which
+    // has been misread as "LOCAL_ONLY reroutes" more than once.
+    //
+    // LOCAL_ONLY is the one whose reason names something the author can act on:
+    // "a local destination accepts it" is true, and the runtime does not route
+    // there (rerouting would silently downshift the model, a separate decision
+    // that is not this one to make). So the message must at least say how they
+    // reach that destination themselves, or it states a fact with no available
+    // action. The suggestion is appended to the STEP TEXT only — the receipt's
+    // `reason` stays exactly the policy fact it has always been, so the
+    // evidence-log format does not move.
+    //
+    // No other decision gets a suggestion. DENY is already honest that no
+    // approval unlocks it, and pointing its author at `driver: local` would
+    // send them to configure a destination that by construction does not
+    // accept the classification.
+    //
+    // The remedy goes BEFORE the reason, which reads oddly and is deliberate:
+    // `stepObservation`'s silent-fail detector caps the matched fragment at 120
+    // characters, and the LOCAL_ONLY reason alone is ~113. Appending the remedy
+    // put it past the cap, so the runner amputated it mid-word — a message
+    // written to be actionable, cut at exactly the actionable part. Anyone
+    // lengthening this string should re-check that cap rather than assume the
+    // whole of it reaches an operator.
+    const remedy =
+      boundary.decision === "LOCAL_ONLY"
+        ? "set `driver: local` on this step; "
+        : "";
     return {
-      text: `[agent step failed: information boundary — ${boundary.reason}]`,
+      text: `[agent step failed: information boundary — ${remedy}${boundary.reason}]`,
       servedBy: { driver: driver ?? "auto" },
     };
   }

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -3685,6 +3685,16 @@ function buildAgentExecutorDeps(
         const wsId = evidenceWorkspaceId();
         boundaryReceiptLog().record({
           ...(wsId && { workspaceId: wsId }),
+          // Which recipe produced this. Same source and same reasoning as
+          // `recordPrivacyShadowFn` 26 lines above — from StepDeps, not from
+          // the executor's callback shape, so the decision point is not widened
+          // to carry identity it does not need.
+          //
+          // #1469 added it to the SHADOW ledger and stopped there, leaving the
+          // ENFORCING ledger anonymous: an auditor could see that a `personal`
+          // dispatch was refused and not which of 80 recipes to go and fix.
+          // `BoundaryReceipt` has declared the field the whole time.
+          ...(stepDeps.recipeName && { recipeName: stepDeps.recipeName }),
           decision: r.decision as BoundaryDecisionValue,
           classification: r.classification as ClassificationValue,
           destinationId: r.destinationId,


### PR DESCRIPTION
## The gap

#1469 fixed exactly this on the shadow ledger and stopped one file short.

`recordBoundaryDecisionFn` sits **26 lines below** `recordPrivacyShadowFn` in the same object literal in `yamlRunner.ts` and never passed `recipeName` — though `BoundaryReceipt` has declared the field throughout. Declared-but-supplied-nowhere, the same pattern, the same seam, one screen away.

The consequence is the wrong way round:

| Ledger | Records | Attributed before this PR |
|---|---|---|
| `privacy_shadow.jsonl` | hypotheticals | yes (#1469) |
| `boundary_receipts.jsonl` | **enforced decisions** | **no** |

The receipt log is what ADR-0021 calls the audit record, and the only ledger that can say why a step actually failed. An auditor could read that a `personal` dispatch had been stopped and not learn which recipe to go and fix.

## Measured first

Four live probe runs against an isolated `PATCHWORK_HOME`: **nine receipts, three of them `LOCAL_ONLY` refusals, none carrying a recipe name.**

## Second change: the refusal names its remedy

`LOCAL_ONLY` read:

```
"personal" may not leave the machine; a local destination accepts it
```

True; names a destination the runtime does not route to; gives the author no way to reach it. It now leads with `set \`driver: local\` on this step`.

- **Rerouting instead of refusing is deliberately NOT done here.** That would silently downshift the model, which is a separate design decision.
- **`DENY` gets no suggestion.** It is already honest that no approval unlocks it, and a suggestion there would send an author to configure something that by construction cannot apply. A test asserts this, and it fails when the remedy is made unconditional.
- **The remedy is emitted BEFORE the reason**, which reads oddly and is load-bearing: `stepObservation` caps a silent-fail fragment at 120 characters and the reason alone is ~113, so appending it was amputated mid-word — a message written to be actionable, cut at exactly the actionable part.

## What does not change

The suggestion goes to the **step text only**. `reason` stays the policy fact, so the evidence-log format does not move. A recipe name is not payload — ADR-0021's "receipts carry no payload field" rule is untouched, and this is the same attribution metadata #1455 established for evidence records.

## Verification

Tests drive the real `runYamlRecipe` with `PATCHWORK_HOME` (not a spy on `os.homedir`, and not hand-injected deps) — the defect is missing wiring, and hand-injection cannot see it.

All three guards mutation-tested, each mutation confirmed applied before trusting the result:

| Mutation | Expected | Observed |
|---|---|---|
| delete the `recipeName` pass-through | attribution dies | 2 failed |
| blank the remedy | LOCAL_ONLY message dies | 1 failed |
| make the remedy unconditional | DENY guard dies | 1 failed |

`npx vitest run src/recipes src/privacy` — 146 files, 1866 tests, green. Typecheck clean. In-flight, business-content, private-identifier and LSP-tool gates all pass.

Also repairs `docs/in-flight.md`, where #1472's merge left a duplicated "Recently closed" heading and an orphaned entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)