### PR TITLE
fix(doctor): exit 0 when a bridge is missing, including when nothing runs (#1481)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,21 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `tools search <query> [--json]` — Filter the registered tools by name / description substring.
 - `install <companion>` — Install one of the bundled MCP-companion server registrations into Claude Desktop or Claude Code config. Use `--target cli|desktop` to choose, `--env KEY=VAL` to pass per-companion env vars. Companions: `memory`, `superpowers`, `devtools`, `database`, `slack`, `playwright`, `codebase-memory`. Each is a documented server config; the command writes it into `~/.claude.json` (CLI) or the Claude Desktop config (desktop) atomically.
 - `codex doctor [--config <path>] [--json]` — Diagnoses whether `~/.codex/config.toml` is correctly (and *currently*) wired up to this bridge: config file exists, has a `[mcp_servers.claude-ide-bridge]` entry, the entry's `url` is well-formed, and — when a bridge is running — the config's port and Bearer token still match the live bridge's lock file. A bridge restart (without `--fixed-token`) rotates its port/token, silently staling out a previously-generated config with no error until Codex's next tool call 401s; this catches that before it surprises the user. Fail-soft like `recipe doctor`: no live bridge → warns, doesn't fail (config alone can be valid while the bridge just isn't started yet). Exits 1 when unhealthy. Codex CLI itself connects over Streamable HTTP, not the stdio shim — generate the config with `scripts/gen-mcp-config.sh codex`.
-- `doctor [--json]` — **Is the running code the installed code?** Every other gate in this repo verifies the REPOSITORY; none looks at a running process. On 2026-08-19 both live bridges were found containing neither the ADR-0021 privacy code nor `butler` — merged, wired, tested, gated, and absent from every process serving requests, with three workstreams silently blocked for five days. Compares each bridge lock's `startedAt` against the installed build's mtime. **Deliberately NOT a version comparison**: in the live case both stale and fresh reported `1.2.0-beta.2`, because a version marks a release and not a build. Also reports dead locks (the shim discovers by lock file, so an orphan can win discovery) and refuses to judge a lock with no usable `startedAt`. Exits 1 when unhealthy.
+- `doctor [--json] [--expect-running [N]]` — **Is the running code the installed code?** Every other gate in this repo verifies the REPOSITORY; none looks at a running process. On 2026-08-19 both live bridges were found containing neither the ADR-0021 privacy code nor `butler` — merged, wired, tested, gated, and absent from every process serving requests, with three workstreams silently blocked for five days. Compares each bridge lock's `startedAt` against the installed build's mtime. **Deliberately NOT a version comparison**: in the live case both stale and fresh reported `1.2.0-beta.2`, because a version marks a release and not a build. Also reports dead locks (the shim discovers by lock file, so an orphan can win discovery) and refuses to judge a lock with no usable `startedAt`. Exits 1 when unhealthy.
+
+  **`--expect-running [N]` (#1481) — because doctor cannot see a bridge that is not there.**
+  Its denominator is *locks that exist*, not *bridges that should exist*, and
+  `findings.some(...)` on an empty array is `false` — so zero bridges resolved to
+  healthy and `patchwork doctor && echo deployed` printed `deployed` after a total
+  failure to start. That is the worst possible moment for it: doctor is run
+  immediately after a kickstart, which is exactly when a bridge is most likely to be
+  absent. Observed 2026-08-20 — doctor printed one of two bridges and exited 0 while
+  the second was still restarting. Pass `--expect-running 2` after a kickstart; bare
+  `--expect-running` means at least one. Absent, zero bridges stays HEALTHY on
+  purpose, since "nothing is running" is legitimate for anyone who never started one.
+  A dead lock never counts toward the expectation (a corpse must not satisfy the
+  check); a live-but-stale bridge does count as running, because staleness is already
+  reported separately and conflating them sends the operator to the wrong remedy.
 
   **What it does NOT answer: is the installed code the MERGED code.** There are
   three states, not two — `merged → installed → running` — and `doctor` guards

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -38,6 +38,12 @@ _Nothing in flight._
   under-classifies. ADR-0021 paragraph + worked example, plus a `recipe lint` WARNING (never
   an error) on the population most likely affected. — main session
 
+- 2026-08-20 `fix/doctor-expect-running` — #1481: `doctor`'s denominator is locks that
+  EXIST, not bridges that SHOULD exist, so it exits 0 when a bridge is missing — including
+  when nothing is running at all. Adds `--expect-running [N]`. — main session
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-20 `fix/butler-promote-denominator` — #1477: the promote report counted ledger
   ROWS in its headline and distinct ACTIONS in the breakdown, with nothing saying the unit
   changed, so its arithmetic did not close on the screen a person reads before a one-way

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,7 +29,9 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Nothing in flight._
+- 2026-08-20 `fix/doctor-expect-running` — #1481: `doctor`'s denominator is locks that
+  EXIST, not bridges that SHOULD exist, so it exits 0 when a bridge is missing — including
+  when nothing is running at all. Adds `--expect-running [N]`. — main session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/__tests__/deploymentFreshness.test.ts
+++ b/src/__tests__/deploymentFreshness.test.ts
@@ -118,3 +118,131 @@ describe("the output explains why it is not a version check", () => {
     expect(out).toContain("Nothing is running to be stale");
   });
 });
+
+/**
+ * #1481 — doctor's denominator is "locks that exist", not "bridges that should
+ * exist", so it cannot see a bridge that is not there.
+ *
+ * `findings.some(...)` on an empty array is `false`, so zero locks resolved to
+ * healthy and exit 0. The prose said "No bridge locks found. Nothing is running
+ * to be stale.", which is literally true and is what made it easy to miss — the
+ * exit code did not carry it, so `patchwork doctor && echo deployed` printed
+ * `deployed` after a total failure to start.
+ *
+ * That matters because doctor is run IMMEDIATELY AFTER a kickstart, which is
+ * exactly the moment a bridge is most likely to be absent: a failed LaunchAgent,
+ * a crash on startup, a port collision, a half-finished restart. Observed on
+ * 2026-08-20 — doctor printed one of two bridges and exited 0 while the second
+ * was still restarting.
+ */
+describe("#1481: expecting a number of bridges to be running", () => {
+  it("still exits healthy on zero locks when no expectation is set", () => {
+    // The legitimate state — nothing installed yet — must stay quiet by
+    // default, or the command hard-fails for people who never ran a bridge.
+    const r = assessDeploymentFreshness({
+      locks: [],
+      buildTimeMs: BUILD,
+      isAlive: alive,
+    });
+    expect(r.unhealthy).toBe(false);
+    expect(r.running).toBe(0);
+  });
+
+  it("is unhealthy on zero locks once a bridge is expected", () => {
+    const r = assessDeploymentFreshness({
+      locks: [],
+      buildTimeMs: BUILD,
+      isAlive: alive,
+      expectRunning: 1,
+    });
+    expect(r.unhealthy).toBe(true);
+    expect(r.shortfall).toEqual({ expected: 1, running: 0 });
+  });
+
+  it("catches the observed case — one of two bridges missing", () => {
+    const r = assessDeploymentFreshness({
+      locks: [lock()],
+      buildTimeMs: BUILD,
+      isAlive: alive,
+      expectRunning: 2,
+    });
+    expect(r.unhealthy).toBe(true);
+    expect(r.shortfall).toEqual({ expected: 2, running: 1 });
+  });
+
+  it("is satisfied when the expectation is met", () => {
+    const r = assessDeploymentFreshness({
+      locks: [lock(), lock({ file: "63906.lock", pid: 5678 })],
+      buildTimeMs: BUILD,
+      isAlive: alive,
+      expectRunning: 2,
+    });
+    expect(r.unhealthy).toBe(false);
+    expect(r.shortfall).toBeUndefined();
+  });
+
+  it("does not count a dead lock as a running bridge", () => {
+    // A dead lock is the opposite of reassurance — the shim discovers by lock
+    // file, so it can win discovery over a live bridge. Counting it toward the
+    // expectation would let a corpse satisfy the check.
+    const r = assessDeploymentFreshness({
+      locks: [lock(), lock({ file: "63906.lock", pid: 5678 })],
+      buildTimeMs: BUILD,
+      isAlive: dead,
+      expectRunning: 2,
+    });
+    expect(r.running).toBe(0);
+    expect(r.shortfall).toEqual({ expected: 2, running: 0 });
+  });
+
+  it("counts a live but STALE bridge as running", () => {
+    // It is running — it is just running the wrong code. Staleness is already
+    // reported on its own; conflating the two would let a stale bridge read as
+    // a missing one and send the operator to the wrong remedy.
+    const r = assessDeploymentFreshness({
+      locks: [lock({ startedAt: BUILD - 60_000 })],
+      buildTimeMs: BUILD,
+      isAlive: alive,
+      expectRunning: 1,
+    });
+    expect(r.running).toBe(1);
+    expect(r.shortfall).toBeUndefined();
+    // Still unhealthy, for the original reason rather than a shortfall.
+    expect(r.unhealthy).toBe(true);
+  });
+
+  it("does not count an IDE's own lock toward the expectation", () => {
+    const r = assessDeploymentFreshness({
+      locks: [lock({ isBridge: undefined, file: "47326.lock" })],
+      buildTimeMs: BUILD,
+      isAlive: alive,
+      expectRunning: 1,
+    });
+    expect(r.running).toBe(0);
+    expect(r.unhealthy).toBe(true);
+  });
+
+  it("says how many were expected and how many were found", () => {
+    const r = assessDeploymentFreshness({
+      locks: [lock()],
+      buildTimeMs: BUILD,
+      isAlive: alive,
+      expectRunning: 2,
+    });
+    const out = formatFreshness(r, BUILD);
+    expect(out).toMatch(/expected 2 .*found 1/i);
+  });
+
+  it("names the absence explicitly when nothing is running at all", () => {
+    const out = formatFreshness(
+      assessDeploymentFreshness({
+        locks: [],
+        buildTimeMs: BUILD,
+        isAlive: alive,
+        expectRunning: 1,
+      }),
+      BUILD,
+    );
+    expect(out).toMatch(/expected 1 .*found 0/i);
+  });
+});

--- a/src/deploymentFreshness.ts
+++ b/src/deploymentFreshness.ts
@@ -68,12 +68,29 @@ export interface FreshnessInput {
   buildTimeMs: number;
   /** Liveness probe, injected so this stays a pure function under test. */
   isAlive: (pid: number) => boolean;
+  /**
+   * How many live bridges the caller expects (#1481).
+   *
+   * Absent ⇒ no expectation, and zero bridges stays HEALTHY. That default is
+   * deliberate: "nothing is running" is a legitimate state for anyone who has
+   * not started a bridge, and hard-failing on it would make the command useless
+   * to them. The expectation has to be stated, because only the caller knows
+   * it — this module cannot discover how many bridges *ought* to exist.
+   */
+  expectRunning?: number;
 }
 
 export interface FreshnessReport {
   findings: FreshnessFinding[];
   /** True when any bridge needs attention. Drives the exit code. */
   unhealthy: boolean;
+  /**
+   * Live bridges found. Counted separately from `findings.length`, which also
+   * includes dead locks — a corpse must never satisfy an expectation.
+   */
+  running: number;
+  /** Present only when fewer bridges are running than were expected. */
+  shortfall?: { expected: number; running: number };
 }
 
 export function assessDeploymentFreshness(
@@ -143,9 +160,26 @@ export function assessDeploymentFreshness(
     });
   }
 
+  // A live bridge is one whose process answered the liveness probe. A STALE
+  // bridge counts — it is running, it is merely running the wrong code, and
+  // that is already reported on its own. Conflating the two would make a stale
+  // bridge read as a missing one and send the operator to the wrong remedy.
+  const running = findings.filter((f) => f.state !== "dead-lock").length;
+
+  const shortfall =
+    input.expectRunning !== undefined && running < input.expectRunning
+      ? { expected: input.expectRunning, running }
+      : undefined;
+
   return {
     findings,
-    unhealthy: findings.some((f) => f.state !== "fresh"),
+    // `some` on an empty array is `false`, which is how zero bridges resolved
+    // to healthy: the denominator was "locks that exist" rather than "bridges
+    // that should exist". A shortfall now carries its own weight.
+    unhealthy:
+      findings.some((f) => f.state !== "fresh") || shortfall !== undefined,
+    running,
+    ...(shortfall ? { shortfall } : {}),
   };
 }
 
@@ -161,9 +195,24 @@ export function formatFreshness(
   const L: string[] = [];
   L.push("[deployment] is the running code the installed code?");
   L.push(`  installed build: ${new Date(buildTimeMs).toISOString()}`);
+  if (report.shortfall) {
+    L.push("");
+    L.push(
+      `  MISSING  expected ${report.shortfall.expected} live bridge(s), found ` +
+        `${report.shortfall.running}`,
+    );
+    L.push(
+      "           a bridge that failed to start leaves no lock, and a check whose",
+    );
+    L.push(
+      "           denominator is the locks it found cannot see one that is absent.",
+    );
+  }
   if (report.findings.length === 0) {
     L.push("");
-    L.push("  No bridge locks found. Nothing is running to be stale.");
+    if (!report.shortfall) {
+      L.push("  No bridge locks found. Nothing is running to be stale.");
+    }
     return L.join("\n");
   }
   L.push("");

--- a/src/index.ts
+++ b/src/index.ts
@@ -5377,6 +5377,25 @@ if (process.argv[2] === "doctor") {
       // No lock dir ⇒ no bridges ⇒ reported as "nothing running".
     }
 
+    // `--expect-running [N]` (#1481). Only the caller knows how many bridges
+    // ought to be up — this command cannot discover it — so the expectation is
+    // stated rather than inferred. Bare `--expect-running` means "at least one",
+    // which is the assertion worth making right after a kickstart.
+    const expectIdx = args.indexOf("--expect-running");
+    let expectRunning: number | undefined;
+    if (expectIdx !== -1) {
+      const raw = args[expectIdx + 1];
+      const parsed =
+        raw !== undefined && !raw.startsWith("--") ? Number(raw) : 1;
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        process.stderr.write(
+          "[deployment] --expect-running takes a non-negative integer\n",
+        );
+        process.exit(2);
+      }
+      expectRunning = parsed;
+    }
+
     const report = assessDeploymentFreshness({
       locks,
       buildTimeMs,
@@ -5388,6 +5407,7 @@ if (process.argv[2] === "doctor") {
           return false;
         }
       },
+      ...(expectRunning !== undefined ? { expectRunning } : {}),
     });
     if (args.includes("--json")) {
       process.stdout.write(


### PR DESCRIPTION
Closes #1481.

## The defect

`doctor`'s denominator is the locks that **exist**, not the bridges that **should** exist — so it cannot see a bridge that is not there. A bridge that fails to start leaves no lock, and no lock leaves nothing to complain about:

```ts
unhealthy: findings.some((f) => f.state !== "fresh")
```

`some` on an empty array is `false`. Zero bridges resolved to healthy, and `patchwork doctor && echo deployed` printed `deployed` after a total failure to start.

`formatFreshness` did say *"No bridge locks found. Nothing is running to be stale."* — literally true, which is exactly what made it easy to miss, because the **exit code** did not carry it.

## Why this is the worst place for it

`doctor` exists to be run **immediately after a kickstart** — which is precisely when a bridge is most likely to be absent: a failed LaunchAgent, a crash on startup, a port collision, a half-finished restart. The check most likely to catch that failure was the one reporting success through it.

Observed 2026-08-20 during a routine deploy: doctor printed one of two bridges and exited 0 while the second was still restarting. Nothing was actually broken that time.

This is the **third gap in the same seam**, after *"running == installed" is not "installed == merged"* and the template-copy gap found earlier today. Each is something doctor structurally cannot see.

## The fix

`--expect-running [N]` states the expectation, because only the caller knows it — this command cannot discover how many bridges ought to exist. Bare `--expect-running` means at least one.

```
  MISSING  expected 5 live bridge(s), found 2
           a bridge that failed to start leaves no lock, and a check whose
           denominator is the locks it found cannot see one that is absent.
```

**Absent the flag, zero bridges stays healthy** — deliberately. "Nothing is running" is legitimate for anyone who has not started a bridge, and hard-failing by default would make the command useless to them rather than safer.

### Two counting rules, each of which could quietly gut the check

- A **dead lock never counts** toward the expectation. The shim discovers by lock file, so an orphan can win discovery over a live bridge; letting a corpse satisfy "2 running" would be worse than not checking.
- A **live-but-stale bridge does count** as running. It *is* running — it is running the wrong code, which is already reported on its own. Conflating the two would make a stale bridge read as a missing one and send the operator to the wrong remedy.

## Deliberately not done

The launchd reconciliation the issue also suggests (comparing loaded agents against live locks) would be **macOS-only in a repo whose CI covers Windows**. It deserves its own change rather than a platform fork smuggled into this one, so the expectation stays explicit.

## Verification

Live: `--expect-running 5` prints MISSING and exits 1; `--expect-running 2` with both bridges up exits 0; bare flag exits 0; a negative argument exits 2.

Checked **without a pipe** — `| tail` returns tail's exit code, which hid the result on my first attempt and made a working guard look broken.

Mutation tested by never constructing the shortfall: confirmed applied, six assertions failed, restored.

Note: `src/__tests__/tokenEfficiency.test.ts` fails locally on a machine with live bridges, on `main` as well as here — pre-existing and unrelated, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)