### PR TITLE
fix(test): tokenEfficiency tests depended on the developer's environment (#1483)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -29,11 +29,15 @@ verified (which is how this line came to be written).
 
 ## Active
 
+- 2026-08-20 `fix/token-efficiency-env-isolation` — #1483: `findActiveLockFile` short-circuits
+  on `PATCHWORK_BRIDGE_PORT` before the discovery path the tests mock, so three tests failed
+  on any machine with the documented variable set while CI stayed green. — main session
+
+## Recently closed (informal log, prune periodically)
+
 - 2026-08-20 `fix/doctor-expect-running` — #1481: `doctor`'s denominator is locks that
   EXIST, not bridges that SHOULD exist, so it exits 0 when a bridge is missing — including
   when nothing is running at all. Adds `--expect-running [N]`. — main session
-
-## Recently closed (informal log, prune periodically)
 
 - 2026-08-20 `docs/classify-by-what-a-step-handles` — #1473: an author classifies what the
   prompt shows, but a tool-enabled step's prompt is instructions to FETCH, so it

--- a/src/__tests__/tokenEfficiency.test.ts
+++ b/src/__tests__/tokenEfficiency.test.ts
@@ -45,6 +45,26 @@ describe("tokenEfficiencyStatus", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    // #1483 — `findActiveLockFile` short-circuits on PATCHWORK_BRIDGE_PORT
+    // BEFORE reaching the discovery path every mock below is written for:
+    //
+    //   const portEnv = process.env.PATCHWORK_BRIDGE_PORT;
+    //   if (portEnv && /^\d{1,5}$/.test(portEnv)) { ...; return ...; }
+    //   const found = findBridgeLock({ lockDir });   // <- what we mock
+    //
+    // So on a machine where that variable is set — which CLAUDE.md documents
+    // as the supported way for CLI subcommands to find the bridge, and which
+    // anyone running two bridges pins — three of these tests failed, while CI
+    // stayed green because CI has it unset. A false red that nobody who sees
+    // it can reproduce, and nobody who could reproduce it ever sees.
+    //
+    // The file already guards one leak (the `default` export, see the mock
+    // factory above). The environment was the second one, and unstubbed
+    // ambient state is the same family as the PATCHWORK_HOME lesson: a spy on
+    // the reader does not help when the code never reaches the reader.
+    vi.stubEnv("PATCHWORK_BRIDGE_PORT", "");
+    vi.stubEnv("PATCHWORK_BRIDGE_URL", "");
+
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.mocked(config.loadConfigFile).mockReturnValue({
       lspVerbosity: "minimal",
@@ -52,6 +72,7 @@ describe("tokenEfficiencyStatus", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     consoleSpy.mockRestore();
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
Closes #1483.

## The defect

`findActiveLockFile` short-circuits on `PATCHWORK_BRIDGE_PORT` **before** reaching the discovery path every mock in this file is written for:

```ts
const portEnv = process.env.PATCHWORK_BRIDGE_PORT;
if (portEnv && /^\d{1,5}$/.test(portEnv)) { ...; return ...; }
const found = findBridgeLock({ lockDir });   // <- what the test mocks
```

So on a machine where that variable is set, three tests failed. CI has it unset, so CI was green and stayed green.

That is the expensive shape of a false red: it appears only on a contributor's machine, where it reads as a regression *they* just caused — and nobody who sees it can reproduce it on CI, while nobody on CI ever sees it. The developers most exposed are the ones following the docs: `CLAUDE.md` lists `PATCHWORK_BRIDGE_PORT` as the supported way for CLI subcommands to find the bridge.

The file already guarded **one** leak — the mock factory overrides `default` because `findBridgeLock` uses a default import, with a comment explaining why. The environment was the second, and it's the same family as the `PATCHWORK_HOME` lesson: mocking the reader does not help when the code never reaches the reader.

## Scope is measured, not grepped

The issue suggested grepping for other tests reading ambient state. A grep names ten test files touching this surface and cannot say which are actually *sensitive*, so I ran the whole suite once per variable against a clean baseline of 10 211 passing:

| variable | result |
|---|---|
| `PATCHWORK_BRIDGE_PORT` | **3 failed** — deterministic, reproduced twice |
| `PATCHWORK_BRIDGE_URL` | clean |
| `PATCHWORK_HOME` | clean |
| `CLAUDE_CONFIG_DIR` | clean |

The first pass *appeared* to find one extra failure under each of `_URL` and `_HOME`. Both vanished on re-run, and the `_HOME` one returned later on **different** tests — so they were flakes, not env-dependence. Recorded here because a single run cannot tell the two apart, and reporting them as findings would have been wrong.

`PATCHWORK_BRIDGE_URL` is stubbed alongside the port anyway: it is read on the same discovery surface, and stubbing a variable that is clean today costs nothing next to discovering it the way this one was discovered.

## Verification

With `PATCHWORK_BRIDGE_PORT=3101` the full suite now passes **10 211**, where it failed 3 before. Passes with the variable unset too.

## Separate finding

The suite has intermittent flakes unrelated to this fix — `recipeRoutes-install` (2 tests) and `patchworkInit` (1) each failed once across these runs and passed on re-run, on `main` as well as here. Filing separately rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)