### PR TITLE
ci: persist the coverage numbers the gate fails on (#1386)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,19 @@ jobs:
           path: vitest-progress/
           if-no-files-found: warn
           retention-days: 14
+      # `if: always()` for the same reason as above, and it matters more here:
+      # the only run whose coverage numbers anyone wants is the run that FAILED
+      # the threshold, which is exactly the run a success-only condition
+      # discards. See #1386 — the percentages were unrecoverable from the step
+      # log twice, because the retrievable log ends before the failure.
+      - name: Upload coverage summary (#1386)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-summary-${{ matrix.os }}-node${{ matrix.node-version }}
+          path: coverage/coverage-summary.json
+          if-no-files-found: warn
+          retention-days: 14
 
   schema-audit:
     name: Tool schema breaking-change gate

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,17 @@ export default defineConfig({
         "src/index.ts",
       ],
       all: true,
+      // `json-summary` is added to the defaults (text/html/clover/json) rather
+      // than replacing them — `getCodeCoverage` parses lcov/clover, so dropping
+      // one would break a shipped tool.
+      //
+      // It exists so the GATE'S NUMBERS SURVIVE THE GATE. #1386 fails this step
+      // on unrelated PRs; diagnosing it needs the percentages it failed on, and
+      // those were unrecoverable twice: the step log retrievable from the API
+      // ends ~30s before the failure, so the summary and the threshold error —
+      // the only part anyone needs — are simply gone. A gate that refuses
+      // without recording what it refused on cannot be argued with.
+      reporter: ["text", "html", "clover", "json", "json-summary"],
       // Re-baselined for vitest 4's AST-aware coverage counting (the ast-v8
       // remapper counts more branches/functions than v3's heuristic, so the
       // SAME tests measure lower). Was 75/70/75 under vitest 3. Set ~1pt below


### PR DESCRIPTION
Contributes to #1386. **Does not fix it, and does not try to** — it makes the next occurrence diagnosable, which two attempts at diagnosing the last one could not be.

## The problem this closes

#1386 fails the Coverage step on PRs that cannot have changed coverage. Most recently on #1488, whose **entire diff was one markdown file**, where windows-22 passed and windows-24 failed on the same commit.

Diagnosing that needs the percentages it failed on. **Those were unrecoverable twice.** The step log retrievable from the jobs API ends about thirty seconds before the failure:

```
last log line   08:04:25   (test output)
step failed     08:04:57
```

The coverage summary and the threshold error live in that gap. So the gate refuses without recording what it refused on — and a gate that cannot say *by how much* it failed cannot be argued with, which is part of why #1386 has survived two timeout bumps aimed at the wrong thing.

## The change

- `json-summary` **added** to the default coverage reporters (`text`, `html`, `clover`, `json`) rather than replacing them. Dropping `clover` or `json` would break `getCodeCoverage`, a shipped tool that parses them — swapping one silent gap for another is not an improvement.
- Upload `coverage/coverage-summary.json` with **`if: always()`**, mirroring the #1365 progress artifact. That condition matters more here: the only run whose coverage numbers anyone wants is the run that *failed* the threshold, which is exactly the run a success-only condition discards.

## What the last failure already tells us

From the same job's `vitest-progress` artifact:

```
coverage.jsonl: run-start 1 · module-start 751 · module-end 751 · run-end {reason: "passed"}
in-flight at end: none
step duration:  4m54s against an 8-minute cap
```

The suite completed, every module finished, the tests **passed**, and the step still exited 1. `retry: 2` in CI would also have absorbed a flaky test. So the failure is in **threshold enforcement, after the run** — not a kill, not a timeout.

That points at the measured percentages themselves varying between two Windows cells on identical code, against roughly one point of headroom (`vitest.config.ts` records Windows at 72.08/63.03/70.94 versus a 71/62/70 gate). This artifact is how we find out on the next occurrence instead of inferring.

## Verification

The summary file is produced and carries `total.{lines,branches,functions,statements}.pct`.

Mutation tested by removing `json-summary` from the reporter list — the file is then **absent**, confirming the config change is what produces it rather than something already writing it.

Workflow YAML re-parsed after editing; both upload steps carry `if: always()`.

`docs/in-flight.md` untouched: #1488 is open against the same section, and editing it here would guarantee a conflict rather than avoid one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)