### PR TITLE
fix(lint): five shipped event-trigger templates could never register

### DIFF
--- a/src/recipes/__tests__/eventTriggerStepIds.test.ts
+++ b/src/recipes/__tests__/eventTriggerStepIds.test.ts
@@ -1,0 +1,89 @@
+/**
+ * An event-triggered recipe whose steps have no `id` can never register.
+ *
+ * `collectEventTriggerPrograms` parses each candidate with `parseRecipe`, and
+ * `parseStep` calls `requireString(s, "id")` — so a step without one throws,
+ * the recipe is skipped at bridge startup with a WARN in a log, and it never
+ * fires. `validateRecipeDefinition` did not require `id`, so the recipe linted
+ * clean: 0 errors, 0 warnings.
+ *
+ * Observed live in the bridge log, not theorised:
+ *
+ *   WARN [recipe-triggers] skipped watch-failing-tests.yaml — id: missing or empty 'id'
+ *
+ * FIVE SHIPPED TEMPLATES were dead this way — ambient-journal,
+ * fix-errors-on-save, lint-on-save, triage-failing-tests, watch-failing-tests.
+ * All are fixed in the same change, because a rule that fails your own
+ * templates is a rule you will turn off.
+ *
+ * SCOPE IS MEASURED, NOT ASSUMED. `id` is required by `parseRecipe`, which also
+ * backs the installer — but 20 of 29 shipped templates omit it somewhere, and
+ * cron/manual/webhook recipes run fine without it through the flat runner. A
+ * global error would break most of the library to fix five files. So the rule
+ * covers exactly the population that provably cannot work: recipes whose
+ * trigger is an event type.
+ *
+ * Same drift as #1493 (`git_hook.event`), one field over, found in the same
+ * log during the same reading. That is the fourth instance of a failure mode
+ * this repository has named twice.
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+const EVENT_TRIGGERS = [
+  { type: "file_watch", patterns: ["**/*.ts"] },
+  { type: "git_hook", event: "post-commit" },
+  { type: "on_file_save", patterns: ["**/*.ts"] },
+  { type: "on_test_run" },
+];
+
+const stepNoId = { tool: "file.read", path: "/dev/null" };
+const stepWithId = { id: "s1", ...stepNoId };
+
+const errorsFor = (trigger: unknown, steps: unknown[]) =>
+  validateRecipeDefinition({ name: "probe", trigger, steps }).issues.filter(
+    (i) => i.level === "error",
+  );
+
+describe("event-triggered recipes require a step id", () => {
+  it("rejects a missing id under every event trigger", () => {
+    for (const trigger of EVENT_TRIGGERS) {
+      const errs = errorsFor(trigger, [stepNoId]);
+      expect(errs.length, JSON.stringify(trigger.type)).toBeGreaterThan(0);
+      expect(errs.map((e) => e.message).join(" ")).toMatch(
+        /never registers|id/i,
+      );
+    }
+  });
+
+  it("accepts the same recipe once every step has an id", () => {
+    for (const trigger of EVENT_TRIGGERS) {
+      expect(errorsFor(trigger, [stepWithId]), trigger.type).toEqual([]);
+    }
+  });
+
+  it("rejects an id that is present but empty", () => {
+    expect(
+      errorsFor(EVENT_TRIGGERS[0], [{ id: "   ", ...stepNoId }]).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("flags the offending step so the author knows which one", () => {
+    const errs = errorsFor(EVENT_TRIGGERS[0], [stepWithId, stepNoId]);
+    expect(errs.map((e) => e.message).join(" ")).toMatch(/2/);
+  });
+
+  it("leaves cron, manual and webhook recipes alone", () => {
+    // Load-bearing: 20 of 29 shipped templates omit `id` somewhere and run
+    // fine, because the flat runner does not need it. A global rule would
+    // break most of the library to fix five files.
+    for (const trigger of [
+      { type: "cron", at: "0 9 * * *" },
+      { type: "manual" },
+      { type: "webhook" },
+    ]) {
+      expect(errorsFor(trigger, [stepNoId]), trigger.type).toEqual([]);
+    }
+  });
+});

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -189,6 +189,42 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
           message: `Invalid trigger.type. Must be one of: ${validTypes.join(", ")}`,
         });
       }
+      // An event-triggered recipe whose steps have no `id` can never
+      // register. `collectEventTriggerPrograms` parses with `parseRecipe`, and
+      // `parseStep` calls `requireString(s, "id")` — so it throws, the recipe
+      // is skipped at bridge startup with only a WARN in a log, and it never
+      // fires. Five SHIPPED templates were dead this way.
+      //
+      // Scoped to event triggers on purpose, and the scope is measured: `id`
+      // is required by `parseRecipe` (which also backs the installer), but 20
+      // of 29 shipped templates omit it somewhere and run fine, because the
+      // flat runner does not need it. A global error would break most of the
+      // library to fix five files.
+      if (
+        typeof trigger.type === "string" &&
+        ["file_watch", "git_hook", "on_file_save", "on_test_run"].includes(
+          trigger.type,
+        ) &&
+        Array.isArray(r.steps)
+      ) {
+        (r.steps as unknown[]).forEach((step: unknown, idx: number) => {
+          if (!step || typeof step !== "object" || Array.isArray(step)) return;
+          const id = (step as Record<string, unknown>).id;
+          if (typeof id !== "string" || id.trim() === "") {
+            issues.push({
+              level: "error",
+              message:
+                `Step ${idx + 1}: an event-triggered recipe (trigger.type: ` +
+                `${trigger.type}) requires a non-empty \`id\` on every step. ` +
+                "Without one the recipe never registers — it is skipped at " +
+                "bridge startup and never fires.",
+              path: `steps.${idx}.id`,
+              code: "event-trigger-step-id-missing",
+            });
+          }
+        });
+      }
+
       // A git_hook recipe that lints clean and never fires. `parseTrigger`
       // (parser.ts) requires `event` to be one of these three and throws
       // otherwise, which surfaces only as a startup WARN in a log — the

--- a/templates/recipes/ambient-journal.yaml
+++ b/templates/recipes/ambient-journal.yaml
@@ -8,7 +8,8 @@ trigger:
   # fired. `recipe lint` now refuses it.
   event: post-commit
 steps:
-  - tool: file.append
+  - id: journal
+    tool: file.append
     path: ~/.patchwork/journal/{{date}}.md
     content: "- {{time}}  committed {{hash}} — {{message}}\n"
 output:

--- a/templates/recipes/fix-errors-on-save.yaml
+++ b/templates/recipes/fix-errors-on-save.yaml
@@ -13,12 +13,14 @@ trigger:
   glob: "**/*.{ts,tsx}"
 
 steps:
-  - tool: diagnostics.get
+  - id: read_file
+    tool: diagnostics.get
     uri: "{{file}}"
     filter: error
     into: errors
 
-  - agent:
+  - id: fix
+    agent:
       # Declared `internal` — source, diagnostics, git history, test output, issue
       # text. Declared EXPLICITLY rather than left to the default, which is also
       # `internal`: an absent policy means nobody decided, and a reference template
@@ -71,7 +73,8 @@ steps:
 
   # Only append to the inbox when fixes were applied. When no errors exist
   # the agent outputs nothing (empty string) and {{result}} is empty → falsy → skip.
-  - tool: file.append
+  - id: write_back
+    tool: file.append
     path: ~/.patchwork/inbox/auto-fixes.md
     content: "{{result}}\n\n"
     when: "{{result}}"

--- a/templates/recipes/lint-on-save.yaml
+++ b/templates/recipes/lint-on-save.yaml
@@ -4,9 +4,11 @@ trigger:
   type: on_file_save
   glob: "**/*.{ts,tsx}"
 steps:
-  - tool: diagnostics.get
+  - id: lint
+    tool: diagnostics.get
     uri: "{{file}}"
     into: diags
-  - tool: file.append
+  - id: report
+    tool: file.append
     path: ~/.patchwork/inbox/lint.md
     content: "- {{time}}  {{file}} — {{diags}}\n"

--- a/templates/recipes/triage-failing-tests.yaml
+++ b/templates/recipes/triage-failing-tests.yaml
@@ -12,10 +12,12 @@ trigger:
   type: on_test_run
   filter: failure
 steps:
-  - tool: git.log_since
+  - id: triage
+    tool: git.log_since
     since: 12h
     into: recent
-  - agent:
+  - id: summarise
+    agent:
       # Declared `internal` — source, diagnostics, git history, test output, issue
       # text. Declared EXPLICITLY rather than left to the default, which is also
       # `internal`: an absent policy means nobody decided, and a reference template
@@ -36,7 +38,8 @@ steps:
         command to run to confirm.
       driver: claude-code
       into: triage
-  - tool: file.write
+  - id: record
+    tool: file.write
     path: ~/.patchwork/inbox/test-triage-{{date}}-{{time}}.md
     content: |
       # Test triage — {{date}} {{time}}

--- a/templates/recipes/watch-failing-tests.yaml
+++ b/templates/recipes/watch-failing-tests.yaml
@@ -4,7 +4,8 @@ trigger:
   type: on_test_run
   filter: failure
 steps:
-  - agent:
+  - id: diagnose
+    agent:
       # Declared `internal` — source, diagnostics, git history, test output, issue
       # text. Declared EXPLICITLY rather than left to the default, which is also
       # `internal`: an absent policy means nobody decided, and a reference template
@@ -16,6 +17,7 @@ steps:
         Failures: {{failures}}.
         Write 3 sentences: which test, likely cause, first thing to check.
       into: summary
-  - tool: file.append
+  - id: record
+    tool: file.append
     path: ~/.patchwork/inbox/test-failures.md
     content: "\n## {{date}} {{time}}\n{{summary}}\n"


### PR DESCRIPTION
Follow-on to #1493, found in the same log reading.

## The defect

`collectEventTriggerPrograms` parses each candidate with `parseRecipe`, and `parseStep` calls `requireString(s, "id")`. A step without one **throws**, the recipe is skipped at bridge startup with a WARN in a log, and it never fires. `validateRecipeDefinition` did not require `id`, so the recipe linted clean — **0 errors, 0 warnings**.

```
WARN [recipe-triggers] skipped watch-failing-tests.yaml — id: missing or empty 'id'
```

**Five shipped templates were dead on arrival**: `ambient-journal`, `fix-errors-on-save`, `lint-on-save`, `triage-failing-tests`, `watch-failing-tests`. All fixed here — a rule that fails your own templates is a rule someone turns off rather than satisfies.

## This makes #1493 look better than it was

`ambient-journal` carried **two independent defects**: `on:` where the parser wants `event:` (fixed in #1493) **and** a step with no id. Fixing the first alone left it **exactly as dead as before**, and the log line that would have said so is the one nobody reads.

Worth recording as its own lesson: a fix verified only against the defect it targeted can leave the user's symptom completely unchanged.

## Scope is measured, not assumed

`id` is required by `parseRecipe`, which also backs the installer — but **20 of 29 shipped templates omit it somewhere and run fine**, because the flat runner does not need it. A global error would break most of the library to fix five files.

So the rule covers exactly the population that provably cannot work: recipes whose trigger is an event type. A test pins that cron, manual and webhook recipes are left alone.

## Verified behaviourally, not by lint

Lint agreeing with itself proves nothing here. Driving `collectEventTriggerPrograms` over the five templates against a clean `PATCHWORK_HOME`:

| | registered | warnings |
|---|---|---|
| before | **0 of 5** | 5 |
| after | **5 of 5** | 0 |

An intermediate run registered only 1 with no warnings, which looked like a partial failure and was not — four of the five are in this machine's disabled list and the collector honours it. Chasing that down is why the final check isolates the config rather than inheriting it.

5 new tests, 3 of which failed before the change. 10 236 tests pass. All 29 templates parse and lint with 0 errors.

**One self-inflicted near-miss, recorded:** the first attempt at inserting ids matched two-space list items *anywhere* in the file and corrupted an `allowWrites:` entry into invalid YAML. Caught by parsing every file immediately afterwards rather than trusting the edit; reverted and redone scoped to the `steps:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)