### PR TITLE
fix(lint): a git_hook recipe could lint clean and never fire

### DIFF
--- a/src/recipes/__tests__/gitHookEventValidation.test.ts
+++ b/src/recipes/__tests__/gitHookEventValidation.test.ts
@@ -1,0 +1,79 @@
+/**
+ * A `git_hook` recipe that lints clean and never fires.
+ *
+ * `parseTrigger` in parser.ts requires `trigger.event` to be one of
+ * `post-commit` / `pre-push` / `post-merge`. `validateRecipeDefinition` did not
+ * check it at all, so a recipe naming the key anything else — `on:` is the
+ * natural guess, and it is what GitHub Actions uses — passed lint with zero
+ * errors and zero warnings, then failed to register at bridge startup with a
+ * WARN buried in a log nobody reads. The recipe simply never ran.
+ *
+ * Observed live, not theorised: two installed recipes had been silently dead
+ * this way, both declaring `on:` with an otherwise VALID value. The values
+ * were right; only the key was wrong, so nothing looked broken anywhere a
+ * person would look.
+ *
+ * This is the same drift `compoundSteps.ts` and `dataPolicyPlacement.ts` were
+ * each written to close — authoring-time and run-time verdicts disagreeing —
+ * and the same reasoning the `cron.at` check three lines above already states:
+ * users should see the error at save time, not when the scheduler silently
+ * fails to register the recipe.
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+function lint(trigger: Record<string, unknown>) {
+  return validateRecipeDefinition({
+    name: "probe",
+    trigger: { type: "git_hook", ...trigger },
+    steps: [{ id: "s1", tool: "file.read", path: "/dev/null" }],
+  });
+}
+
+const errorsOf = (t: Record<string, unknown>) =>
+  lint(t).issues.filter((i) => i.level === "error");
+
+describe("git_hook.event is validated at lint time", () => {
+  it("accepts each event the parser accepts", () => {
+    for (const event of ["post-commit", "pre-push", "post-merge"]) {
+      expect(errorsOf({ event }), event).toEqual([]);
+    }
+  });
+
+  it("rejects a missing event", () => {
+    expect(
+      errorsOf({})
+        .map((e) => e.message)
+        .join(" "),
+    ).toMatch(/git_hook.*event/i);
+  });
+
+  it("rejects an event the parser would refuse", () => {
+    expect(errorsOf({ event: "pre-commit" }).length).toBeGreaterThan(0);
+  });
+
+  it("names `on:` specifically, because that is the mistake people make", () => {
+    // The live case. A generic "event is required" would be correct and much
+    // less useful: the author DID say post-commit, and needs to be told the
+    // key is wrong rather than the value.
+    const msg = errorsOf({ on: "post-commit" })
+      .map((e) => e.message)
+      .join(" ");
+    expect(msg).toMatch(/`on`/);
+    expect(msg).toMatch(/`event`/);
+  });
+
+  it("still rejects `on:` carrying a value that is not valid either", () => {
+    expect(errorsOf({ on: "pre-commit" }).length).toBeGreaterThan(0);
+  });
+
+  it("leaves other trigger types alone", () => {
+    const r = validateRecipeDefinition({
+      name: "probe",
+      trigger: { type: "manual" },
+      steps: [{ id: "s1", tool: "file.read", path: "/dev/null" }],
+    });
+    expect(r.issues.filter((i) => /git_hook/i.test(i.message))).toEqual([]);
+  });
+});

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -189,6 +189,51 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
           message: `Invalid trigger.type. Must be one of: ${validTypes.join(", ")}`,
         });
       }
+      // A git_hook recipe that lints clean and never fires. `parseTrigger`
+      // (parser.ts) requires `event` to be one of these three and throws
+      // otherwise, which surfaces only as a startup WARN in a log — the
+      // recipe is skipped and nothing else says so.
+      //
+      // Observed live: two installed recipes had been silently dead this way,
+      // both naming the key `on:` with an otherwise VALID value. Same
+      // reasoning as the `cron.at` check below, which exists so the author
+      // sees this at save time rather than never.
+      if (trigger.type === "git_hook") {
+        const GIT_HOOK_EVENTS = ["post-commit", "pre-push", "post-merge"];
+        const event = trigger.event;
+        if (event === undefined) {
+          // `on:` is the natural guess and what GitHub Actions uses, so name
+          // it. A generic "event is required" would be correct and much less
+          // useful — the author DID say post-commit; the KEY is wrong, not the
+          // value, and a message about the value sends them hunting the wrong
+          // thing.
+          const hint =
+            (trigger as Record<string, unknown>).on !== undefined
+              ? " Found `on` instead — rename it to `event`."
+              : "";
+          issues.push({
+            level: "error",
+            message:
+              `git_hook trigger requires \`event\` (one of: ${GIT_HOOK_EVENTS.join(", ")}).` +
+              `${hint} Without it the recipe is skipped at bridge startup and never fires.`,
+            path: "trigger.event",
+            code: "git-hook-event-missing",
+          });
+        } else if (
+          typeof event !== "string" ||
+          !GIT_HOOK_EVENTS.includes(event)
+        ) {
+          issues.push({
+            level: "error",
+            message:
+              `Invalid git_hook.event ${JSON.stringify(event)}. Must be one of: ` +
+              `${GIT_HOOK_EVENTS.join(", ")}. Otherwise the recipe is skipped at ` +
+              "bridge startup and never fires.",
+            path: "trigger.event",
+            code: "git-hook-event-invalid",
+          });
+        }
+      }
       if (trigger.type === "cron" && !trigger.at) {
         issues.push({
           level: "warning",

--- a/templates/recipes/ambient-journal.yaml
+++ b/templates/recipes/ambient-journal.yaml
@@ -2,7 +2,11 @@ name: ambient-journal
 description: Append a timestamped line to your daily journal whenever a git commit lands.
 trigger:
   type: git_hook
-  on: post-commit
+  # The key is `event`, not `on` (#1464-family). The parser requires
+  # `event` and skips the recipe at bridge startup otherwise, with only a
+  # WARN in a log — so `on:` produced a recipe that linted clean and never
+  # fired. `recipe lint` now refuses it.
+  event: post-commit
 steps:
   - tool: file.append
     path: ~/.patchwork/journal/{{date}}.md


### PR DESCRIPTION
## The defect

`parseTrigger` (`parser.ts`) requires `trigger.event` to be `post-commit`, `pre-push` or `post-merge` and throws otherwise. `validateRecipeDefinition` **did not check it at all** — so a recipe naming that key anything else passed lint with **zero errors and zero warnings**, then failed to register at bridge startup with a WARN buried in a log. The recipe simply never ran, and nothing anywhere a person looks said so.

## Found by reading the live bridge log, not the code

```
WARN [recipe-triggers] skipped ambient-journal.yaml — trigger.event: invalid git_hook.event
WARN [recipe-triggers] skipped pre-pr-flightcheck.yaml — trigger.event: invalid git_hook.event
```

Two installed recipes had been **silently dead**. Both declared `on:` with an otherwise **valid value** — `on: post-commit`, `on: pre-push`. The values were right; only the key was wrong, which is exactly why nothing looked broken. `on:` is the natural guess, and it is what GitHub Actions uses.

## One of them is a shipped template

`templates/recipes/ambient-journal.yaml` carried `on:`. So the dead installed copy is **not a local mistake** — it was installed that way, and so would anyone else's be.

Fixed here too, because a lint rule that fails a shipped template must arrive **with** the template fix rather than after it. Precisely the #1464 shape: the reference recipe modelled the bug and users inherited it.

## The message names `on:` specifically

A generic *"event is required"* would be correct and much less useful. The author **did** say `post-commit` — they need to be told the **key** is wrong, not sent hunting the value.

## Third instance of a named failure mode

`compoundSteps.ts` and `dataPolicyPlacement.ts` each exist because authoring-time and run-time verdicts must not drift. The `cron.at` check **three lines above this one** states the identical reasoning — reject it at save time *"not when the scheduler silently fails to register the recipe and it never fires"*. `git_hook` was simply left out of that.

## Verification

6 new tests, 4 of which failed before the change. 10 231 tests pass. All 29 shipped templates lint with 0 errors.

Mutation tested by disabling the new branch — the same 4 assertions fail, restored.

**Impact measured before committing rather than after:** 1 shipped template and 2 installed recipes were newly flagged. That is the point of the rule, and the template is fixed in this commit. The second installed recipe is operator config outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)