### PR TITLE
fix(lint): the recipe-name rule said "should"; the parser says no

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,29 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `recipe run <name> [--local --dry-run --step <id> --attempt <n> --ledger-dir <path> --var k=v]` — Manual run with overrides; `--local` skips the bridge API.
 - `recipe rollback <name> --attempt <id> --ledger-dir <path> [--json]` — Undo a recipe attempt's `file.write`/`file.append` side effects, restoring each touched file to its pre-run content (or deleting it if the run created it). `<name>` must match the recipe's declared `name:`, and `--attempt`/`--ledger-dir` must match the original `recipe run` invocation. No bridge required — reads `${ledgerDir}/file_rollback.jsonl` (see `src/recipes/fileRollback.ts`), the pre-image counterpart to `--ledger-dir`'s idempotency ledger (PR5b). Ephemeral rollback: attempt-scoped undo of filesystem side effects, not a general version-control system, and deliberately narrow to file tools — undoing a GitHub issue creation, Slack post, or git push has no generic inverse and is out of scope.
 - `recipe lint <file.yaml>` — Lint a recipe YAML against the schema + best-practice rules.
+
+  **Three rules exist because lint and runtime had drifted, and drift here is
+  silent and permissive — the recipe passes every check and never runs.**
+  `compoundSteps.ts` and `dataPolicyPlacement.ts` were each written for an
+  earlier instance of exactly this; these are the next three.
+
+  - **`git_hook.event`** must be `post-commit` / `pre-push` / `post-merge`.
+    `parseTrigger` throws otherwise, so the recipe is skipped at bridge startup
+    with only a WARN in a log. Two live recipes named the key `on:` — the value
+    was right, so nothing looked broken. A shipped template did too.
+  - **Event-triggered recipes need a step `id` on every step.** `parseStep`
+    calls `requireString(s, "id")`, so without one the recipe never registers.
+    **Five shipped templates were dead this way.** Scoped to event triggers
+    deliberately: 20 of 29 templates omit `id` somewhere and run fine, because
+    the flat runner does not need it — a global rule would break most of the
+    library to fix five files.
+  - **A tool-enabled agent step with no `data_policy`** is a WARNING, never an
+    error (ADR-0021 fail-soft: absent ⇒ `internal`). It marks the population
+    most likely to be under-classified, and says in its own text that it cannot
+    see a step whose driver is `auto`.
+
+  A recipe that fails any of these is reported by `recipe doctor`, which is
+  where an operator will actually look.
 - `recipe preflight <file.yaml>` — Connector preflight: list authorisations the recipe needs.
 - `recipe doctor <name|file.yaml> [--json] [--local]` — One-screen "why is this recipe unhealthy + how do I fix it" diagnosis. Composes the static preflight check (lint + write-policy + plan) with the recipe-scoped runtime halt summary from a live bridge (`/runs/halt-summary?recipe=`), mapping every finding to an actionable hint (shared `HALT_CATEGORY_HINTS`/`HALT_CATEGORY_LABELS` in `src/recipes/haltCategory.ts`, also used by `halts`). Fail-soft: no bridge → static-only; a recipe too broken to plan → lint-only diagnosis (never stack-traces). `--local` skips the runtime check. Exits 1 when unhealthy. Same composition is exposed over HTTP at `GET /recipes/doctor?recipe=<name>` (name-only over HTTP; reuses `deps.haltSummaryFn` in-process) and surfaced in the dashboard as a **Doctor** panel on the recipe-detail page (needs the dedicated `api/bridge/recipes/doctor` proxy — the dynamic `recipes/[...name]` proxy would otherwise swallow the `?recipe=` query). Run-detail step rows also render the per-category fix hint next to `haltReason` (shared `HALT_CATEGORY_HINT` in `dashboard/src/lib/haltCategory.ts`).
 - `recipe fmt <file.yaml>` — Format a recipe YAML in place.
@@ -489,6 +512,28 @@ worker may DO; this answers what a destination may RECEIVE.
   - Direct `requestOrNull` + inline unwrap — when handler has rich contract (e.g. `{success: true/false, data, error}`) and caller needs structured error (see `closeTab`, `saveFile`). Do NOT use `tryRequest` — hides info caller needs.
   - When auditing: read handler in `vscode-extension/src/handlers/*.ts`, enumerate ALL return statements (success AND error paths) before choosing helper. Test mocks always lie — handler file is ground truth.
 - **Automation DSL**: automation hooks compile to an `AutomationProgram` ADT (`src/fp/automationProgram.ts`) via `parsePolicy` (`src/fp/policyParser.ts`) and run through a single interpreter `executeAutomationPolicy` (`src/fp/automationInterpreter.ts`). Seven nodes: `Hook`, `Sequence`, `Parallel`, `WithCooldown`, `WithDedup`, `WithRateLimit`, `WithRetry`. Side effects isolated behind the `Backend` interface (`src/fp/interpreterContext.ts`): `VsCodeBackend` (prod) + `TestBackend` (collector with `reset()`). `AutomationHooks` holds one `AutomationState` value (`src/fp/automationState.ts`) — all state transitions go through pure functions. New hooks: extend `HookType` union, add parser case, wire handler to `_runInterpreter(hookType, eventData)`. Parallel branches merge via `mergeAutomationStates` (max timestamp per key).
+
+## Packaging gate
+
+`npm run audit:pack` (wired into `prepublishOnly`) refuses to publish any file
+git does not track, `dist/` aside.
+
+`package.json`'s `files` includes `templates` wholesale, and **git exclusions
+have no effect on npm packaging** — `.git/info/exclude` is per-clone and
+invisible to everyone else, and the `.npmignore` makes npm ignore `.gitignore`
+entirely. So a file deliberately kept out of the repository is still packed.
+Releases cut in CI are safe only because a fresh clone has no untracked files;
+that is a property of the RUNNER, not of the package.
+
+It is a gate rather than a denylist on purpose: `files` already carried
+name-based exclusions for the private tool modules, which handled the compiled
+side and missed the template side. It also **never prints filenames** — the
+name of a deliberately-excluded file is itself the disclosure — reporting a
+count and directory, with `--show` for a local listing. Same reasoning as the
+private-identifier gate.
+
+Deliberately NOT in CI: a clean clone can never fail it, and a check that
+always reports OK is the noise that teaches people to ignore checks.
 
 ## Testing Requirements
 

--- a/src/recipes/__tests__/recipeNameSeverity.test.ts
+++ b/src/recipes/__tests__/recipeNameSeverity.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The recipe-name rule said "should"; the parser says no.
+ *
+ * `validateRecipeDefinition` warned that a name "should use kebab-case", which
+ * reads as a style preference. `parseRecipe` REFUSES a name outside
+ * `RECIPE_NAME_RE`, and it backs both the installer and the event-trigger
+ * collector — so such a recipe cannot be installed via `recipe install` and
+ * can never register a file_watch / git_hook / on_file_save / on_test_run
+ * trigger. Two installed recipes carry such names today.
+ *
+ * The severity is split rather than raised wholesale, and the split is
+ * measured. A cron recipe with a non-conforming name still RUNS: the scheduler
+ * loads it by its own path, and the live logs show no scheduler complaint about
+ * either offender. Making this an error everywhere would fail recipes that
+ * work — the opposite mistake, and the one that gets a rule deleted.
+ *
+ * So: error where it provably breaks (event triggers, which cannot register),
+ * warning elsewhere — with wording that states the consequence instead of
+ * implying taste. Same scoping as the step-id rule.
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateRecipeDefinition } from "../validation.js";
+
+const steps = [{ id: "s1", tool: "file.read", path: "/dev/null" }];
+
+function lint(name: string, trigger: unknown) {
+  return validateRecipeDefinition({ name, description: "d", trigger, steps });
+}
+
+const CRON = { type: "cron", at: "0 9 * * *" };
+const EVENT = { type: "on_test_run" };
+const BAD = "Ollama Local Engine Test";
+
+describe("a name the parser would refuse", () => {
+  it("is only a warning on a cron recipe, which still runs", () => {
+    const r = lint(BAD, CRON);
+    expect(r.issues.filter((i) => i.level === "error")).toEqual([]);
+    expect(
+      r.issues.filter((i) => i.level === "warning" && /name/i.test(i.message)),
+    ).not.toEqual([]);
+  });
+
+  it("is an ERROR on an event-triggered recipe, which cannot register", () => {
+    const errs = lint(BAD, EVENT).issues.filter((i) => i.level === "error");
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.map((e) => e.message).join(" ")).toMatch(
+      /register|never fires/i,
+    );
+  });
+
+  it("says what actually happens rather than what is tidy", () => {
+    // "should use kebab-case" reads as taste. The consequence is refusal.
+    const msg = lint(BAD, CRON)
+      .issues.map((i) => i.message)
+      .join(" ");
+    expect(msg).toMatch(/install|register/i);
+    expect(msg).not.toMatch(/should use kebab-case\b/);
+  });
+
+  it("leaves a conforming name alone under both triggers", () => {
+    for (const trigger of [CRON, EVENT]) {
+      const r = lint("fine-name", trigger);
+      expect(r.issues.filter((i) => i.level === "error")).toEqual([]);
+      expect(
+        r.issues.filter(
+          (i) => i.level === "warning" && /kebab|name/i.test(i.message),
+        ),
+      ).toEqual([]);
+    }
+  });
+
+  it("still accepts the scoped @scope/name registry form", () => {
+    const r = lint("@acme/some-recipe", CRON);
+    expect(r.issues.filter((i) => /kebab|name/i.test(i.message))).toEqual([]);
+  });
+});

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -155,10 +155,36 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
       // shape error worth flagging.
       !/^@[a-z0-9-]+\/[a-z0-9][a-z0-9-]{0,63}$/.test(r.name)
     ) {
+      // `parseRecipe` REFUSES a name outside RECIPE_NAME_RE, and it backs both
+      // the installer and the event-trigger collector. So this is not a style
+      // preference: the recipe cannot be installed via `recipe install`, and
+      // it can never register an event trigger.
+      //
+      // The severity is SPLIT rather than raised wholesale, and the split is
+      // measured. A cron recipe with such a name still runs — the scheduler
+      // loads it by its own path, and the live logs show no scheduler
+      // complaint about either offending recipe. An error everywhere would
+      // fail recipes that work, which is the opposite mistake and the one that
+      // gets a rule deleted.
+      const eventTriggered =
+        typeof (r.trigger as Record<string, unknown> | undefined)?.type ===
+          "string" &&
+        ["file_watch", "git_hook", "on_file_save", "on_test_run"].includes(
+          (r.trigger as Record<string, unknown>).type as string,
+        );
       issues.push({
-        level: "warning",
+        level: eventTriggered ? "error" : "warning",
         message:
-          "Recipe name should use kebab-case (lowercase letters, numbers, hyphens; max 64 chars; must start with a letter or digit)",
+          "Recipe name must be kebab-case (lowercase letters, numbers, hyphens; " +
+          "max 64 chars; must start with a letter or digit). " +
+          (eventTriggered
+            ? "This recipe declares an event trigger, and a name the parser " +
+              "refuses means it never registers — it is skipped at bridge " +
+              "startup and never fires."
+            : "As written it cannot be installed via `recipe install`, and it " +
+              "could never register an event trigger."),
+        path: "name",
+        code: "recipe-name-invalid",
       });
     }
 


### PR DESCRIPTION
Found by sweeping the **second** bridge's log, which had never been read:

```
WARN [recipe-triggers] skipped ollama-test.yaml — name: name must match /^[a-z…
```

## The defect

`validateRecipeDefinition` warned that a name *"should use kebab-case"* — which reads as a style preference. `parseRecipe` **refuses** a name outside `RECIPE_NAME_RE`, and it backs both the installer and the event-trigger collector. So such a recipe **cannot be installed** via `recipe install` and can **never register** an event trigger.

Two installed recipes carry such names.

## The severity is split, not raised — and the split is measured

A cron recipe with a non-conforming name **still runs**: the scheduler loads it by its own path, and neither bridge log shows a scheduler complaint about either offender.

Raising this to an error everywhere would fail recipes that work — the opposite mistake, and the one that gets a rule deleted. So:

- **error** where it provably breaks (event triggers, which cannot register)
- **warning** elsewhere

Same scoping as the step-id rule in #1494.

The wording now states the consequence rather than implying taste. *"Should use kebab-case"* invites a shrug; *"cannot be installed, and could never register an event trigger"* does not.

## A correction worth recording

I first reported that lint did not catch this **at all** — having printed only `errors` and not `warnings`. **The check existed.** What was wrong was its severity and its wording, which is a smaller finding than the one I nearly filed.

## Verification

Measured before committing: **0 of 29 shipped templates affected**; the 2 installed offenders are disabled scratch recipes.

10 248 tests pass. 5 new tests, 2 of which failed before the change. Mutation tested by forcing the level back to a flat warning — the event-trigger assertion fails, restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)