### PR TITLE
docs(privacy): declare a data_policy on every shipped template (#1473)

### DIFF
--- a/templates/recipes/approval-queue-ui-test.yaml
+++ b/templates/recipes/approval-queue-ui-test.yaml
@@ -56,6 +56,12 @@ trigger:
 steps:
   - id: drive_browser
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       driver: claude-code
       model: claude-haiku-4-5-20251001
       prompt: |

--- a/templates/recipes/butler-errand.yaml
+++ b/templates/recipes/butler-errand.yaml
@@ -37,6 +37,19 @@ steps:
     into: existing
 
   - agent:
+      # Declared `personal` because this step HANDLES personal data — mail,
+      # calendar entries, a private task list — even where the prompt text only
+      # says how to go and fetch it (#1473). Classify by what the step handles,
+      # including whatever its tools return.
+      #
+      # CONSEQUENCE, stated so it is not a surprise: if you have registered a
+      # remote destination that does not accept `personal`, this step resolves to
+      # LOCAL_ONLY and REFUSES rather than silently downgrading. That is the
+      # boundary working. Resolve it by pointing this step at a local driver, or
+      # by widening the destination's classifications if that is what you intend.
+      # With no `privacy` block configured the boundary is inert and nothing changes.
+      data_policy:
+        classification: personal
       # REQUIRED, not stylistic. With PATCHWORK_FLAG_WORKER_AUTONOMY on, an
       # agent step in a worker recipe must name a driver that can enforce a
       # tool sandbox; agentExecutor refuses to run un-sandboxed otherwise. This

--- a/templates/recipes/ctx-loop-test.yaml
+++ b/templates/recipes/ctx-loop-test.yaml
@@ -17,6 +17,12 @@ steps:
     into: recent_commits
 
   - agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         You are validating the Patchwork cross-session memory loop end-to-end.
 

--- a/templates/recipes/daily-status.yaml
+++ b/templates/recipes/daily-status.yaml
@@ -12,6 +12,12 @@ steps:
     into: plan
     optional: true
   - agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         Write a 5-line morning brief. Yesterday's commits: {{commits}}.
         Today's plan: {{plan}}.

--- a/templates/recipes/dependency-bump.yaml
+++ b/templates/recipes/dependency-bump.yaml
@@ -16,6 +16,12 @@ steps:
     max: 30
     into: prs
   - agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         Open pull requests:
         {{prs}}

--- a/templates/recipes/fix-errors-on-save.yaml
+++ b/templates/recipes/fix-errors-on-save.yaml
@@ -19,6 +19,12 @@ steps:
     into: errors
 
   - agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         A TypeScript file was just saved: {{file}}
 

--- a/templates/recipes/incident-to-pr.yaml
+++ b/templates/recipes/incident-to-pr.yaml
@@ -67,6 +67,12 @@ trigger:
 steps:
   - id: investigate
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       driver: claude-code
       prompt: |
         A production incident has fired. Root-cause it against THIS repository.
@@ -92,6 +98,12 @@ steps:
     awaits:
       - investigate
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       driver: claude-code
       prompt: |
         Using the root-cause analysis below, write a concrete, MINIMAL fix.
@@ -123,6 +135,12 @@ steps:
     awaits:
       - draft_fix
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       kind: judge
       reviews: fix_draft
       max_revisions: 2
@@ -148,6 +166,12 @@ steps:
     awaits:
       - review_fix
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       driver: claude-code
       prompt: |
         The fix below has passed judge review. Open a pull request for it.

--- a/templates/recipes/morning-brief-slack.yaml
+++ b/templates/recipes/morning-brief-slack.yaml
@@ -18,6 +18,19 @@ steps:
     max: 10
     into: calendar
   - agent:
+      # Declared `personal` because this step HANDLES personal data — mail,
+      # calendar entries, a private task list — even where the prompt text only
+      # says how to go and fetch it (#1473). Classify by what the step handles,
+      # including whatever its tools return.
+      #
+      # CONSEQUENCE, stated so it is not a surprise: if you have registered a
+      # remote destination that does not accept `personal`, this step resolves to
+      # LOCAL_ONLY and REFUSES rather than silently downgrading. That is the
+      # boundary working. Resolve it by pointing this step at a local driver, or
+      # by widening the destination's classifications if that is what you intend.
+      # With no `privacy` block configured the boundary is inert and nothing changes.
+      data_policy:
+        classification: personal
       prompt: |
         You are a personal assistant writing a concise morning brief. Use ONLY the data provided below — do not call any tools or fetch additional information.
 

--- a/templates/recipes/morning-brief.yaml
+++ b/templates/recipes/morning-brief.yaml
@@ -29,6 +29,19 @@ steps:
     max: 10
     into: calendar
   - agent:
+      # Declared `personal` because this step HANDLES personal data — mail,
+      # calendar entries, a private task list — even where the prompt text only
+      # says how to go and fetch it (#1473). Classify by what the step handles,
+      # including whatever its tools return.
+      #
+      # CONSEQUENCE, stated so it is not a surprise: if you have registered a
+      # remote destination that does not accept `personal`, this step resolves to
+      # LOCAL_ONLY and REFUSES rather than silently downgrading. That is the
+      # boundary working. Resolve it by pointing this step at a local driver, or
+      # by widening the destination's classifications if that is what you intend.
+      # With no `privacy` block configured the boundary is inert and nothing changes.
+      data_policy:
+        classification: personal
       prompt: |
         You are a personal assistant writing a concise morning brief. Use ONLY the data provided below — do not call any tools or fetch additional information.
 

--- a/templates/recipes/project-health-check.yaml
+++ b/templates/recipes/project-health-check.yaml
@@ -21,6 +21,12 @@ steps:
         max: 10
   - id: summarize
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         Write a concise project health summary using ONLY the data below.
 

--- a/templates/recipes/release-notes.yaml
+++ b/templates/recipes/release-notes.yaml
@@ -16,6 +16,12 @@ steps:
     into: commits
   - id: draft_notes
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         New commits landed in the last 24h:
         {{commits}}

--- a/templates/recipes/sentry-to-linear.yaml
+++ b/templates/recipes/sentry-to-linear.yaml
@@ -31,6 +31,12 @@ trigger:
 
 steps:
   - agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         You are a triage assistant. Follow these steps exactly — do not skip any.
 

--- a/templates/recipes/triage-failing-tests-autofile.yaml
+++ b/templates/recipes/triage-failing-tests-autofile.yaml
@@ -44,6 +44,12 @@ steps:
     into: recent
   - id: triage_agent
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         Tests just failed. Runner: {{runner}}. Failed {{failed}} / {{total}}.
 
@@ -100,6 +106,12 @@ steps:
   - id: decide_file
     optional: true
     agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         A test run reported failures and this triage was written:
 

--- a/templates/recipes/triage-failing-tests.yaml
+++ b/templates/recipes/triage-failing-tests.yaml
@@ -16,6 +16,12 @@ steps:
     since: 12h
     into: recent
   - agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         Tests just failed. Runner: {{runner}}. Failed {{failed}} / {{total}}.
 

--- a/templates/recipes/watch-failing-tests.yaml
+++ b/templates/recipes/watch-failing-tests.yaml
@@ -5,6 +5,12 @@ trigger:
   filter: failure
 steps:
   - agent:
+      # Declared `internal` — source, diagnostics, git history, test output, issue
+      # text. Declared EXPLICITLY rather than left to the default, which is also
+      # `internal`: an absent policy means nobody decided, and a reference template
+      # should model the deciding (#1473).
+      data_policy:
+        classification: internal
       prompt: |
         Tests just failed. Runner: {{runner}}. Failed: {{failed}} / {{total}}.
         Failures: {{failures}}.

--- a/templates/recipes/webhook/apple-watch-health-log.yaml
+++ b/templates/recipes/webhook/apple-watch-health-log.yaml
@@ -65,6 +65,18 @@ steps:
 
   - id: coach_insight
     agent:
+      # Declared `personal` because this step HANDLES personal data, even where the
+      # prompt text only says how to go and fetch it (#1473). Classify by what the
+      # step handles, including whatever its tools return.
+      #
+      # CONSEQUENCE, stated so it is not a surprise: if you have registered a
+      # remote destination that does not accept `personal`, this step resolves to
+      # LOCAL_ONLY and REFUSES rather than silently downgrading. That is the
+      # boundary working. Point the step at a local driver, or widen the
+      # destination if that is what you intend. With no `privacy` block configured
+      # the boundary is inert and nothing changes.
+      data_policy:
+        classification: personal
       driver: claude-code
       model: claude-haiku-4-5-20251001
       into: insight

--- a/templates/recipes/webhook/customer-escalation.yaml
+++ b/templates/recipes/webhook/customer-escalation.yaml
@@ -33,6 +33,16 @@ steps:
     query: "{{payload.customer_email}}"
     into: contact
   - agent:
+      # Declared `confidential`: this step handles a THIRD PARTY's data pulled from
+      # a CRM, which is a stronger claim than `personal` — it is not the operator's
+      # own data to route wherever they like, and a customer did not consent to a
+      # vendor's model seeing it (#1473).
+      #
+      # CONSEQUENCE: under any destination that does not accept `confidential` this
+      # step REFUSES rather than downgrading. That is the intended behaviour. With
+      # no `privacy` block configured the boundary is inert and nothing changes.
+      data_policy:
+        classification: confidential
       prompt: |
         Compose a Slack alert for the customer-success team. Keep it under
         12 lines. Include: customer name + company, tier (from contact.tier

--- a/templates/recipes/webhook/meeting-prep.yaml
+++ b/templates/recipes/webhook/meeting-prep.yaml
@@ -33,6 +33,18 @@ steps:
     max: 10
     into: related_issues
   - agent:
+      # Declared `personal` because this step HANDLES personal data, even where the
+      # prompt text only says how to go and fetch it (#1473). Classify by what the
+      # step handles, including whatever its tools return.
+      #
+      # CONSEQUENCE, stated so it is not a surprise: if you have registered a
+      # remote destination that does not accept `personal`, this step resolves to
+      # LOCAL_ONLY and REFUSES rather than silently downgrading. That is the
+      # boundary working. Point the step at a local driver, or widen the
+      # destination if that is what you intend. With no `privacy` block configured
+      # the boundary is inert and nothing changes.
+      data_policy:
+        classification: personal
       prompt: |
         You are about to walk into a meeting. Produce a 10-line briefing.
 

--- a/templates/recipes/webhook/morning-brief.yaml
+++ b/templates/recipes/webhook/morning-brief.yaml
@@ -38,6 +38,18 @@ steps:
     max: 10
     into: calendar
   - agent:
+      # Declared `personal` because this step HANDLES personal data, even where the
+      # prompt text only says how to go and fetch it (#1473). Classify by what the
+      # step handles, including whatever its tools return.
+      #
+      # CONSEQUENCE, stated so it is not a surprise: if you have registered a
+      # remote destination that does not accept `personal`, this step resolves to
+      # LOCAL_ONLY and REFUSES rather than silently downgrading. That is the
+      # boundary working. Point the step at a local driver, or widen the
+      # destination if that is what you intend. With no `privacy` block configured
+      # the boundary is inert and nothing changes.
+      data_policy:
+        classification: personal
       prompt: |
         Write a 12-line morning brief from this data, in plain English,
         prioritising what needs attention today.


### PR DESCRIPTION
Follow-on to #1479. The reference recipes modelled the unlabelled default — **23 agent steps across 19 templates, none carrying a `data_policy`**. Anyone copying one inherited that, which is a large part of why real recipes inherit it too (measured on the live set: 34 of 74 agent steps tool-enabled and unlabelled).

## Classification

Classified by what each step **handles**, including whatever its tools fetch — the rule #1479 added, and the one that is easy to agree with and still get wrong.

| | |
|---|---|
| **confidential** (1) | the CRM escalation template — a **third party's** contact data. A stronger claim than `personal`: not the operator's own data to route wherever they like, and the customer did not consent to a vendor's model seeing it. |
| **personal** (6) | the mail/calendar briefs, meeting-prep, the private task list, and the health log — the clearest case in the set. |
| **internal** (16) | source, diagnostics, git history, test output, issue text. |

`internal` is declared **explicitly** even though it is also the default. That is the point rather than noise: an absent policy means nobody decided, a declared one means someone did, and a reference template should model the deciding. It also stops the lint hint firing on the very files people learn from.

## The consequence is stated in each affected file

A template that silently failed on install would be hostile. Under a policy whose remote destination does not accept `personal`/`confidential`, those steps resolve to **LOCAL_ONLY, which REFUSES** rather than downgrading — the boundary working as designed. Each carries a comment saying so, naming the two ways out (local driver, or widen the destination), plus the reminder that with no `privacy` block the boundary is inert and nothing changes.

## Found while verifying

The counts above are **not** the ones this change first claimed. The first pass enumerated one directory and missed a `webhook/` subdirectory holding four more templates — which happened to be **the four most sensitive in the repository**, including the health log and the customer-data one. The scripted pass reported success over the surface it had looked at.

Caught by re-counting against `git ls-files` rather than a directory listing, after a mismatch between "17 files changed" and 15 files in the commit. A correct mechanism pointed at a partial surface — in a change whose whole subject is that exact failure.

## Verification

Over **tracked** templates: 19 templates, 23 agent steps, **0 unlabelled**, 0 reported by `misplacedDataPolicy` (the block must sit inside `agent:`, and does), **0 lint errors and 0 warnings**, and `unclassifiedToolEnabledAgent` — the hint shipped for #1473 this morning — now fires on **none** of them, where it fired on 20 before.

Comments are preserved; the insertion is textual for that reason, since parse-and-reserialise would have discarded the commentary that makes these teaching material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)