### PR TITLE
fix(recipes): every butler errand filed to the inbox, whatever project you named (#1464)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,11 +29,13 @@ verified (which is how this line came to be written).
 
 ## Active
 
+_Nothing in flight._
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-20 `fix/butler-errand-project-id` — #1464: butler-errand template passed `project_id`
   where `todoist.create_task` declares `projectId`, so every errand filed to the default
   inbox. One-line template fix + a scoped regression test. — main session
-
-## Recently closed (informal log, prune periodically)
 
 - 2026-08-19 `fix/evidence-workspace-seed` — the evidence workspace tag (#1455) records WHICH PROCESS
   wrote the row, not which workspace. `evidenceWorkspaceId()` in `yamlRunner` calls

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,9 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-20 `fix/butler-errand-project-id` — #1464: butler-errand template passed `project_id`
+  where `todoist.create_task` declares `projectId`, so every errand filed to the default
+  inbox. One-line template fix + a scoped regression test. — main session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/recipes/__tests__/butlerErrandTemplateParams.test.ts
+++ b/src/recipes/__tests__/butlerErrandTemplateParams.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression test for #1464 — `templates/recipes/butler-errand.yaml` passed
+ * `project_id` to `todoist.create_task`, which declares `projectId`.
+ *
+ * Why this failed silently, and why a test rather than a drive-by commit:
+ * `executeStep` (yamlRunner.ts) builds a tool's params from EVERY step key
+ * except `tool` / `agent` / `into`, and no tool's `paramsSchema` sets
+ * `additionalProperties: false`. So an undeclared key is accepted, rendered,
+ * handed to the executor, and ignored — `resolvedParams` in the run log even
+ * records it faithfully, because that is what the recipe said. The task is
+ * created, the run succeeds, and the only symptom is that every Butler errand
+ * lands in the default inbox regardless of the `project_id` var the operator
+ * set.
+ *
+ * Scope is deliberately this ONE template, not a general lint rule. The step
+ * control keys and the tool params share one flat namespace, and the set of
+ * control keys exists only implicitly across validation.ts, yamlRunner.ts and
+ * compiler.ts — there is no authoritative list to check an arbitrary recipe
+ * against. Inventing one here would be a correct-looking rule pointed at a
+ * partial surface. `butler-errand.yaml` is the reference worker bundle, its
+ * step set is small and enumerable, so the narrow check is sound where the
+ * general one is not. See the measurement in #1464.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import "../tools/index.js";
+import { getTool } from "../toolRegistry.js";
+
+const TEMPLATE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../templates/recipes/butler-errand.yaml",
+);
+
+/**
+ * Step keys `executeStep` consumes itself rather than forwarding to the tool,
+ * plus the keys the validator/compiler own. Hand-maintained ON PURPOSE and
+ * safe only because the surface is one small template — see the module doc.
+ */
+const STEP_CONTROL_KEYS = new Set([
+  "tool",
+  "agent",
+  "into",
+  "id",
+  "when",
+  "do",
+  "optional",
+  "retry",
+  "retryDelay",
+  "transform",
+  "expect",
+  "timeout_ms",
+  "silentFailDetection",
+  "risk",
+  "awaits",
+  "data_policy",
+]);
+
+interface Step {
+  tool?: string;
+  [key: string]: unknown;
+}
+
+let steps: Step[];
+
+beforeAll(() => {
+  const doc = parseYaml(readFileSync(TEMPLATE, "utf8")) as { steps: Step[] };
+  steps = doc.steps;
+});
+
+describe("#1464: butler-errand template names declared tool parameters", () => {
+  it("registers the tools the template calls (guards a silently empty registry)", () => {
+    const toolSteps = steps.filter((s) => typeof s.tool === "string");
+    expect(toolSteps.length).toBeGreaterThan(0);
+    for (const step of toolSteps) {
+      expect(getTool(step.tool as string), `tool ${step.tool}`).toBeDefined();
+    }
+  });
+
+  it("passes no undeclared parameter to any tool step", () => {
+    const offenders: string[] = [];
+    for (const step of steps) {
+      if (typeof step.tool !== "string") continue;
+      const tool = getTool(step.tool);
+      if (!tool) continue;
+      const declared = Object.keys(
+        (tool.paramsSchema?.properties ?? {}) as Record<string, unknown>,
+      );
+      for (const key of Object.keys(step)) {
+        if (STEP_CONTROL_KEYS.has(key)) continue;
+        if (!declared.includes(key)) offenders.push(`${step.tool}.${key}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("files into the Todoist project the operator named", () => {
+    const create = steps.find((s) => s.tool === "todoist.create_task");
+    expect(create).toBeDefined();
+    // The declared name, and the var the trigger exposes, must both be right —
+    // renaming the key while dropping the var would pass the check above and
+    // still file everything into the inbox.
+    expect(create).toHaveProperty("projectId", "{{project_id}}");
+    expect(create).not.toHaveProperty("project_id");
+  });
+});

--- a/src/recipes/__tests__/butlerErrandTemplateParams.test.ts
+++ b/src/recipes/__tests__/butlerErrandTemplateParams.test.ts
@@ -86,9 +86,13 @@ describe("#1464: butler-errand template names declared tool parameters", () => {
       if (typeof step.tool !== "string") continue;
       const tool = getTool(step.tool);
       if (!tool) continue;
-      const declared = Object.keys(
-        (tool.paramsSchema?.properties ?? {}) as Record<string, unknown>,
-      );
+      // `paramsSchema` is typed `{}` on RegisteredTool, so `.properties`
+      // needs a narrowing cast — the core-ratchet typecheck is stricter than
+      // the main tsconfig and rejects the property access otherwise.
+      const schema = tool.paramsSchema as {
+        properties?: Record<string, unknown>;
+      };
+      const declared = Object.keys(schema?.properties ?? {});
       for (const key of Object.keys(step)) {
         if (STEP_CONTROL_KEYS.has(key)) continue;
         if (!declared.includes(key)) offenders.push(`${step.tool}.${key}`);

--- a/templates/recipes/butler-errand.yaml
+++ b/templates/recipes/butler-errand.yaml
@@ -62,7 +62,7 @@ steps:
   - when: "{{title}} != DUPLICATE"
     tool: todoist.create_task
     content: "{{title}}"
-    project_id: "{{project_id}}"
+    projectId: "{{project_id}}"
     into: created
 
   # The receipt. `created.id` is what todoist.delete_task needs to undo this —


### PR DESCRIPTION
Closes #1464.

## The defect

`templates/recipes/butler-errand.yaml` passed `project_id` to `todoist.create_task`, which declares **`projectId`**.

Nothing rejected it. `executeStep` (`src/recipes/yamlRunner.ts:3054`) builds a tool's params from *every* step key except `tool` / `agent` / `into`, and no tool's `paramsSchema` sets `additionalProperties: false`. The key was accepted, template-rendered, handed to the executor, and ignored. `createTask` saw `projectId === undefined`, omitted it from the request body, and filed into the account's default inbox.

Nothing errored. The task was created, the run succeeded, the receipt printed a real id, and `todoist.delete_task` could still undo it. The only symptom was errands landing in the wrong place — which reads as a Todoist setting rather than a bug. The run log made it worse rather than better: `resolvedParams` recorded `project_id` faithfully, because that is what the recipe said.

This is the reference worker bundle, so anyone copying it inherited the same dead parameter.

## Why the test is scoped to one template

The issue asks whether an undeclared parameter should be a lint error. Measured before deciding, across 101 recipe files / 329 tool steps (live operator set + shipped templates): **152 step keys are not declared by the tool they are passed to** — but most are not typos. `optional`, `risk`, `transform` and `awaits` are real step control keys, handled in `yamlRunner.ts` / `compiler.ts` / `validation.ts`.

Step control keys and tool params share one flat namespace, and the control-key set exists only *implicitly* across those three files. There is no authoritative list to check an arbitrary recipe against, and a hand-written one would be a correct-looking rule pointed at a partial surface — mine was wrong twice while measuring. So the general rule needs that constant extracted first; that stays filed on #1464 rather than being guessed at here.

`butler-errand.yaml` is small and its step set enumerable, so the narrow check is sound where the general one is not.

## Verification

The two target assertions failed before the fix and pass after.

The registry guard is the load-bearing half, and it was mutation-tested: changing the step's tool id to an unregistered name makes the undeclared-param check pass **vacuously** — `getTool` returns `undefined` and the loop skips every key. Applied that mutation, confirmed it applied (`grep -c` on the file), watched the guard fail, restored and re-confirmed. Without the guard, a future tool rename would silently retire this test rather than break it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)