### PR TITLE
fix(identity): a roster we could not read is not a one-person workspace

### DIFF
--- a/src/__tests__/approvalHttp-actor.test.ts
+++ b/src/__tests__/approvalHttp-actor.test.ts
@@ -28,7 +28,12 @@ const ada: Roster["members"][number] = {
   active: true,
 };
 
-const roster: Roster = { members: [ada], implicit: false, dropped: [] };
+const roster: Roster = {
+  members: [ada],
+  implicit: false,
+  unreadable: false,
+  dropped: [],
+};
 
 function makeQueue(): ApprovalQueue {
   return {

--- a/src/identity/__tests__/approverFromSession.test.ts
+++ b/src/identity/__tests__/approverFromSession.test.ts
@@ -18,7 +18,7 @@ import { implicitOwner } from "../roster.js";
 const SECRET = "d".repeat(48);
 
 function rosterOf(...members: Roster["members"]): Roster {
-  return { members, implicit: false, dropped: [] };
+  return { members, implicit: false, unreadable: false, dropped: [] };
 }
 
 const ada: Roster["members"][number] = {
@@ -104,7 +104,12 @@ describe("createApproverResolver", () => {
     const owner = implicitOwner();
     const cookie = await signSession({ memberId: owner.id });
     const resolve = createApproverResolver({
-      rosterFor: () => ({ members: [owner], implicit: true, dropped: [] }),
+      rosterFor: () => ({
+        members: [owner],
+        implicit: true,
+        unreadable: false,
+        dropped: [],
+      }),
     });
     // No members.json exists, so this "member" was synthesised as a degraded
     // default rather than configured by anyone. Attributing to them would be

--- a/src/identity/__tests__/identity.test.ts
+++ b/src/identity/__tests__/identity.test.ts
@@ -270,11 +270,22 @@ describe("loadRoster", () => {
     expect(r.members).toEqual([implicitOwner()]);
   });
 
-  it("malformed JSON degrades to the implicit owner rather than locking anyone out", () => {
-    // Opposite stance to the approval gate's fail-closed (ADR-0016), and
-    // deliberately so: this decides who you are on your own machine.
+  it("malformed JSON is UNREADABLE, not the implicit owner", () => {
+    // Changed deliberately. This test previously asserted `implicit === true`,
+    // on the reasoning that deciding "who you are on your own machine" should
+    // fail soft — the opposite stance to the approval gate's fail-closed
+    // (ADR-0016). The fail-soft stance is right and is kept for an ABSENT file.
+    //
+    // It is wrong here: this file EXISTS, so a membership decision was made,
+    // and answering "I could not read it" with an owner who holds every
+    // capability makes corrupting the file a way to become the owner. Nothing
+    // consults the roster to permit an action yet, so the distinction costs
+    // nothing to draw now and would be a live escalation to discover later.
     writeFileSync(at(), "{ not json");
-    expect(loadRoster(at()).implicit).toBe(true);
+    const r = loadRoster(at());
+    expect(r.unreadable).toBe(true);
+    expect(r.implicit).toBe(false);
+    expect(r.members).toEqual([]);
   });
 
   it("accepts both a bare array and a { members } wrapper", () => {
@@ -315,9 +326,16 @@ describe("loadRoster", () => {
     expect(r.dropped).toEqual([1]);
   });
 
-  it("a roster whose entries are all invalid degrades to the implicit owner", () => {
+  it("a roster whose entries are all invalid is UNREADABLE, not implicit", () => {
+    // Same reversal, same reason as the malformed-JSON case above: the
+    // operator listed members and we understood none of them, which is not the
+    // same fact as "this is a one-person machine". The rejected positions are
+    // carried through so the report can say which.
     writeFileSync(at(), JSON.stringify([{ nope: true }]));
-    expect(loadRoster(at()).implicit).toBe(true);
+    const r = loadRoster(at());
+    expect(r.unreadable).toBe(true);
+    expect(r.implicit).toBe(false);
+    expect(r.dropped).toEqual([0]);
   });
 
   it("a real one-entry roster is not implicit", () => {
@@ -370,6 +388,7 @@ describe("resolvePrincipal", () => {
       },
     ] as Member[],
     implicit: false,
+    unreadable: false,
     dropped: [],
   };
 
@@ -405,7 +424,12 @@ describe("resolvePrincipal", () => {
 
 describe("findMember", () => {
   it("finds by id and returns null when absent", () => {
-    const r = { members: [member()], implicit: false, dropped: [] };
+    const r = {
+      members: [member()],
+      implicit: false,
+      unreadable: false,
+      dropped: [],
+    };
     expect(findMember(r, "anna")?.id).toBe("anna");
     expect(findMember(r, "nobody")).toBeNull();
   });
@@ -417,6 +441,7 @@ describe("describeRoster", () => {
       describeRoster({
         members: [implicitOwner()],
         implicit: true,
+        unreadable: false,
         dropped: [],
       }),
     ).toContain("single implicit owner");
@@ -434,13 +459,19 @@ describe("describeRoster", () => {
         }),
       ],
       implicit: false,
+      unreadable: false,
       dropped: [],
     };
     expect(describeRoster(r)).toBe("roster loaded: 2 people, 1 worker");
   });
 
   it("omits workers when there are none, and singularises", () => {
-    const r = { members: [member()], implicit: false, dropped: [] };
+    const r = {
+      members: [member()],
+      implicit: false,
+      unreadable: false,
+      dropped: [],
+    };
     expect(describeRoster(r)).toBe("roster loaded: 1 person");
   });
 
@@ -448,7 +479,12 @@ describe("describeRoster", () => {
     // Without this, a typo silently removes a member — they never appear and
     // nothing errors, which is the worst failure for a file deciding who may
     // approve things.
-    const r = { members: [member()], implicit: false, dropped: [1, 3] };
+    const r = {
+      members: [member()],
+      implicit: false,
+      unreadable: false,
+      dropped: [1, 3],
+    };
     const out = describeRoster(r);
     expect(out).toContain("REJECTED");
     expect(out).toContain("1, 3");

--- a/src/identity/__tests__/rosterUnreadable.test.ts
+++ b/src/identity/__tests__/rosterUnreadable.test.ts
@@ -1,0 +1,136 @@
+/**
+ * A roster we could not read is not a one-person workspace.
+ *
+ * `loadRoster` collapses five different situations into one answer — a single
+ * implicit OWNER, which `principalCan` grants every capability:
+ *
+ *   1. no `members.json`            — a genuine one-person workspace
+ *   2. `members.json` is not JSON
+ *   3. it is JSON of the wrong shape
+ *   4. it is the right shape but every entry is malformed
+ *   5. it is an empty list
+ *
+ * Only (1) means "nobody has ever made a membership decision here". The rest
+ * mean "a membership decision exists and we could not read it", and answering
+ * those with an omnipotent owner turns file corruption into privilege
+ * escalation: delete or break the file, become the owner.
+ *
+ * This is harmless today only because nothing consults the roster to permit an
+ * action (verified: zero production call sites for `principalCan` /
+ * `canApproveAction` / `capabilitiesFor` outside `src/identity/`). It stops
+ * being harmless the moment the first one exists, which is exactly when nobody
+ * will be looking at this file. So the distinction is drawn now, while the
+ * change cannot break anything.
+ *
+ * Fail-soft for the absent file is KEPT — see the module docstring: the free
+ * product is one person on one machine and must not grow a login screen.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  describeRoster,
+  loadRoster,
+  principalCan,
+  resolvePrincipal,
+} from "../roster.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "roster-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const rosterAt = (contents?: string) => {
+  const p = join(dir, "members.json");
+  if (contents !== undefined) writeFileSync(p, contents, "utf8");
+  return loadRoster(p);
+};
+
+describe("a roster file that exists but cannot be read", () => {
+  const unreadable: ReadonlyArray<[string, string]> = [
+    ["not JSON at all", "{ this is not json"],
+    ["JSON of the wrong shape", '{"nope": true}'],
+    ["a bare JSON scalar", '"members"'],
+    ["every entry malformed", '[{"no":"id"},{"also":"broken"}]'],
+    ["an empty list", "[]"],
+  ];
+
+  for (const [label, contents] of unreadable) {
+    it(`${label} — is reported unreadable, not implicit`, () => {
+      const r = rosterAt(contents);
+      expect(r.unreadable).toBe(true);
+      expect(r.implicit).toBe(false);
+    });
+
+    it(`${label} — grants an unidentified request NOTHING`, () => {
+      const r = rosterAt(contents);
+      const principal = resolvePrincipal(r);
+      expect(principal).toBeNull();
+      // The capability that matters: an approval is the one place segregation
+      // of duties is modelled, so it is the one an escalation would target.
+      expect(principalCan(principal, "action.approve")).toBe(false);
+      expect(principalCan(principal, "workspace.read")).toBe(false);
+    });
+  }
+});
+
+describe("a roster file that is simply absent", () => {
+  it("still means one implicit owner — the free product must not grow a login", () => {
+    const r = rosterAt();
+    expect(r.implicit).toBe(true);
+    expect(r.unreadable).toBe(false);
+    const principal = resolvePrincipal(r);
+    expect(principal).not.toBeNull();
+    expect(principalCan(principal, "action.approve")).toBe(true);
+  });
+});
+
+describe("a roster that reads fine", () => {
+  it("is neither implicit nor unreadable, and drops only what it must", () => {
+    const r = rosterAt(
+      JSON.stringify([
+        { id: "a", displayName: "A", roles: ["owner"], active: true },
+        { broken: true },
+      ]),
+    );
+    expect(r.implicit).toBe(false);
+    expect(r.unreadable).toBe(false);
+    expect(r.members).toHaveLength(1);
+    expect(r.dropped).toEqual([1]);
+  });
+
+  it("does not hand an unidentified request a member", () => {
+    const r = rosterAt(
+      JSON.stringify([
+        { id: "a", displayName: "A", roles: ["owner"], active: true },
+      ]),
+    );
+    // A real roster has never answered an anonymous request, and must not
+    // start: `implicit` is false, so there is nobody to default to.
+    expect(resolvePrincipal(r)).toBeNull();
+  });
+});
+
+describe("what the operator is told at startup", () => {
+  it("names the unreadable file, and does not read as an empty workspace", () => {
+    const line = describeRoster(rosterAt('[{"no":"id"}]'));
+    // The failure this guards: without its own branch, the generic path
+    // reports "roster loaded: 0 people" — which an operator reads as "nobody
+    // has signed up yet", not "your file is broken".
+    expect(line).not.toMatch(/roster loaded/);
+    expect(line).toMatch(/could not be read/);
+    expect(line).toMatch(/position 0/);
+    // It must not claim the single-owner default, which is a different state.
+    expect(line).toMatch(/NOT/);
+  });
+
+  it("still describes an absent file as the single implicit owner", () => {
+    expect(describeRoster(rosterAt())).toMatch(/single implicit owner/);
+  });
+});

--- a/src/identity/roster.ts
+++ b/src/identity/roster.ts
@@ -47,6 +47,20 @@ export interface Roster {
    * decision, the first is the absence of one.
    */
   implicit: boolean;
+  /**
+   * True when a roster file EXISTS and could not be understood — unparseable,
+   * the wrong shape, or holding no entry that parses.
+   *
+   * This is the opposite of `implicit` and must never be confused with it. An
+   * absent file means nobody has made a membership decision here, and the
+   * one-person default is right. An unreadable file means a decision EXISTS
+   * and we cannot read it, so the safe answer is nobody — otherwise breaking
+   * the file is a way to become the owner.
+   *
+   * `members` is empty in this state, so `resolvePrincipal` yields `null` and
+   * `principalCan` grants nothing.
+   */
+  unreadable: boolean;
   /** Entries that failed to parse, by index, so the operator can be told. */
   dropped: number[];
 }
@@ -63,7 +77,22 @@ export function implicitOwner(): Member {
 }
 
 function implicitRoster(): Roster {
-  return { members: [implicitOwner()], implicit: true, dropped: [] };
+  return {
+    members: [implicitOwner()],
+    implicit: true,
+    unreadable: false,
+    dropped: [],
+  };
+}
+
+/**
+ * A roster file we found and could not read. Deliberately NOT `implicitRoster`:
+ * see `Roster.unreadable`. `dropped` carries the entry indices when we got far
+ * enough to have any, so the operator can be told what was lost rather than
+ * only that something was.
+ */
+function unreadableRoster(dropped: number[] = []): Roster {
+  return { members: [], implicit: false, unreadable: true, dropped };
 }
 
 /** Default location: `~/.patchwork/members.json`, honouring `PATCHWORK_HOME`. */
@@ -90,11 +119,14 @@ export function defaultRosterPath(): string {
 export function loadRoster(path = defaultRosterPath()): Roster {
   if (!existsSync(path)) return implicitRoster();
 
+  // Every `return` below this line is `unreadableRoster`, never
+  // `implicitRoster`. The file exists, so a membership decision was made here;
+  // failing to read it must not answer with an owner who can do everything.
   let parsed: unknown;
   try {
     parsed = JSON.parse(readFileSync(path, "utf8"));
   } catch {
-    return implicitRoster();
+    return unreadableRoster();
   }
 
   const raw = Array.isArray(parsed)
@@ -102,7 +134,7 @@ export function loadRoster(path = defaultRosterPath()): Roster {
     : Array.isArray((parsed as { members?: unknown })?.members)
       ? (parsed as { members: unknown[] }).members
       : null;
-  if (!raw) return implicitRoster();
+  if (!raw) return unreadableRoster();
 
   const members: Member[] = [];
   const dropped: number[] = [];
@@ -119,8 +151,11 @@ export function loadRoster(path = defaultRosterPath()): Roster {
     members.push(m);
   }
 
-  if (members.length === 0) return implicitRoster();
-  return { members, implicit: false, dropped };
+  // A file whose every entry was dropped is unreadable, not one-person: the
+  // operator listed members and we understood none of them. `dropped` is
+  // carried through so the report says which.
+  if (members.length === 0) return unreadableRoster(dropped);
+  return { members, implicit: false, unreadable: false, dropped };
 }
 
 /**
@@ -134,6 +169,21 @@ export function loadRoster(path = defaultRosterPath()): Roster {
 export function describeRoster(roster: Roster): string {
   if (roster.implicit) {
     return "no members.json — running as a single implicit owner";
+  }
+  // Loud, and deliberately not phrased as a degraded-but-fine state. Without
+  // this branch the line below reports "roster loaded: 0 people", which reads
+  // like an empty workspace rather than an unreadable file — and this string is
+  // the startup log an operator actually sees.
+  if (roster.unreadable) {
+    const where =
+      roster.dropped.length > 0
+        ? ` — every entry REJECTED at position ${roster.dropped.join(", ")}`
+        : "";
+    return (
+      `members.json EXISTS but could not be read${where}. ` +
+      "Nobody is identified in this workspace until it is fixed; this is NOT " +
+      "the single-owner default, which applies only when the file is absent."
+    );
   }
   const humans = roster.members.filter((m) => m.kind === "human").length;
   const workers = roster.members.length - humans;


### PR DESCRIPTION
Removes a privilege-escalation trap **before** the code path that would arm it exists.

## The bug

`loadRoster` collapsed five different situations into one answer — a single implicit **OWNER**, which `principalCan` grants every capability:

| situation | old result |
|---|---|
| no `members.json` | implicit owner |
| `members.json` is not JSON | implicit owner |
| JSON of the wrong shape | implicit owner |
| right shape, every entry malformed | implicit owner |
| an empty list | implicit owner |

Only the first means *nobody has ever made a membership decision here*. The rest mean *a decision exists and we could not read it*.

Answering those with an omnipotent owner makes **corrupting the file a way to become the owner**: break `members.json`, and a six-member workspace with segregation of duties silently becomes one party who can do everything.

## Why now, when nothing consults it

Verified: **zero** production call sites for `principalCan` / `canApproveAction` / `capabilitiesFor` outside `src/identity/` and its tests. Nothing consults the roster to permit an action, so this is inert today.

That is the argument for fixing it now rather than later. It stops being inert the moment the first consumer lands — which is exactly when nobody will be re-reading this file, and when the change would carry real risk instead of none.

## What is kept

**Fail-soft for the absent file, unchanged**, for the reason the module docstring gives: the free product is one person on one machine and must not grow a login screen. That stance is right. It was being applied to four cases it does not describe.

## Notes on the shape

- **`Roster.unreadable` is required, not optional.** An optional flag reads as `false` when omitted — the permissive answer, and the same silent fallthrough this fixes. Being required, it caught **13 construction sites** (all tests) that vitest accepted and `typecheck:tests:core` had not been run against.
- **Two existing tests are reversed, not deleted.** Each now states what it used to assert and why that was wrong. The fail-soft reasoning they encoded is correct for the case they were named after, and worth preserving in the record.
- **`describeRoster` gets its own branch.** Without it the generic path reported `roster loaded: 0 people` — which an operator reads as an empty workspace, not a broken file, and that string is the startup log line they actually see.

## Verification

- New test starts **red**: 12 of 13 failed before the fix; the one that passed is the absent-file case, i.e. behaviour preserved.
- `describeRoster` branch mutation-checked — stubbing it to `if (false)` turns the test red, with the mutation grep-confirmed in the file first.
- `typecheck` and `typecheck:tests:core` both clean.
- Full suite green: **758 files, 10266 tests**.