### PR TITLE
fix(privacy): the workspace tag recorded which process wrote the row

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,16 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-19 `fix/evidence-workspace-seed` — the evidence workspace tag (#1455) records WHICH PROCESS
+  wrote the row, not which workspace. `evidenceWorkspaceId()` in `yamlRunner` calls
+  `resolveWorkspaceRoot()` with no seed, so it walks up from `process.cwd()`. Measured: two bridges
+  serving the SAME workspace, one with cwd `~` (no `.git` ancestor → every row untagged) and one with
+  cwd in the repo (tagged) — 22 of 40 shadow rows tagged, 0 of 4 boundary receipts. Two sibling call
+  sites already seed correctly (`recipeOrchestration.ts:1607`, `claudeOrchestrator.ts:532`); this is
+  the third and it is the one writing privacy evidence. Seeds from `stepDeps.workdir`, which
+  `bridge.ts` already fills from `config.workspace`. Existing untagged rows are NOT backfilled.
+  Touches `src/recipes/yamlRunner.ts` — collides with any privacy, evidence or recipe-runner work.
+  — this session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,6 +29,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-19 `fix/evidence-workspace-seed` — the evidence workspace tag (#1455) records WHICH PROCESS
   wrote the row, not which workspace. `evidenceWorkspaceId()` in `yamlRunner` calls
   `resolveWorkspaceRoot()` with no seed, so it walks up from `process.cwd()`. Measured: two bridges
@@ -38,9 +42,7 @@ verified (which is how this line came to be written).
   the third and it is the one writing privacy evidence. Seeds from `stepDeps.workdir`, which
   `bridge.ts` already fills from `config.workspace`. Existing untagged rows are NOT backfilled.
   Touches `src/recipes/yamlRunner.ts` — collides with any privacy, evidence or recipe-runner work.
-  — this session
-
-## Recently closed (informal log, prune periodically)
+  — this session — merged as #1475
 
 - 2026-08-19 `fix/boundary-receipt-attribution` — #1469 attributed the SHADOW ledger to its recipe
   and left the ENFORCING one anonymous: `recordBoundaryDecisionFn` sits 26 lines below

--- a/src/privacy/__tests__/evidenceWorkspaceSeed.test.ts
+++ b/src/privacy/__tests__/evidenceWorkspaceSeed.test.ts
@@ -1,0 +1,208 @@
+/**
+ * The evidence workspace tag records WHICH PROCESS wrote the row, not which
+ * workspace produced it.
+ *
+ * #1455 tagged evidence records with a short workspace id. `evidenceWorkspaceId()`
+ * in `yamlRunner` resolves it with a bare `resolveWorkspaceRoot()` — and that
+ * function, given no `startDir`, walks up from `process.cwd()` looking for a
+ * `.git` marker. So the tag describes the writing process's working directory,
+ * never the workspace the bridge was pointed at.
+ *
+ * Measured on the live deployment, and the measurement is the argument:
+ *
+ *   bridge A   cwd = the home directory   no `.git` ancestor → UNTAGGED
+ *   bridge B   cwd = the checkout          `.git` found       → tagged
+ *
+ * Both lock files record the SAME `workspace`. So two identically-configured
+ * bridges serving one workspace disagreed about its identity, and the ledger
+ * recorded which of them happened to take the call. 22 of 40 shadow rows carried
+ * a tag; 0 of 4 boundary receipts did.
+ *
+ * A partially-populated field is worse than an empty one here: rows carrying a
+ * tag invite the conclusion that tagging works.
+ *
+ * Two sibling call sites already do this correctly and neither was copied:
+ *
+ *   recipeOrchestration.ts:1607   currentWorkspaceId(this.deps.workdir)
+ *   claudeOrchestrator.ts:532     resolveWorkspaceRoot({ startDir: this.workspace })
+ *
+ * `stepDeps.workdir` is the right seed and is already present at this seam —
+ * it is the same object `recipeName` was taken from in #1474, and `bridge.ts`
+ * fills it from `config.workspace`.
+ *
+ * NOT backfilled. `workspaceId.ts` says an omitted field "says nothing" while a
+ * populated one asserts somebody looked — rewriting history to assert a
+ * workspace nobody recorded is the error that module exists to avoid.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { currentWorkspaceId } from "../../workspaceId.js";
+
+let dir: string;
+let home: string;
+let workdir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(os.tmpdir(), "ws-seed-"));
+  home = join(dir, "home");
+  mkdirSync(home, { recursive: true });
+
+  // A workspace that is NOT an ancestor of the test process's cwd, and that
+  // carries its own `.git` marker so the resolver stops there. Without the
+  // marker the walk would climb out of the temp tree and the assertion could
+  // not tell a fixed implementation from a lucky one.
+  workdir = join(dir, "a-workspace");
+  mkdirSync(join(workdir, ".git"), { recursive: true });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function writeShadowOnlyConfig(): void {
+  // `privacy.shadow`, not `privacy.destinations`: this test is about the tag on
+  // the row, so it must not also turn enforcement on.
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify({
+      privacy: {
+        shadow: {
+          destinations: {
+            "test-local": {
+              type: "local",
+              classifications: ["public", "internal"],
+              drivers: ["local"],
+            },
+          },
+        },
+      },
+    }),
+  );
+}
+
+function writeEnforcingConfig(): void {
+  // The ENFORCING key. The receipt log is the ledger ADR-0021 calls the audit
+  // record, and it was the one with 0 of 4 rows tagged — so it needs its own
+  // case rather than riding on the shadow assertions. Without it, reverting the
+  // seed at the receipt call site alone leaves every test green.
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify({
+      privacy: {
+        destinations: {
+          "test-local": {
+            type: "local",
+            classifications: ["public", "internal"],
+            drivers: ["local"],
+          },
+        },
+      },
+    }),
+  );
+}
+
+function receipts(): Array<{ workspaceId?: string }> {
+  return readFileSync(join(home, "boundary_receipts.jsonl"), "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as { workspaceId?: string });
+}
+
+async function run(): Promise<Array<{ workspaceId?: string }>> {
+  const prev = process.env.PATCHWORK_HOME;
+  const prevWs = process.env.PATCHWORK_WORKSPACE;
+  process.env.PATCHWORK_HOME = home;
+  // Unset so the resolver cannot reach the answer by env — the point is that
+  // the SEED is wrong, and an env var would mask it.
+  delete process.env.PATCHWORK_WORKSPACE;
+  try {
+    const { runYamlRecipe } = await import("../../recipes/yamlRunner.js");
+    await runYamlRecipe(
+      {
+        name: "tagged-recipe",
+        trigger: { type: "manual" },
+        steps: [{ agent: { prompt: "hi", driver: "local" } }],
+      } as never,
+      {
+        testMode: true,
+        logDir: dir,
+        workdir,
+        now: () => new Date("2026-08-19T00:00:00Z"),
+        readFile: () => {
+          throw new Error("nope");
+        },
+        writeFile: () => {},
+        appendFile: () => {},
+        mkdir: () => {},
+        gitLogSince: () => "",
+        gitStaleBranches: () => "",
+        getDiagnostics: () => "",
+        claudeFn: async () => "ok",
+      } as never,
+    );
+    // Absent under an enforcing-only config, which is a valid state for this
+    // helper rather than a failure — the receipt case asserts on its own file.
+    try {
+      return readFileSync(join(home, "privacy_shadow.jsonl"), "utf-8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as { workspaceId?: string });
+    } catch {
+      return [];
+    }
+  } finally {
+    if (prev === undefined) delete process.env.PATCHWORK_HOME;
+    else process.env.PATCHWORK_HOME = prev;
+    if (prevWs !== undefined) process.env.PATCHWORK_WORKSPACE = prevWs;
+  }
+}
+
+describe("the evidence tag names the workspace, not the writing process's cwd", () => {
+  it("tags the row with the workspace the run was given", async () => {
+    writeShadowOnlyConfig();
+
+    const rows = await run();
+    expect(rows.length).toBeGreaterThan(0);
+
+    // The discriminating assertion. Before the fix this is the id of whatever
+    // repo the TEST RUNNER happens to sit in — a real id, on the wrong
+    // workspace, which is precisely why the defect survived: the field was
+    // populated and plausible.
+    expect(rows.at(-1)?.workspaceId).toBe(currentWorkspaceId(workdir));
+  });
+
+  it("does not tag it with the process's own workspace", async () => {
+    writeShadowOnlyConfig();
+
+    const rows = await run();
+    const cwdId = currentWorkspaceId(process.cwd());
+
+    // Guard against a fix that merely stops resolving: `toBe(workdirId)` above
+    // would also pass if BOTH were undefined on some machine. This pins the
+    // direction of the error the fix removes.
+    expect(rows.at(-1)?.workspaceId).toBeDefined();
+    expect(rows.at(-1)?.workspaceId).not.toBe(cwdId);
+  });
+});
+
+describe("the enforcing receipt ledger is tagged too", () => {
+  it("tags a boundary receipt with the run's workspace", async () => {
+    writeEnforcingConfig();
+
+    await run();
+    const rows = receipts();
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.at(-1)?.workspaceId).toBe(currentWorkspaceId(workdir));
+    expect(rows.at(-1)?.workspaceId).not.toBe(
+      currentWorkspaceId(process.cwd()),
+    );
+  });
+});

--- a/src/privacy/boundaryReceiptLog.ts
+++ b/src/privacy/boundaryReceiptLog.ts
@@ -50,9 +50,16 @@ export interface BoundaryReceipt {
   /** Which categories the decision required be removed. */
   redactCategories?: string[];
   reason: string;
-  /** Recipe/step context when the caller knows it. */
+  /**
+   * Which recipe produced this (#1474).
+   *
+   * A sibling `stepId` was declared here and supplied by nothing — the exact
+   * field, for the exact reason, that #1469 removed from `ShadowRow`. Removed
+   * rather than wired: the decision point has no step id in scope, so a
+   * declared-but-empty field only tells a reader that step-level attribution
+   * exists when it does not.
+   */
   recipeName?: string;
-  stepId?: string;
   /** Short workspace id — a tag for attribution, never a filter. */
   workspaceId?: string;
 }
@@ -66,7 +73,6 @@ export interface RecordBoundaryReceiptInput {
   redactCategories?: string[];
   reason: string;
   recipeName?: string;
-  stepId?: string;
   workspaceId?: string;
 }
 
@@ -149,7 +155,14 @@ export class BoundaryReceiptLog {
         ? { redactCategories: input.redactCategories }
         : {}),
       ...(input.recipeName ? { recipeName: input.recipeName } : {}),
-      ...(input.stepId ? { stepId: input.stepId } : {}),
+      // Both types have declared `workspaceId` since #1455 and the caller has
+      // been passing it since; this constructor never copied it, so the field
+      // could not appear on a receipt from any bridge, in any working
+      // directory. That is why 22 of 40 shadow rows carried a workspace tag
+      // while 0 of 4 receipts did — two independent bugs stacked on one field,
+      // and the shadow ledger's partial success hid the receipt ledger's total
+      // failure.
+      ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
     };
     this.receipts.push(receipt);
     this.trim();

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -3580,10 +3580,30 @@ const _boundaryReceiptLogs = new Map<string, BoundaryReceiptLog>();
  * Fail-soft to `undefined` — an unattributed record is the honest outcome when
  * the workspace cannot be resolved, and it is strictly better than a record
  * that asserts the wrong one.
+ *
+ * `startDir` is the run's `workdir`, and passing it is the whole point. With no
+ * seed `resolveWorkspaceRoot` walks up from `process.cwd()`, so the tag recorded
+ * the WRITING PROCESS's directory rather than the workspace the bridge was
+ * pointed at. Measured live: two bridges serving the same workspace, one with
+ * cwd `~` (no `.git` ancestor, every row untagged) and one with cwd inside the
+ * repo (tagged) — so the ledger recorded which of them took the call. That is
+ * worse than an empty field, because the rows that DID carry a tag made the
+ * mechanism look like it worked.
+ *
+ * Two sibling sites already seed correctly and neither was copied here:
+ * `recipeOrchestration.ts` (`currentWorkspaceId(this.deps.workdir)`) and
+ * `claudeOrchestrator.ts` (`resolveWorkspaceRoot({ startDir: this.workspace })`).
+ *
+ * The `.git` walk is KEPT rather than hashing `startDir` directly, which is the
+ * smaller change: it fixes the seed without changing the derivation. The two
+ * differ only when a workspace is a SUBDIRECTORY of a repo, where this yields
+ * the repo root and `recipeOrchestration` yields the subdirectory. That
+ * divergence predates this change and unifying it is a separate decision — it
+ * would move existing ids, splitting a ledger rather than tagging it.
  */
-function evidenceWorkspaceId(): string | undefined {
+function evidenceWorkspaceId(startDir?: string): string | undefined {
   try {
-    return currentWorkspaceId(resolveWorkspaceRoot()?.path);
+    return currentWorkspaceId(resolveWorkspaceRoot({ startDir })?.path);
   } catch {
     return undefined;
   }
@@ -3653,7 +3673,7 @@ function buildAgentExecutorDeps(
         }
       ).privacy?.shadow,
     recordPrivacyShadowFn: (r) => {
-      const shadowWsId = evidenceWorkspaceId();
+      const shadowWsId = evidenceWorkspaceId(stepDeps.workdir);
       recordPrivacyShadow({
         ...(shadowWsId && { workspaceId: shadowWsId }),
         // Which recipe produced this (#1469). Taken from StepDeps rather than
@@ -3682,7 +3702,7 @@ function buildAgentExecutorDeps(
       // Fail-soft: a receipt that cannot be written must never affect the
       // decision it describes, which has already been made and enforced.
       try {
-        const wsId = evidenceWorkspaceId();
+        const wsId = evidenceWorkspaceId(stepDeps.workdir);
         boundaryReceiptLog().record({
           ...(wsId && { workspaceId: wsId }),
           // Which recipe produced this. Same source and same reasoning as


### PR DESCRIPTION
## Two bugs on one field, and the first hid the second

#1455 tagged evidence records with a short workspace id. The tag never described the workspace.

### 1. The seed

`evidenceWorkspaceId()` called `resolveWorkspaceRoot()` with no `startDir` — and that walks up from `process.cwd()` looking for a `.git` marker. So the tag recorded the **writing process's working directory**.

Measured live on two bridges whose lock files name the **same** workspace:

| bridge | cwd | `.git` ancestor | rows |
|---|---|---|---|
| A | home directory | none | **untagged** |
| B | the checkout | found | tagged |

Two identically-configured bridges serving one workspace disagreed about its identity, and the ledger recorded which of them happened to take the call.

Two sibling sites already seed correctly, and neither was copied:

```
recipeOrchestration.ts   currentWorkspaceId(this.deps.workdir)
claudeOrchestrator.ts    resolveWorkspaceRoot({ startDir: this.workspace })
yamlRunner.ts            resolveWorkspaceRoot()                 ← this one
```

`stepDeps.workdir` is the right seed, is already present at this seam (it is the same object `recipeName` came from in #1474), and `bridge.ts` fills it from `config.workspace`.

The `.git` walk is **kept** rather than hashing the workdir directly — the smaller change, fixing the seed without moving existing ids. The two derivations differ only when a workspace is a subdirectory of a repo; that divergence predates this PR, and unifying it would split a ledger rather than tag it.

### 2. The receipt constructor dropped the field

`BoundaryReceiptLog.record` builds its row field-by-field and **never copied `workspaceId`** — though `BoundaryReceipt` and `RecordBoundaryReceiptInput` both declare it, and the caller has been passing it since #1455. A receipt could not carry a workspace from any bridge, in any directory.

**That is why 22 of 40 shadow rows were tagged and 0 of 4 receipts were.** The shadow ledger's partial success made the mechanism look like it worked — a partially-populated field is worse than an empty one for precisely that reason.

Caught only because the test asserts on the receipt ledger **separately** rather than assuming the shadow case covered it. It did not.

## Also

Removes a dead `stepId` from the receipt — declared twice, supplied by nothing, no consumer anywhere including the dashboard. The same field, for the same reason, that #1469 removed from `ShadowRow`. A note is left where it was so it is not re-added.

## Not backfilled

Existing untagged rows stay untagged. `workspaceId.ts` states that an omitted field says nothing while a populated one asserts somebody looked — writing a workspace nobody recorded is the error that module exists to avoid.

## Verification

The failing test is the defect: before the fix, a run explicitly given workspace `X` recorded the id of **whatever repo the test runner sat in** — a real id, on the wrong workspace, which is why this survived.

All three changes mutation-tested, each mutation confirmed applied before trusting the result:

| Mutation | Applied | Result |
|---|---|---|
| un-seed the shadow writer | 2 sites → 1 | 2 failed |
| un-seed the receipt writer | 2 sites → 1 | 1 failed |
| stop persisting `workspaceId` | 1 site → 0 | 1 failed |

`npx vitest run src/recipes src/privacy` — 147 files, 1869 tests, green. Typecheck clean. In-flight, business-content and LSP-tool gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)