### PR TITLE
docs(privacy): classify a step by what it handles, not by what its prompt says (#1473)

### DIFF
--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -179,6 +179,51 @@ are unaffected. This is the same fail-soft choice `members.json` makes and for
 the same reason: a boundary that breaks every existing install to solve a
 problem those installs do not have will be turned off.
 
+#### Classify by what the step HANDLES, not by what is in its prompt
+
+An author writing a `data_policy` naturally reads the prompt and classifies what
+they see there. For a tool-enabled driver (`claude-code`, `subprocess`) that
+**under-classifies**, because the prompt is frequently *instructions to go and
+fetch the data* rather than the data itself.
+
+```yaml
+- id: weekly_summary
+  agent:
+    driver: claude-code
+    prompt: |
+      Step 1 — Gather data. Run:
+        ls -1t ~/records/*.md | head -7
+      For each file, extract the recorded measurements and summarise the week.
+```
+
+Read literally, that prompt contains no records at all. Read for what the step
+*handles*, it processes a week of them. **The second reading is the correct
+one, and it is not the one a careful author necessarily arrives at.** The
+abstract rule is easy to agree with and still get wrong, which is why the
+example is here rather than only the rule.
+
+So: **classify by everything the step will handle, including whatever its tools
+will fetch.** If a human could not read the output without seeing the
+underlying records, the step handles those records.
+
+This is not a hole in enforcement, and the obvious inference from the above is
+wrong. The boundary gates the **dispatch**, not the payload. A step declared
+`personal` against a remote destination resolves to `LOCAL_ONLY`, so the step
+runs against a local model and *that* model performs the tool fetch — the data
+never leaves. `DENY` stops the step outright. Either way the fetch happens on
+the correct side of the line, or does not happen.
+
+The gap is entirely in **how an author picks the label**, and this ADR's design
+already anticipates it: classification is *declared, never detected*, precisely
+so that it can describe a step's subject matter rather than its bytes. What was
+missing was saying so where an author reads.
+
+`recipe lint` emits a hint for the population most likely to be affected — an
+agent step with a tool-enabled driver and no `data_policy`. It is a hint and
+not an error: absence is a legitimate default, deliberately, and the hint marks
+where the default is most likely to be the wrong one. It does not and cannot
+find an under-classified step that *did* declare a policy.
+
 ### Phase 2 — the decision
 
 `ALLOW` · `ALLOW_REDACTED` · `LOCAL_ONLY` · `REQUIRE_APPROVAL` · `DENY`

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,16 +29,17 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-20 `fix/butler-promote-denominator` — #1477: the promote report counted ledger
-  ROWS in its headline and distinct ACTIONS in the breakdown, with nothing saying the unit
-  changed, so its arithmetic did not close on the screen a person reads before a one-way
-  write. — main session
 - 2026-08-20 `docs/classify-by-what-a-step-handles` — #1473: an author classifies what the
   prompt shows, but a tool-enabled step's prompt is instructions to FETCH, so it
   under-classifies. ADR-0021 paragraph + worked example, plus a `recipe lint` WARNING (never
   an error) on the population most likely affected. — main session
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-20 `fix/butler-promote-denominator` — #1477: the promote report counted ledger
+  ROWS in its headline and distinct ACTIONS in the breakdown, with nothing saying the unit
+  changed, so its arithmetic did not close on the screen a person reads before a one-way
+  write. — main session
 
 - 2026-08-20 `fix/butler-errand-project-id` — #1464: butler-errand template passed `project_id`
   where `todoist.create_task` declares `projectId`, so every errand filed to the default

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -33,6 +33,10 @@ verified (which is how this line came to be written).
   ROWS in its headline and distinct ACTIONS in the breakdown, with nothing saying the unit
   changed, so its arithmetic did not close on the screen a person reads before a one-way
   write. — main session
+- 2026-08-20 `docs/classify-by-what-a-step-handles` — #1473: an author classifies what the
+  prompt shows, but a tool-enabled step's prompt is instructions to FETCH, so it
+  under-classifies. ADR-0021 paragraph + worked example, plus a `recipe lint` WARNING (never
+  an error) on the population most likely affected. — main session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/recipes/__tests__/dataPolicyPlacement.test.ts
+++ b/src/recipes/__tests__/dataPolicyPlacement.test.ts
@@ -13,7 +13,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { misplacedDataPolicy } from "../dataPolicyPlacement.js";
+import {
+  misplacedDataPolicy,
+  unclassifiedToolEnabledAgent,
+} from "../dataPolicyPlacement.js";
 import { validateRecipeDefinition } from "../validation.js";
 
 describe("placements that are correct and must stay silent", () => {
@@ -137,5 +140,113 @@ describe("recipe lint refuses it", () => {
     expect(
       res.issues.filter((i) => i.code === "data-policy-misplaced"),
     ).toEqual([]);
+  });
+});
+
+/**
+ * #1473 — classify by what a step HANDLES, not by what is in its prompt.
+ *
+ * A tool-enabled step's prompt is frequently instructions to go and fetch the
+ * data rather than the data itself, so an author classifying what they can see
+ * under-classifies what the step handles. This hint marks that population.
+ *
+ * It is a WARNING on purpose. Absence of a `data_policy` is a legitimate,
+ * documented default, so an error here would break existing recipes to solve a
+ * problem those recipes may not have — the exact failure ADR-0021's fail-soft
+ * choice exists to avoid.
+ */
+describe("#1473: unclassifiedToolEnabledAgent", () => {
+  const prompt = "Run `ls ~/records` and summarise what you find";
+
+  it("hints at a tool-enabled agent step with no data_policy", () => {
+    const hit = unclassifiedToolEnabledAgent({
+      agent: { driver: "claude-code", prompt },
+    });
+    expect(hit?.message).toMatch(/what the step HANDLES/);
+  });
+
+  it("covers subprocess and codex too", () => {
+    for (const driver of ["subprocess", "codex"]) {
+      expect(
+        unclassifiedToolEnabledAgent({ agent: { driver, prompt } }),
+      ).not.toBeNull();
+    }
+  });
+
+  it("stays silent once a policy is declared in the right place", () => {
+    expect(
+      unclassifiedToolEnabledAgent({
+        agent: {
+          driver: "claude-code",
+          prompt,
+          data_policy: { classification: "personal" },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("stays silent on a driver that cannot fetch", () => {
+    expect(
+      unclassifiedToolEnabledAgent({ agent: { driver: "local", prompt } }),
+    ).toBeNull();
+  });
+
+  it("does not fire on a step whose driver is absent (auto)", () => {
+    // Named limit, not an oversight: `auto` resolves at run time and may well
+    // become tool-enabled, but flagging every driver-less agent step would flag
+    // most steps in most recipes. The hint text says so rather than implying
+    // total coverage.
+    expect(unclassifiedToolEnabledAgent({ agent: { prompt } })).toBeNull();
+  });
+
+  it("says out loud that it cannot see an `auto` step", () => {
+    const hit = unclassifiedToolEnabledAgent({
+      agent: { driver: "subprocess", prompt },
+    });
+    expect(hit?.message).toMatch(/cannot see[\s\S]*`auto`/);
+  });
+
+  it("defers to the misplacement error rather than doubling up", () => {
+    // One author mistake must produce one message. Both firing would suggest
+    // opposite fixes: "move it inside agent" and "add one".
+    const step = {
+      agent: { driver: "claude-code", prompt },
+      data_policy: { classification: "personal" },
+    };
+    expect(misplacedDataPolicy(step)).not.toBeNull();
+    expect(unclassifiedToolEnabledAgent(step)).toBeNull();
+  });
+
+  it("ignores a tool step, which makes no dispatch at all", () => {
+    expect(
+      unclassifiedToolEnabledAgent({ tool: "file.read", path: "x" }),
+    ).toBeNull();
+  });
+});
+
+describe("#1473: surfaced by the validator as a warning, never an error", () => {
+  const recipe = {
+    name: "tool-enabled-unlabelled",
+    trigger: { type: "manual" },
+    steps: [
+      {
+        id: "s1",
+        agent: {
+          driver: "claude-code",
+          prompt: "Read ~/records and summarise",
+        },
+      },
+    ],
+  };
+
+  it("reports it, and the recipe still validates", () => {
+    const result = validateRecipeDefinition(recipe);
+    const hint = result.issues.find(
+      (i) => i.code === "data-policy-tool-enabled-unclassified",
+    );
+    expect(hint).toBeDefined();
+    expect(hint?.level).toBe("warning");
+    // The whole point of a hint: it must not break an existing recipe.
+    expect(result.issues.some((i) => i.level === "error")).toBe(false);
   });
 });

--- a/src/recipes/dataPolicyPlacement.ts
+++ b/src/recipes/dataPolicyPlacement.ts
@@ -99,3 +99,72 @@ export function misplacedDataPolicy(step: unknown): MisplacedDataPolicy | null {
       "A classification on a step that never talks to a model describes nothing.",
   };
 }
+
+/**
+ * Drivers that spawn a CLI able to run tools, and so can FETCH data the prompt
+ * does not contain.
+ *
+ * Deliberately a closed list of the drivers that are explicitly tool-enabled.
+ * It does NOT include `auto` (the value an agent step gets when it names no
+ * driver), and that limit is real rather than an oversight: `auto` resolves at
+ * RUN time to whatever the deployment configured, so it may well become one of
+ * these. Flagging every driver-less agent step would flag most steps in most
+ * recipes, and a hint that fires everywhere is one people learn to skip.
+ *
+ * So the hint below covers the population it can name with certainty and says
+ * so out loud. It is not a claim that every under-classified step is caught —
+ * a correct rule pointed at a partial surface, presented as total, is the
+ * recurring defect this codebase keeps paying for.
+ */
+const TOOL_ENABLED_DRIVERS = new Set(["claude-code", "subprocess", "codex"]);
+
+export interface UnclassifiedToolStep {
+  message: string;
+  key: "data_policy";
+}
+
+/**
+ * Hint at an agent step that can fetch data and declared no classification.
+ *
+ * A HINT, never an error. Absence of a `data_policy` is a legitimate default
+ * (ADR-0021 fail-soft: absent ⇒ `internal`), and the shadow report already
+ * counts the defaulted population. What this adds is authoring-time signal at
+ * the point where the default is most likely to be WRONG — a tool-enabled step
+ * whose prompt is instructions to go and fetch rather than the data itself, so
+ * an author classifying what they can see under-classifies what the step
+ * handles.
+ *
+ * It cannot find an under-classified step that DID declare a policy. Nothing
+ * can: classification is declared and never detected, on purpose.
+ */
+export function unclassifiedToolEnabledAgent(
+  step: unknown,
+): UnclassifiedToolStep | null {
+  if (!step || typeof step !== "object" || Array.isArray(step)) return null;
+  const rec = step as Record<string, unknown>;
+
+  const agent = rec.agent;
+  if (!agent || typeof agent !== "object" || Array.isArray(agent)) return null;
+  const agentRec = agent as Record<string, unknown>;
+
+  // A policy declared at step level is a DIFFERENT defect with its own error
+  // (`misplacedDataPolicy`). Staying silent here keeps one author mistake to
+  // one message instead of two that suggest opposite fixes.
+  if (rec.data_policy !== undefined) return null;
+  if (agentRec.data_policy !== undefined) return null;
+
+  const driver =
+    typeof agentRec.driver === "string" ? agentRec.driver : undefined;
+  if (driver === undefined || !TOOL_ENABLED_DRIVERS.has(driver)) return null;
+
+  return {
+    key: "data_policy",
+    message:
+      `agent step uses the tool-enabled driver "${driver}" and declares no \`data_policy\`, ` +
+      "so it dispatches at the default `internal` classification. Classify by what the step " +
+      "HANDLES — including anything its tools will fetch — not by what appears in the prompt: " +
+      "a prompt that only says how to go and read the records still handles those records. " +
+      "This is a hint, not an error; absence is a legitimate default, and this hint cannot see " +
+      "a step whose driver is `auto`.",
+  };
+}

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -3,7 +3,10 @@ import cron from "node-cron";
 import { createAjv2020, type ErrorObject } from "../ajv2020.js";
 import { FLAG_SCHEMA_LINT, isEnabled } from "../featureFlags.js";
 import { unsupportedKeysOf, unsupportedStepMessage } from "./compoundSteps.js";
-import { misplacedDataPolicy } from "./dataPolicyPlacement.js";
+import {
+  misplacedDataPolicy,
+  unclassifiedToolEnabledAgent,
+} from "./dataPolicyPlacement.js";
 import {
   defaultDeprecationWarn,
   normalizeRecipeForRuntime,
@@ -271,6 +274,19 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
             message: `Step ${i + 1}: ${bad.message}`,
             path: `steps.${i}.${bad.key}`,
             code: "data-policy-misplaced",
+          });
+        }
+        // #1473 — a WARNING, never an error. Absence of a policy is a
+        // legitimate default; this marks where that default is most likely to
+        // be the wrong one, because the prompt of a tool-enabled step is often
+        // instructions to fetch rather than the data being handled.
+        const hint = unclassifiedToolEnabledAgent(rawSteps[i]);
+        if (hint) {
+          issues.push({
+            level: "warning",
+            message: `Step ${i + 1}: ${hint.message}`,
+            path: `steps.${i}.agent`,
+            code: "data-policy-tool-enabled-unclassified",
           });
         }
       }


### PR DESCRIPTION
Closes #1473.

## The hazard

An author writing a `data_policy` reads the step's prompt and classifies what they see. For a tool-enabled driver that **under-classifies**, because the prompt is frequently *instructions to go and fetch the data* rather than the data itself.

A prompt that only says how to read a directory of records still **handles** those records. That second reading is the correct one, and it is not the one a careful author necessarily arrives at.

## Not a hole in enforcement

Worth stating plainly, because the obvious inference is wrong. The boundary gates the **dispatch**, not the payload. A step declared `personal` against a remote destination resolves to `LOCAL_ONLY`, so the step runs against a *local* model and that model performs the tool fetch — the data never leaves. `DENY` stops the step outright.

The gap is entirely in **how an author picks the label**, which is why the fix is words plus a hint, rather than detection. ADR-0021 already anticipates this: classification is *declared, never detected*, precisely so it can describe subject matter rather than bytes. What was missing was saying so where an author reads.

## What's here

**ADR-0021 Phase 1** gains the rule and a worked example — the abstract statement is easy to agree with and still get wrong.

The example is **synthetic**. The real case involves personal records, and copying the operator's actual paths into a world-readable doc would disclose exactly the category of thing the boundary exists to protect.

**`recipe lint` gains a warning** for the affected population: an agent step with a tool-enabled driver and no `data_policy`. A warning and **never an error** — absence is a legitimate, documented default (fail-soft: absent ⇒ `internal`), and an error would break existing recipes to solve a problem they may not have, which is the exact failure that fail-soft choice exists to avoid.

### Two limits, named in the hint text rather than left implicit

- It **cannot see a step whose driver is `auto`** — the value an agent step gets when it names none, which resolves at run time and may well *become* tool-enabled. Flagging every driver-less agent step would flag most steps in most recipes, and a hint that fires everywhere is one people learn to skip.
- It **cannot find an under-classified step that did declare a policy.** Nothing can — classification is declared and never detected, on purpose.

A correct rule pointed at a partial surface and presented as total is the defect this codebase keeps paying for, so the surface is stated out loud instead.

It defers to `misplacedDataPolicy` when a policy exists in the wrong place, so one author mistake yields one message rather than two suggesting opposite fixes.

## Measured on the real recipe set

| | agent steps | already labelled | hinted |
|---|---|---|---|
| live | 74 | 13 | 34 |
| shipped templates | 22 | 0 | 20 |

The templates modelling the unlabelled default is worth its own change; not attempted here.

## Verification

1960 recipe/butler tests pass with no regression, so the new warning breaks nothing that asserted a clean lint. Confirmed no CI gate requires templates to lint warning-free.

Mutation tested by emptying the tool-enabled driver set — confirmed applied, four assertions failed, restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)