### PR TITLE
fix(butler): the promote report's arithmetic did not close (#1477)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-20 `fix/butler-promote-denominator` — #1477: the promote report counted ledger
+  ROWS in its headline and distinct ACTIONS in the breakdown, with nothing saying the unit
+  changed, so its arithmetic did not close on the screen a person reads before a one-way
+  write. — main session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/butler/__tests__/promoteShadowOutcomes.test.ts
+++ b/src/butler/__tests__/promoteShadowOutcomes.test.ts
@@ -323,3 +323,64 @@ describe("a worker cannot reach this", () => {
     expect(SRC).toMatch(/PATCHWORK_FLAG_BUTLER_PROMOTE/);
   });
 });
+
+/**
+ * #1477 — the report counted ledger ROWS in its headline and distinct ACTIONS
+ * in the breakdown beneath it, with no line saying the unit had changed.
+ *
+ * Found by running the command against the live ledger: it printed 9 rows and
+ * then "1 promotable · 2 withheld", and one plus two is three. Nothing was
+ * wrong with the fold — an errand is re-graded on every pass, so the same ref
+ * legitimately appears many times and `latest` keeps the newest grade. The
+ * reporting was wrong, and it was wrong in the one place it matters most: the
+ * summary a person reads before authorising a one-way write to the trust dial.
+ * The two plausible readings of a gap like that — rows silently dropped, rows
+ * that failed to parse — are both good reasons to refuse.
+ */
+describe("#1477: the report's arithmetic closes", () => {
+  it("counts distinct actions separately from ledger rows", () => {
+    // Three errands, each graded three times — the live shape exactly.
+    seedLedger([
+      { ref: "todoist.create_task:aaa", disposition: "unknown", gradedAt: 1 },
+      { ref: "todoist.create_task:bbb", disposition: "unknown", gradedAt: 2 },
+      { ref: "todoist.create_task:ccc", disposition: "unknown", gradedAt: 3 },
+      { ref: "todoist.create_task:aaa", disposition: "unknown", gradedAt: 4 },
+      { ref: "todoist.create_task:bbb", disposition: "unknown", gradedAt: 5 },
+      { ref: "todoist.create_task:ccc", disposition: "unknown", gradedAt: 6 },
+      { ref: "todoist.create_task:aaa", disposition: "confirmed", gradedAt: 7 },
+      { ref: "todoist.create_task:bbb", disposition: "unknown", gradedAt: 8 },
+      { ref: "todoist.create_task:ccc", disposition: "unknown", gradedAt: 9 },
+    ]);
+    const r = promoteShadowOutcomes({ patchworkDir: dir, dryRun: true });
+
+    expect(r.rows).toBe(9);
+    expect(r.actions).toBe(3);
+    // The breakdown is per-action, and it must account for every action.
+    expect(r.promotable + r.withheld).toBe(r.actions);
+  });
+
+  it("names both units in the rendered report", () => {
+    seedLedger([
+      { ref: "todoist.create_task:aaa", disposition: "unknown", gradedAt: 1 },
+      { ref: "todoist.create_task:aaa", disposition: "confirmed", gradedAt: 2 },
+    ]);
+    const out = formatPromoteResult(
+      promoteShadowOutcomes({ patchworkDir: dir, dryRun: true }),
+    );
+    expect(out).toMatch(/2 graded row\(s\)/);
+    expect(out).toMatch(/1 distinct action/);
+    // A reader must be told WHY the two numbers differ, or the report has
+    // merely replaced an unexplained gap with an unexplained pair.
+    expect(out).toMatch(/re-graded/i);
+  });
+
+  it("keeps rows and actions equal when nothing was re-graded", () => {
+    seedLedger([
+      { ref: "todoist.create_task:aaa", disposition: "confirmed", gradedAt: 1 },
+      { ref: "todoist.create_task:bbb", disposition: "unknown", gradedAt: 2 },
+    ]);
+    const r = promoteShadowOutcomes({ patchworkDir: dir, dryRun: true });
+    expect(r.rows).toBe(2);
+    expect(r.actions).toBe(2);
+  });
+});

--- a/src/butler/promoteShadowOutcomes.ts
+++ b/src/butler/promoteShadowOutcomes.ts
@@ -73,11 +73,24 @@ export interface PromoteOptions {
 }
 
 export interface PromoteResult {
-  /** Every graded row considered — the DENOMINATOR, always reported. */
+  /**
+   * Every graded row read from the shadow ledger.
+   *
+   * NOT the denominator of the breakdown below — see `actions`. The two are in
+   * different units, and printing them as though they were the same is #1477.
+   */
   rows: number;
-  /** Rows whose disposition is `confirmed` or `junk`. */
+  /**
+   * Distinct actions those rows cover, after folding by ref. THIS is the
+   * denominator of `promotable` / `withheld` / `alreadyRecorded`.
+   *
+   * An errand is re-graded on every ingester pass, so one action legitimately
+   * contributes many rows and only its latest grade counts.
+   */
+  actions: number;
+  /** Actions whose latest disposition is `confirmed` or `junk`. */
   promotable: number;
-  /** Rows withheld because the grader said `unknown`. */
+  /** Actions withheld because the latest grade was `unknown`. */
   withheld: number;
   /** Rows written to the outcome log. Zero on a dry run or with the flag off. */
   promoted: number;
@@ -139,6 +152,9 @@ export function promoteShadowOutcomes(opts: PromoteOptions): PromoteResult {
   const enabled = flagEnabled(opts);
   const result: PromoteResult = {
     rows: rows.length,
+    // Filled in once the fold below has run — it is the size of `latest`, and
+    // deriving it any other way would let the two drift apart again.
+    actions: 0,
     promotable: 0,
     withheld: 0,
     promoted: 0,
@@ -159,6 +175,8 @@ export function promoteShadowOutcomes(opts: PromoteOptions): PromoteResult {
     const prev = latest.get(row.ref);
     if (!prev || row.gradedAt >= prev.gradedAt) latest.set(row.ref, row);
   }
+
+  result.actions = latest.size;
 
   for (const row of latest.values()) {
     if (!wouldCountAsEvidence(row.disposition)) {
@@ -207,9 +225,20 @@ export function promoteShadowOutcomes(opts: PromoteOptions): PromoteResult {
  */
 export function formatPromoteResult(r: PromoteResult): string {
   const lines: string[] = [];
-  lines.push(`[butler-promote] ${r.rows} graded row(s) in the shadow ledger`);
   lines.push(
-    `  ${r.promotable} promotable (confirmed or junk) · ${r.withheld} withheld as unknown`,
+    `[butler-promote] ${r.rows} graded row(s) covering ${r.actions} distinct action(s)`,
+  );
+  // Say WHY the two differ whenever they do. Printing an unexplained pair is
+  // only marginally better than printing an unexplained gap — the reader still
+  // has to guess, and the plausible guesses are all worse than the truth.
+  if (r.rows !== r.actions) {
+    lines.push(
+      "  (an errand is re-graded on every pass; only its latest grade counts)",
+    );
+  }
+  lines.push(
+    `  of those ${r.actions}: ${r.promotable} promotable (confirmed or junk) · ` +
+      `${r.withheld} withheld as unknown`,
   );
   if (r.alreadyRecorded > 0) {
     lines.push(`  ${r.alreadyRecorded} already recorded with the same verdict`);


### PR DESCRIPTION
Closes #1477.

## The defect

`patchwork butler promote --dry-run` printed a headline counting ledger **rows** and a breakdown counting distinct **actions**, with no line saying the unit had changed. Against the live ledger:

```
9 graded row(s) in the shadow ledger
  1 promotable (confirmed or junk) · 2 withheld as unknown
```

One plus two is three. Six rows appeared to have gone missing.

## Nothing was missing

The fold is correct, and its comment already explains why: an errand is re-graded on every ingester pass, so one action legitimately contributes many rows and `latest` keeps the newest grade. Three errands graded three times each is exactly what the live ledger held.

The **reporting** was the defect, and it sat in the worst possible place — the summary a person reads before authorising a **one-way** write to the trust dial. The plausible readings of a gap like that are "rows were silently dropped" and "rows failed to parse", and both are good grounds to refuse.

`PromoteResult.rows` even carried the comment

```ts
/** Every graded row considered — the DENOMINATOR, always reported. */
```

while not being the denominator of the two numbers printed directly beneath it.

## The fix

`actions` is a first-class field taken from `latest.size` rather than recomputed, so the fold and the number describing it cannot drift apart. The render names both units and explains the difference **only when there is one** — an unexplained pair is only marginally better than an unexplained gap, since the reader still has to guess and every plausible guess is worse than the truth.

```
[butler-promote] 9 graded row(s) covering 3 distinct action(s)
  (an errand is re-graded on every pass; only its latest grade counts)
  of those 3: 1 promotable (confirmed or junk) · 2 withheld as unknown
```

## Verification

Three tests added, all failing before the change; the 16 existing tests still pass. Verified against the live ledger — 9 rows / 3 actions / 1 + 2 = 3.

Mutation tested by setting `actions = rows.length`: confirmed applied, watched two assertions fail, restored. Without that check the equal-by-coincidence case (`rows === actions` when nothing was re-graded) would have passed either way.

Fixtures use synthetic refs — the real ones carry third-party record ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)