### PR TITLE
fix(templates): acknowledge the writes every shipped recipe performs

### DIFF
--- a/src/recipes/__tests__/templatesDeclareAllowWrites.test.ts
+++ b/src/recipes/__tests__/templatesDeclareAllowWrites.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Every shipped template acknowledges the writes it performs.
+ *
+ * `FLAG_ENFORCE_ALLOWWRITES` is OFF by default, so a template that omits
+ * `allowWrites` works today — and breaks at its write step the moment an
+ * operator turns that hardening flag on, which is a reasonable thing for them
+ * to do. Enabling a safety control should not silently disable more than half
+ * the template library.
+ *
+ * Measured when this was written: 22 of 29 shipped templates performed a write
+ * they had not acknowledged. All 22 were fixed in the same change, because a
+ * guard that fails your own library is a guard someone deletes.
+ *
+ * The walk is RECURSIVE, and that is not incidental. `templates/recipes` has a
+ * `webhook/` subdirectory holding some of the most sensitive templates in the
+ * repository, and a non-recursive listing missed it three separate times in
+ * one day — each time reporting success over the surface it had looked at.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import "../tools/index.js";
+import { getTool } from "../toolRegistry.js";
+
+const ROOT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../templates/recipes",
+);
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const f = path.join(dir, e.name);
+    if (e.isDirectory()) walk(f, acc);
+    else if (/\.ya?ml$/.test(e.name)) acc.push(f);
+  }
+  return acc;
+}
+
+interface Step {
+  tool?: unknown;
+  steps?: unknown;
+  do?: unknown;
+  fan_out?: { steps?: unknown };
+}
+
+function writeTools(steps: unknown, out = new Set<string>()): Set<string> {
+  if (!Array.isArray(steps)) return out;
+  for (const raw of steps) {
+    if (!raw || typeof raw !== "object") continue;
+    const s = raw as Step;
+    if (typeof s.tool === "string" && getTool(s.tool)?.isWrite === true) {
+      out.add(s.tool);
+    }
+    writeTools(s.steps, out);
+    if (Array.isArray(s.do)) writeTools(s.do, out);
+    else if (s.do && typeof s.do === "object") writeTools([s.do], out);
+    if (s.fan_out) writeTools(s.fan_out.steps, out);
+  }
+  return out;
+}
+
+let files: string[];
+beforeAll(() => {
+  files = walk(ROOT);
+});
+
+describe("shipped templates acknowledge their writes", () => {
+  it("finds templates in subdirectories too", () => {
+    // Guards the assertion below against passing vacuously, and specifically
+    // against the non-recursive listing that missed webhook/ three times.
+    expect(files.length).toBeGreaterThan(20);
+    expect(files.some((f) => f.includes(`${path.sep}webhook${path.sep}`))).toBe(
+      true,
+    );
+  });
+
+  it("registers the tools templates call, so isWrite is meaningful", () => {
+    // Without this, an empty registry makes every template look write-free and
+    // the real assertion passes having checked nothing.
+    expect(getTool("file.write")?.isWrite).toBe(true);
+    expect(getTool("file.append")?.isWrite).toBe(true);
+  });
+
+  it("declares every write tool it uses", () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      let doc: { steps?: unknown; allowWrites?: unknown };
+      try {
+        doc = parseYaml(readFileSync(f, "utf8")) as typeof doc;
+      } catch {
+        continue;
+      }
+      if (!doc || !Array.isArray(doc.steps)) continue;
+      const declared = Array.isArray(doc.allowWrites)
+        ? (doc.allowWrites as string[])
+        : [];
+      for (const tool of writeTools(doc.steps)) {
+        // A namespace entry acknowledges every tool in it, matching the
+        // runtime check in yamlRunner.
+        const ok =
+          declared.includes(tool) ||
+          declared.includes(tool.split(".")[0] ?? "");
+        if (!ok) offenders.push(`${path.basename(f)} → ${tool}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/templates/recipes/ambient-journal.yaml
+++ b/templates/recipes/ambient-journal.yaml
@@ -1,5 +1,12 @@
 name: ambient-journal
 description: Append a timestamped line to your daily journal whenever a git commit lands.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.append
+
 trigger:
   type: git_hook
   # The key is `event`, not `on` (#1464-family). The parser requires

--- a/templates/recipes/approval-queue-ui-test.yaml
+++ b/templates/recipes/approval-queue-ui-test.yaml
@@ -46,6 +46,13 @@ description: |
       no need to find a real session.
     - Use the "Low (0)" filter to hit the empty-state branch deterministically
       (without rejecting cards mid-test).
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: manual
   vars:

--- a/templates/recipes/ctx-loop-test.yaml
+++ b/templates/recipes/ctx-loop-test.yaml
@@ -9,6 +9,13 @@ description: |
   so the agent subprocess has MCP access. Running via `patchwork recipe run`
   (local yamlRunner) will fail at Step 1 — the local claude -p subprocess has
   no bridge MCP context. Trigger from the dashboard Recipes page instead.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: manual
 steps:

--- a/templates/recipes/daily-status.yaml
+++ b/templates/recipes/daily-status.yaml
@@ -1,5 +1,12 @@
 name: daily-status
 description: Every morning at 08:00, summarize yesterday's commits + today's calendar hints from local files.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: cron
   at: "0 8 * * *"

--- a/templates/recipes/fix-errors-on-save.yaml
+++ b/templates/recipes/fix-errors-on-save.yaml
@@ -8,6 +8,13 @@ description: |
   Requires: bridge running with --driver subprocess so the agent subprocess has
   MCP access to getBufferContent, goToDefinition, getHover, getDiagnostics, editText.
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.append
+
 trigger:
   type: on_file_save
   glob: "**/*.{ts,tsx}"

--- a/templates/recipes/gmail-health-check.yaml
+++ b/templates/recipes/gmail-health-check.yaml
@@ -1,5 +1,12 @@
 name: gmail-health-check
 description: Verify Gmail connector is working and report inbox stats.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: manual
 steps:

--- a/templates/recipes/inbox-triage.yaml
+++ b/templates/recipes/inbox-triage.yaml
@@ -1,5 +1,12 @@
 name: inbox-triage
 description: Fetch unread emails from last 24h and write a prioritised triage summary.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: cron
   at: "0 8 * * 1-5"

--- a/templates/recipes/incident-to-pr.yaml
+++ b/templates/recipes/incident-to-pr.yaml
@@ -46,6 +46,13 @@ description: |
         path: /hooks/incident-to-pr
     and reference {{payload.title}} / {{payload.body}} in place of the vars.
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - slack.post_message
+
 trigger:
   type: manual
   vars:

--- a/templates/recipes/lint-on-save.yaml
+++ b/templates/recipes/lint-on-save.yaml
@@ -1,5 +1,12 @@
 name: lint-on-save
 description: On every save of a .ts/.tsx file, surface new diagnostics to the inbox.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.append
+
 trigger:
   type: on_file_save
   glob: "**/*.{ts,tsx}"

--- a/templates/recipes/morning-brief-slack.yaml
+++ b/templates/recipes/morning-brief-slack.yaml
@@ -1,5 +1,13 @@
 name: morning-brief-slack
 description: Daily morning brief combining calendar, GitHub PRs, and Linear issues — posted to Slack.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+  - slack.post_message
+
 trigger:
   type: cron
   at: "0 8 * * 1-5"

--- a/templates/recipes/morning-brief.yaml
+++ b/templates/recipes/morning-brief.yaml
@@ -1,5 +1,12 @@
 name: morning-brief
 description: Daily morning brief combining unread emails, calendar, recent git activity, and open GitHub issues.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: cron
   at: "0 8 * * 1-5"

--- a/templates/recipes/outcome-ingester.yaml
+++ b/templates/recipes/outcome-ingester.yaml
@@ -18,6 +18,13 @@
 apiVersion: patchwork.sh/v1
 name: outcome-ingester
 description: Poll GitHub for Test Guardian issues and record outcome dispositions to the trust-replay store.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - outcomes.classify_issues
+
 trigger:
   type: cron
   at: "0 */6 * * *"

--- a/templates/recipes/project-health-check.yaml
+++ b/templates/recipes/project-health-check.yaml
@@ -2,6 +2,13 @@
 apiVersion: patchwork.sh/v1
 name: project-health-check
 description: Fetch git activity, open issues, and diagnostics in parallel, then write a health summary.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: manual
 maxConcurrency: 4

--- a/templates/recipes/sentry-to-linear.yaml
+++ b/templates/recipes/sentry-to-linear.yaml
@@ -15,6 +15,13 @@ description: |
 #     path: /hooks/sentry-to-linear
 #   Then POST from a Sentry alert rule to https://<bridge-url>/hooks/sentry-to-linear
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: manual
   vars:

--- a/templates/recipes/stale-branches.yaml
+++ b/templates/recipes/stale-branches.yaml
@@ -1,5 +1,12 @@
 name: stale-branches
 description: Weekly sweep — list local branches with no commits in 30+ days.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: cron
   at: "0 9 * * MON"

--- a/templates/recipes/watch-failing-tests.yaml
+++ b/templates/recipes/watch-failing-tests.yaml
@@ -1,5 +1,12 @@
 name: watch-failing-tests
 description: When tests fail, drop a one-paragraph explanation into the inbox.
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.append
+
 trigger:
   type: on_test_run
   filter: failure

--- a/templates/recipes/webhook/apple-watch-health-log.yaml
+++ b/templates/recipes/webhook/apple-watch-health-log.yaml
@@ -42,6 +42,14 @@ description: |
       -H 'Content-Type: application/json' \
       -d '{"sleep_hours":7.4,"sleep_quality":"restful","move_percent":112,"move_calories":645,"exercise_percent":150,"exercise_min":45,"stand_percent":100,"notes":"Closed all three rings."}'
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.append
+  - http.post
+
 trigger:
   type: webhook
   path: /apple-watch-health

--- a/templates/recipes/webhook/capture-thought.yaml
+++ b/templates/recipes/webhook/capture-thought.yaml
@@ -13,6 +13,13 @@ description: |
       -H 'Content-Type: application/json' \
       -d '{"text":"the auth refresh path needs a circuit breaker"}'
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.append
+
 trigger:
   type: webhook
   path: /capture-thought

--- a/templates/recipes/webhook/customer-escalation.yaml
+++ b/templates/recipes/webhook/customer-escalation.yaml
@@ -20,6 +20,13 @@ description: |
       -H 'Content-Type: application/json' \
       -d '{"customer_email":"jane@bigco.com","ticket_url":"https://app.intercom.com/conversations/9876","summary":"Says checkout has been broken for 3 days"}'
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - slack.post_message
+
 trigger:
   type: webhook
   path: /customer-escalation

--- a/templates/recipes/webhook/incident-intake.yaml
+++ b/templates/recipes/webhook/incident-intake.yaml
@@ -23,6 +23,13 @@ description: |
       -H 'Content-Type: application/json' \
       -d '{"title":"checkout p99 over 2s","severity":"high","source":"datadog","url":"https://app.datadoghq.com/monitor/123"}'
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - slack.post_message
+
 trigger:
   type: webhook
   path: /incident-intake

--- a/templates/recipes/webhook/meeting-prep.yaml
+++ b/templates/recipes/webhook/meeting-prep.yaml
@@ -14,6 +14,13 @@ description: |
       -H 'Content-Type: application/json' \
       -d '{"attendees":["alex@example.com","sam@example.com"],"topic":"Q3 planning"}'
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: webhook
   path: /meeting-prep

--- a/templates/recipes/webhook/morning-brief.yaml
+++ b/templates/recipes/webhook/morning-brief.yaml
@@ -15,6 +15,13 @@ description: |
   Example request:
     curl -X POST http://localhost:3101/hooks/morning-brief
 
+# Writes this recipe performs, acknowledged up front. Enforced only when
+# PATCHWORK_FLAG_ENFORCE_ALLOWWRITES is set, which is off by default — but a
+# template that omits it breaks at its write step the moment an operator turns
+# that hardening flag on, which is a reasonable thing for them to do.
+allowWrites:
+  - file.write
+
 trigger:
   type: webhook
   path: /morning-brief


### PR DESCRIPTION
`FLAG_ENFORCE_ALLOWWRITES` is **off by default**, so a template that omits `allowWrites` works today — and breaks at its write step the moment an operator turns that hardening flag on.

**Enabling a safety control should not silently disable most of the template library**, which is what would have happened: **22 of 29 shipped templates** performed a write they had not acknowledged.

## How it surfaced

Pre-flighting a *single* recipe before enabling it. `recipe doctor` reported `unacknowledged-write` on `watch-failing-tests`, which meant enabling it would have produced a recipe that **fires and then halts** — worse than leaving it off.

The one-recipe check turned out to describe most of the library.

## The fix

Each declaration lists the write tools that recipe actually calls, derived from the registry's `isWrite` rather than guessed. The comment states the flag that makes it matter, so the next reader does not delete it as decoration.

## The guard, and why it walks recursively

A rule with no enforcement is how this arose, so a test comes with it.

It walks **recursively**, and that is not incidental. `templates/recipes` has a `webhook/` subdirectory holding some of the most sensitive templates in the repo, and a non-recursive listing missed it **three separate times in one day** — including in my own first pass at this change, which reported 16 rather than 22. Each time the scripted pass reported success over the surface it had looked at.

So the test asserts two things beyond the rule itself:

- the walk actually finds that subdirectory;
- the tool registry is populated — an empty registry would make every template look write-free and the real assertion would pass having checked nothing.

## Verification

All 29 templates parse and lint with **0 errors**. `recipe doctor` reports **0** unacknowledged writes across the set where it reported 22. 10 251 tests pass.

Mutation tested by stripping one template's block — the guard fails and names that exact file and tool, restored.