### PR TITLE
fix(runlog): record event-triggered runs, and name them by recipe (#1487)

### DIFF
--- a/src/__tests__/automationTriggerSourceCarriesRecipe.test.ts
+++ b/src/__tests__/automationTriggerSourceCarriesRecipe.test.ts
@@ -1,0 +1,71 @@
+/**
+ * #1487, second half — the automation trigger string must carry the RECIPE
+ * name, not the hook type.
+ *
+ * `bridge.ts` emitted `automation:${opts.triggerSource}`, and `triggerSource`
+ * is `program.hookType` (`automationInterpreter.ts`) — so the string was
+ * `automation:onFileSave`. Every other kind carries the recipe:
+ * `webhook:${match.name}`, `recipe:${name}`.
+ *
+ * While the run log refused to parse `automation:` at all this was harmless.
+ * The moment it learned to — which is the other half of #1487 — it would have
+ * filed eleven distinct recipes under a handful of names invented from hook
+ * types, merging unrelated recipes into one row-family and cross-attributing
+ * their trust. The run log is the autonomy gate's evidence, so that is worse
+ * than recording nothing, AND it would have looked like a fix.
+ *
+ * WHY THIS TEST READS SOURCE. The call site is constructed inline inside
+ * `Bridge`'s constructor, wired to a live `AutomationHooks` and
+ * `RecipeOrchestration`; there is no seam to inject a fake through without
+ * standing up a bridge. A hand-injected dependency would prove the logic and
+ * not the path — and the path is the entire defect here. So this asserts the
+ * wiring itself, which is crude but is the thing that actually regressed.
+ * If a seam is added later, replace this with a behavioural test driving it.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const BRIDGE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "bridge.ts",
+);
+
+describe("#1487: automation trigger source names the recipe", () => {
+  const src = readFileSync(BRIDGE, "utf8");
+
+  it("has at least one automation trigger-source call site", () => {
+    // Guards the assertion below against passing vacuously if the call sites
+    // are renamed or moved — an absent pattern would otherwise "pass".
+    const sites = src.match(/triggerSourceSuffix: `automation:/g) ?? [];
+    expect(sites.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Only the INTERPOLATED EXPRESSION, deliberately. Matching the whole line
+   * catches the key `triggerSourceSuffix`, whose own name contains
+   * "triggerSource" — the first version of this test failed on that and would
+   * have been "fixed" by loosening the assertion into uselessness.
+   */
+  const interpolations = () =>
+    [...src.matchAll(/triggerSourceSuffix: `automation:\$\{([^}]+)\}`/g)].map(
+      (m) => m[1] ?? "",
+    );
+
+  it("uses the recipe name at every call site", () => {
+    const exprs = interpolations();
+    expect(exprs.length).toBeGreaterThan(0);
+    for (const e of exprs) {
+      expect(e).toContain("recipeName");
+    }
+  });
+
+  it("uses the hook type at none of them", () => {
+    for (const e of interpolations()) {
+      expect(e).not.toContain("triggerSource");
+    }
+  });
+});

--- a/src/__tests__/runLog.test.ts
+++ b/src/__tests__/runLog.test.ts
@@ -1141,3 +1141,59 @@ describe("RecipeRunLog — inboxOutputs (Phase 0β provenance)", () => {
     expect(found?.inboxOutputs).toBeUndefined();
   });
 });
+
+/**
+ * #1487 — event-triggered runs were never recorded at all.
+ *
+ * `parseTrigger` accepted `cron|webhook|recipe`; `bridge.ts` emits
+ * `automation:*`; and `record()` bails on a failed parse — so the run executed
+ * and nothing was written. Measured across the live log plus its rotation
+ * archive: 1214 rows, `cron` 1087 and `recipe` 127, and nothing else. Eleven
+ * installed recipes declare `file_watch` / `git_hook` / `on_file_save` /
+ * `on_test_run` and not one of their runs had ever appeared.
+ *
+ * That matters beyond ops visibility: the run log IS the trust evidence the
+ * autonomy gate replays, so a trigger class absent from it can never earn or
+ * lose trust.
+ *
+ * THE SECOND HALF, which is easy to miss and worse than the first: the emitted
+ * string carried `program.hookType`, not the recipe name — `automation:onFileSave`.
+ * Every other kind carries the recipe (`webhook:${match.name}`,
+ * `recipe:${name}`). Teaching the parser `automation` WITHOUT fixing the
+ * emission would have recorded all eleven recipes under a handful of invented
+ * names taken from hook types, collapsing distinct recipes into one and
+ * attributing their trust to each other. That is materially worse than
+ * recording nothing, and it would have looked like a fix.
+ */
+describe("#1487: automation-triggered runs are recordable", () => {
+  it("parses an automation trigger and keeps the recipe name", () => {
+    expect(RecipeRunLog.parseTrigger("automation:lint-on-save")).toEqual({
+      trigger: "automation",
+      recipeName: "lint-on-save",
+    });
+  });
+
+  it("preserves colons in an automation recipe name", () => {
+    expect(RecipeRunLog.parseTrigger("automation:foo:bar")).toEqual({
+      trigger: "automation",
+      recipeName: "foo:bar",
+    });
+  });
+
+  it("still extracts a parentSeq suffix", () => {
+    expect(RecipeRunLog.parseTrigger("automation:child:p9")).toEqual({
+      trigger: "automation",
+      recipeName: "child",
+      parentSeq: 9,
+    });
+  });
+
+  it("rejects an automation source with no name", () => {
+    expect(RecipeRunLog.parseTrigger("automation:")).toBeNull();
+  });
+
+  it("leaves unrelated sources alone", () => {
+    expect(RecipeRunLog.parseTrigger("onFileSave")).toBeNull();
+    expect(RecipeRunLog.parseTrigger("automation")).toBeNull();
+  });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1453,7 +1453,14 @@ export class Bridge {
                 filePath: patchworkPath("recipes", `${opts.recipeName}.yaml`),
                 name: opts.recipeName,
                 taskIdPrefix: `automation-recipe-${opts.recipeName}`,
-                triggerSourceSuffix: `automation:${opts.triggerSource}`,
+                // The RECIPE name, not the hook type (#1487). Every other kind
+                // carries the recipe — `webhook:${match.name}`, `recipe:${name}`
+                // — and this carried `program.hookType`, so once the run log
+                // learned to parse `automation:` it would have filed all these
+                // recipes under a handful of names invented from hook types,
+                // merging distinct recipes and cross-attributing their trust.
+                // The hook type is still available to the run via seedContext.
+                triggerSourceSuffix: `automation:${opts.recipeName}`,
                 logLabel: `automation "${opts.recipeName}"`,
                 seedContext: Object.fromEntries(Object.entries(opts.eventData)),
               }).then((r) => {
@@ -1501,7 +1508,14 @@ export class Bridge {
                   filePath: patchworkPath("recipes", `${opts.recipeName}.yaml`),
                   name: opts.recipeName,
                   taskIdPrefix: `automation-recipe-${opts.recipeName}`,
-                  triggerSourceSuffix: `automation:${opts.triggerSource}`,
+                  // The RECIPE name, not the hook type (#1487). Every other kind
+                  // carries the recipe — `webhook:${match.name}`, `recipe:${name}`
+                  // — and this carried `program.hookType`, so once the run log
+                  // learned to parse `automation:` it would have filed all these
+                  // recipes under a handful of names invented from hook types,
+                  // merging distinct recipes and cross-attributing their trust.
+                  // The hook type is still available to the run via seedContext.
+                  triggerSourceSuffix: `automation:${opts.recipeName}`,
                   logLabel: `automation "${opts.recipeName}"`,
                   seedContext: Object.fromEntries(
                     Object.entries(opts.eventData),

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -44,7 +44,7 @@ import {
   setRecipeEnabled,
   setTrustLevel,
 } from "./recipesHttp.js";
-import type { RecipeRunLog } from "./runLog.js";
+import type { RecipeRunLog, RunTrigger } from "./runLog.js";
 import type { Server } from "./server.js";
 import { boundaryForRecipe } from "./workers/boundaryPreview.js";
 import {
@@ -685,7 +685,9 @@ export class RecipeOrchestration {
       return this.deps.recipeRunLog.query({
         ...(q.limit !== undefined && { limit: q.limit }),
         ...(q.trigger !== undefined && {
-          trigger: q.trigger as "cron" | "webhook" | "recipe",
+          // Widened for #1487 — a hand-written union here silently excluded
+          // `automation` from run queries the moment the type gained it.
+          trigger: q.trigger as RunTrigger,
         }),
         ...(q.status !== undefined && {
           status: q.status as

--- a/src/runLog.ts
+++ b/src/runLog.ts
@@ -41,7 +41,16 @@ import {
  * dropped — see the `append()` implementation for the exact ordering.
  */
 
-export type RunTrigger = "cron" | "webhook" | "recipe";
+/**
+ * How a run was started.
+ *
+ * `automation` covers the event triggers — `file_watch`, `git_hook`,
+ * `on_file_save`, `on_test_run`. It was absent until #1487, and its absence
+ * was not merely a missing label: `record()` bails when `parseTrigger` fails,
+ * so those runs were executed and never written down at all. Measured across
+ * 1214 live rows, the log held only `cron` and `recipe`.
+ */
+export type RunTrigger = "cron" | "webhook" | "recipe" | "automation";
 export type RunStatus =
   | "running"
   | "done"
@@ -413,7 +422,9 @@ export class RecipeRunLog {
     if (!triggerSource) return null;
     // Format: "<kind>:<name>" or "<kind>:<name>:p<parentSeq>"
     // parentSeq suffix ":p<N>" is always at the end and uses a numeric-only value.
-    const m = /^(cron|webhook|recipe):(.+?)(?::p(\d+))?$/.exec(triggerSource);
+    const m = /^(cron|webhook|recipe|automation):(.+?)(?::p(\d+))?$/.exec(
+      triggerSource,
+    );
     if (!m?.[1] || !m[2]) return null;
     return {
       trigger: m[1] as RunTrigger,


### PR DESCRIPTION
Closes #1487.

## The defect

Event-triggered runs were **never recorded at all** — not merely their duplicates. `parseTrigger` matched `cron|webhook|recipe`, `bridge.ts` emits `automation:*`, and `record()` returns `null` on a failed parse. The run executed and nothing was written.

Measured across the live log plus its rotation archive — **1214 rows**: `cron` 1087, `recipe` 127, everything else **0**. Eleven installed recipes declare `file_watch` / `git_hook` / `on_file_save` / `on_test_run`, and not one of their runs had ever appeared. (Counts only; no ledger contents.)

It matters past observability because the run log **is** the trust evidence the autonomy gate replays. A trigger class absent from it can never earn or lose trust.

## The second half — why this is not a four-line change

The emitted string carried `program.hookType`, not the recipe: `automation:onFileSave`. Every other kind carries the recipe (`webhook:${match.name}`, `recipe:${name}`).

While the parser refused `automation:` outright, that was harmless. **Teaching it to parse without fixing the emission would have filed eleven distinct recipes under a handful of names invented from hook types** — merging unrelated recipes into one row-family and cross-attributing their trust. Worse than recording nothing, and it would have looked like a fix.

Both call sites now pass `opts.recipeName`; the hook type remains available through `seedContext`.

Also widens a hand-written union in `recipeOrchestration` that cast a query's trigger to `"cron" | "webhook" | "recipe"`, which would have silently excluded `automation` from run queries the moment the type gained it.

## On the volume risk

This was filed rather than done immediately because `runs.jsonl` is byte-capped, and that cap is what starves trust evidence (#1337) — `on_file_save` fires on keystrokes, not on a schedule.

Proceeding anyway, because **the alternative is not actually available**: the filtered worker-run ledger spans eight write paths where a miss is a silent evidence gap, and it is not built — while the status quo produces no evidence at all. The risk is already instrumented: `evidenceRetention()` reports span-vs-window and `workers shadow` warns when it goes negative, so a regression here is **visible rather than silent**.

**Re-measure retention after this has run for a few days.**

No migration needed — the sqlite mirror stores `trigger` as plain `TEXT`, no CHECK constraint.

## Verification

10 225 tests pass.

Parser mutation-tested by reverting the regex — three assertions failed, restored.

The **emission** guard is the load-bearing one: reverting it to `opts.triggerSource` fails two assertions. That test reads source rather than behaviour, deliberately, with its reasoning in the file — the call site is built inline in `Bridge`'s constructor with no seam, and a hand-injected fake would prove the logic while missing the path, which is the entire defect. Its first version passed vacuously by matching the key `triggerSourceSuffix`, whose own name contains "triggerSource"; it now inspects only the interpolated expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)