### PR TITLE
feat(butler): say WHY a shadow row was withheld, not just that it was

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -18,8 +18,29 @@ force-moving it back — avoidable with five minutes of a shared ledger.
 
 Before starting non-trivial work (a new branch, a fix touching shared
 subsystems like the worker-trust gate, the recipe runner, or the bridge
-init/shim path), add a line here. Remove the line once the PR merges (or
-mark it merged and delete on the next sweep).
+init/shim path), add a line here.
+
+### Retire your own entry before merging
+
+Move your line to **Recently closed** with its PR number **in the PR itself**,
+as its last commit. Not afterwards.
+
+"Remove the line once the PR merges" is what this file used to say, and it
+cannot work: nothing removes the line during the merge, so `audit-in-flight`
+fails on `main` the moment the PR lands and stays failing until some later PR
+sweeps it — and that PR leaves its own entry behind in turn. Observed on
+2026-08-24, when #1507 merged and immediately turned `main` red; CI runs this
+gate at `.github/workflows/ci.yml:188`. Three hand sweeps had already been
+needed before that, which is the same failure showing up as decay rather than
+as a red build.
+
+The cost is that an entry leaves Active slightly before the work lands. That is
+a few minutes of a stale-clear ledger, against `main` being red after every
+single merge — and a red gate nobody can act on is how a real warning gets
+ignored.
+
+An empty Active section is therefore normal and is not a sign the ledger is
+being neglected.
 
 Format: `- <date> `<branch-or-PR>` — <one-line scope> — <session/chat identity if known>`
 
@@ -29,21 +50,22 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-24 `fix/guard-self-confirmation-invariant` — "a worker cannot self-confirm its
-  own filings" is TRUE but CLAUDE.md attributes it to the wrong mechanism
-  (`outcomes confirm|reject` being CLI-only). `outcomes.classify_issues` is a recipe tool
-  that also writes dispositions. What actually holds the property is that no recipe-facing
-  `github.*` tool can mutate issue state — a load-bearing ABSENCE with no test on it.
-  Adds a guard test + corrects the reasoning. Touches src/recipes/tools/__tests__/,
-  CLAUDE.md. — main session
-- 2026-08-24 `feat/butler-shadow-reason-breakdown` — `butler shadow` reports one `unknown`
-  count covering two opposite situations: `open-recent` (looked, errand still in flight —
-  wait) and `not-observed` (could not look — go fix the path). The rows always carried
-  `reason`; only the summary discarded it. Adds a per-reason breakdown and splits the
-  unknown line. Touches src/butler/outcomeShadowLog.ts + outcomeIngester.ts — collides with
-  any Butler or outcome-store work. — main session
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-24 `feat/butler-shadow-reason-breakdown` — #1508: `butler shadow` reported one
+  `unknown` count covering two opposite situations — `open-recent` (looked; errand still in
+  flight, so wait) and `not-observed` (could not look, so go fix the path). The rows always
+  carried `reason`; only the summary discarded it. Adds a per-reason breakdown and splits
+  the unknown line. — main session
+
+- 2026-08-24 `fix/guard-self-confirmation-invariant` — #1507: "a worker cannot self-confirm
+  its own filings" is true, but CLAUDE.md attributed it to the wrong mechanism
+  (`outcomes confirm|reject` being CLI-only). `outcomes.classify_issues` is a recipe tool
+  that also writes dispositions. What actually holds the property is that no recipe-facing
+  `github.*` tool can mutate issue state — a load-bearing absence with no test on it, until
+  this added one. — main session
 
 - 2026-08-24 `chore/example-recipe-neutral-name` — #1506: gave one example recipe and its
   two references a neutral identifier, per the repository-privacy convention. The recipe's

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -36,6 +36,12 @@ verified (which is how this line came to be written).
   `github.*` tool can mutate issue state — a load-bearing ABSENCE with no test on it.
   Adds a guard test + corrects the reasoning. Touches src/recipes/tools/__tests__/,
   CLAUDE.md. — main session
+- 2026-08-24 `feat/butler-shadow-reason-breakdown` — `butler shadow` reports one `unknown`
+  count covering two opposite situations: `open-recent` (looked, errand still in flight —
+  wait) and `not-observed` (could not look — go fix the path). The rows always carried
+  `reason`; only the summary discarded it. Adds a per-reason breakdown and splits the
+  unknown line. Touches src/butler/outcomeShadowLog.ts + outcomeIngester.ts — collides with
+  any Butler or outcome-store work. — main session
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/butler/__tests__/shadowReasonBreakdown.test.ts
+++ b/src/butler/__tests__/shadowReasonBreakdown.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The `unknown` bucket answers two opposite questions with one number.
+ *
+ * `open-recent` means the channel LOOKED and the errand is not finished yet —
+ * wait. `not-observed` means the channel could not look at all — go and fix it.
+ * Both are withheld by the fold, so both land in `unknown`, and a summary that
+ * reports only the disposition leaves an operator unable to tell a healthy
+ * young ledger from one that is seeing nothing.
+ *
+ * Measured on the real ledger before this was written: 8 of 9 rows `unknown`,
+ * with no way from any shipped verb to find out which kind. The rows have
+ * always carried `reason`; only the summary discarded it — the same defect as
+ * #1469, where a defaulted-classification count named no recipe to go and fix.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  type ErrandObservation,
+  formatShadowSummary,
+  ingestErrandOutcomes,
+} from "../outcomeIngester.js";
+import { SHADOW_REASONS, summariseShadowLog } from "../outcomeShadowLog.js";
+
+const NOW = 1_800_000_000_000;
+
+let dir = "";
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "butler-reason-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/**
+ * `stateObserved: true` is what separates the two. Without it the grader
+ * returns `not-observed` even though it knows the age — age alone cannot tell
+ * "the operator ignored this" from "nobody looked", and only the first is
+ * evidence.
+ */
+const LOOKED_AND_STILL_OPEN: ErrandObservation = {
+  ref: "t:in-flight",
+  createdAt: NOW,
+  stateObserved: true,
+};
+const NEVER_LOOKED: ErrandObservation = { ref: "t:blind" };
+
+describe("summariseShadowLog attributes rows to a reason", () => {
+  it("separates 'still in flight' from 'never observed' inside `unknown`", () => {
+    ingestErrandOutcomes(
+      [
+        LOOKED_AND_STILL_OPEN,
+        { ...NEVER_LOOKED, ref: "t:blind-1" },
+        { ...NEVER_LOOKED, ref: "t:blind-2" },
+      ],
+      { now: NOW, dir },
+    );
+
+    const s = summariseShadowLog({ dir });
+
+    // The old summary could say only this much — three rows, all withheld.
+    expect(s.unknown).toBe(3);
+
+    // The new field is what makes them actionable, and they are NOT equal.
+    expect(s.byReason["open-recent"]).toBe(1);
+    expect(s.byReason["not-observed"]).toBe(2);
+  });
+
+  it("reports the full reason space, not only reasons it happened to see", () => {
+    ingestErrandOutcomes([{ ref: "t:done", completed: true }], {
+      now: NOW,
+      dir,
+    });
+    const s = summariseShadowLog({ dir });
+
+    // A caller reading `byReason["not-observed"]` must get 0, never undefined —
+    // otherwise every consumer has to defend against a missing key and one of
+    // them will forget.
+    for (const r of SHADOW_REASONS) {
+      expect(s.byReason[r]).toBeTypeOf("number");
+    }
+    expect(s.byReason.completed).toBe(1);
+    expect(s.byReason["not-observed"]).toBe(0);
+  });
+
+  it("returns a zeroed breakdown when no ledger exists", () => {
+    const s = summariseShadowLog({ dir });
+    expect(s.total).toBe(0);
+    for (const r of SHADOW_REASONS) expect(s.byReason[r]).toBe(0);
+  });
+
+  // A "counts do not leak between calls" test was written here and REMOVED: it
+  // passed with and without the defensive copy in `summariseShadowLog`, because
+  // that function builds its zero value per call, so nothing is shared to leak.
+  // It read like coverage of the aliasing hazard and proved nothing about it.
+  // The reason the copy is kept anyway is recorded at the call site.
+});
+
+describe("formatShadowSummary makes the distinction visible", () => {
+  it("splits the unknown line and warns when rows were never observed", () => {
+    ingestErrandOutcomes(
+      [
+        LOOKED_AND_STILL_OPEN,
+        { ...NEVER_LOOKED, ref: "t:blind-1" },
+        { ...NEVER_LOOKED, ref: "t:blind-2" },
+      ],
+      { now: NOW, dir },
+    );
+    const out = formatShadowSummary(summariseShadowLog({ dir }));
+
+    expect(out).toContain(
+      "of which 1 still in flight, 2 could not be observed",
+    );
+    expect(out).toContain("by reason");
+    expect(out).toContain("open-recent");
+    expect(out).toContain("not-observed");
+
+    // The warning has to say it is a broken PATH, not a verdict — an operator
+    // who reads "2 unknown" as "2 inconclusive errands" draws the wrong
+    // conclusion about their worker rather than about their plumbing.
+    expect(out).toContain("never observed at all");
+    expect(out).toMatch(/not a verdict about the errand/);
+  });
+
+  it("stays silent about observation failures when there are none", () => {
+    ingestErrandOutcomes(
+      [{ ref: "t:done", completed: true }, LOOKED_AND_STILL_OPEN],
+      { now: NOW, dir },
+    );
+    const out = formatShadowSummary(summariseShadowLog({ dir }));
+
+    expect(out).toContain(
+      "of which 1 still in flight, 0 could not be observed",
+    );
+    // No alarm when nothing is wrong — a warning that always prints is ignored
+    // by the time it matters.
+    expect(out).not.toContain("never observed at all");
+  });
+
+  it("still leads with the denominator and the promotion bar", () => {
+    ingestErrandOutcomes([{ ref: "t:done", completed: true }], {
+      now: NOW,
+      dir,
+    });
+    const out = formatShadowSummary(summariseShadowLog({ dir }));
+    expect(out).toContain("1 graded row(s)");
+    expect(out).toContain("would have become evidence");
+    expect(out).toContain("These rows moved nothing");
+  });
+});

--- a/src/butler/outcomeIngester.ts
+++ b/src/butler/outcomeIngester.ts
@@ -47,8 +47,10 @@ import {
 import {
   appendShadowOutcome,
   firstSeenByRef,
+  SHADOW_REASONS,
   type ShadowSummary,
   summariseShadowLog,
+  UNOBSERVED_REASONS,
 } from "./outcomeShadowLog.js";
 
 /** One artifact to grade, plus the key it joins on. */
@@ -163,14 +165,52 @@ export function formatShadowSummary(s: ShadowSummary): string {
     ].join("\n");
   }
   const pct = (n: number) => `${((n / s.total) * 100).toFixed(1)}%`;
+
+  // Split the `unknown` bucket by what it actually means. "Still in flight" and
+  // "could not be observed" are both withheld by the fold, and they call for
+  // opposite responses — wait, versus go and fix the observation path. Reporting
+  // one number for both leaves an operator unable to tell a healthy young ledger
+  // from a channel that is seeing nothing.
+  const unobserved = UNOBSERVED_REASONS.reduce(
+    (n, r) => n + (s.byReason[r] ?? 0),
+    0,
+  );
+  const inFlight = s.unknown - unobserved;
+
+  const reasonLines = SHADOW_REASONS.filter((r) => (s.byReason[r] ?? 0) > 0)
+    .sort((a, b) => (s.byReason[b] ?? 0) - (s.byReason[a] ?? 0))
+    .map((r) => `    ${r.padEnd(18)}${s.byReason[r]} (${pct(s.byReason[r])})`);
+
+  const unattributed =
+    s.total - SHADOW_REASONS.reduce((n, r) => n + (s.byReason[r] ?? 0), 0);
+
   return [
     `[butler-shadow] ${s.total} graded row(s):`,
     `  confirmed  ${s.confirmed} (${pct(s.confirmed)})`,
     `  junk       ${s.junk} (${pct(s.junk)})`,
     `  unknown    ${s.unknown} (${pct(s.unknown)}) — withheld by the fold`,
+    ...(s.unknown > 0
+      ? [
+          `    of which ${inFlight} still in flight, ${unobserved} could not be observed`,
+        ]
+      : []),
+    "",
+    "  by reason",
+    ...(reasonLines.length > 0 ? reasonLines : ["    (none recorded)"]),
+    ...(unattributed > 0
+      ? [`    (${unattributed} row(s) carry an unrecognised reason)`]
+      : []),
     "",
     `  ${s.wouldCount} row(s) (${pct(s.wouldCount)}) would have become evidence.`,
     "",
+    ...(unobserved > 0
+      ? [
+          `  ${unobserved} row(s) were never observed at all. That is a broken or`,
+          "  unauthorised observation path, not a verdict about the errand — fix it",
+          "  before reading anything into the proportions above.",
+          "",
+        ]
+      : []),
     "  These rows moved nothing. Before promoting, check a sample against the",
     "  real errands they describe — a disposition that reads plausibly in",
     "  aggregate can still be wrong on every individual row.",

--- a/src/butler/outcomeShadowLog.ts
+++ b/src/butler/outcomeShadowLog.ts
@@ -143,7 +143,40 @@ export interface ShadowSummary {
   unknown: number;
   /** Rows that would have become evidence had the grader been live. */
   wouldCount: number;
+  /**
+   * Rows per grading reason.
+   *
+   * The disposition counts alone cannot answer the only question an operator
+   * has when `unknown` dominates: is this channel WORKING on errands that are
+   * simply still in flight, or is it seeing nothing at all? Those are
+   * `open-recent` and `not-observed`, and they collapse into the same
+   * `unknown` bucket while calling for opposite responses — wait, versus go
+   * and fix the observation path.
+   *
+   * The rows have always carried `reason`; only the summary discarded it. Same
+   * defect as #1469, where the shadow report named a defaulted-classification
+   * count and gave no way to find WHICH recipes to go and label.
+   */
+  byReason: Record<GradedOutcome["reason"], number>;
 }
+
+/** Every reason, so a summary always reports the full space rather than only what it saw. */
+export const SHADOW_REASONS: ReadonlyArray<GradedOutcome["reason"]> = [
+  "completed",
+  "deleted",
+  "stale-unactioned",
+  "open-recent",
+  "not-observed",
+];
+
+/**
+ * Reasons that mean "the observation channel could not answer", as opposed to
+ * "it answered, and the errand is not finished yet". Exported so the formatter
+ * and its tests cannot drift on which is which.
+ */
+export const UNOBSERVED_REASONS: ReadonlyArray<GradedOutcome["reason"]> = [
+  "not-observed",
+];
 
 /**
  * Summarise the shadow ledger — the number this phase exists to produce.
@@ -153,12 +186,18 @@ export interface ShadowSummary {
  * count someone is about to make a decision on.
  */
 export function summariseShadowLog(opts: { dir?: string } = {}): ShadowSummary {
+  const emptyByReason = () =>
+    Object.fromEntries(SHADOW_REASONS.map((r) => [r, 0])) as Record<
+      GradedOutcome["reason"],
+      number
+    >;
   const empty: ShadowSummary = {
     total: 0,
     confirmed: 0,
     junk: 0,
     unknown: 0,
     wouldCount: 0,
+    byReason: emptyByReason(),
   };
   const p = shadowLogPath(opts.dir);
   if (!existsSync(p)) return empty;
@@ -168,11 +207,21 @@ export function summariseShadowLog(opts: { dir?: string } = {}): ShadowSummary {
   } catch {
     return empty;
   }
-  const out = { ...empty };
+  // Fresh `byReason` rather than sharing `empty`'s. NOT a live bug — `empty` is
+  // built per call, so the spread aliasing its object harms nothing today. It is
+  // here so that hoisting `empty` to module scope, an obvious tidy-up, cannot
+  // silently make every summary cumulative. Deliberately NOT covered by a test:
+  // no test can distinguish the two while `empty` stays local, and a test that
+  // passes either way would be worse than none.
+  const out: ShadowSummary = { ...empty, byReason: emptyByReason() };
   for (const row of parseShadowRows(text)) {
     out.total++;
     out[row.disposition]++;
     if (row.wouldCountAsEvidence) out.wouldCount++;
+    // A row whose reason is outside the known space is counted in `total` but
+    // not attributed. Silently coercing it into a known bucket would put a
+    // number a person acts on behind a guess.
+    if (row.reason in out.byReason) out.byReason[row.reason]++;
   }
   return out;
 }


### PR DESCRIPTION
`butler shadow` reported one `unknown` count covering two situations that call for **opposite** responses:

| reason | means | response |
|---|---|---|
| `open-recent` | the channel looked; the errand is not finished yet | wait |
| `not-observed` | the channel could not look at all | go and fix the path |

Both are withheld by the fold, so both landed in `unknown`. An operator reading `8 (88.9%) — withheld by the fold` could not tell a healthy young ledger from one that is seeing nothing — and the summary's own closing advice, *"check a sample against the real errands they describe"*, was unfollowable with the verbs that shipped.

The rows have **always** carried `reason`; only the summary discarded it. Same defect as #1469, where the shadow report named a defaulted-classification count and gave no way to find *which* recipes to go and label.

## What changes

`byReason` on `ShadowSummary`, a split unknown line, and a worst-first breakdown. When any row was never observed, the summary says so in its own paragraph and names it a broken or unauthorised observation **path**, not a verdict about the errand — reading "could not observe" as "inconclusive" draws a conclusion about the *worker* when the fault is in the plumbing. That paragraph is absent at zero, because a warning that always prints is ignored by the time it matters.

`byReason` always carries every reason at 0 rather than only those seen, so no consumer has to defend against a missing key and forget. A row whose reason falls outside the known space is counted in `total` and reported as unattributed rather than coerced into a bucket someone will act on.

## Run against the real ledger

9 rows, 8 `unknown` — and all 8 are `open-recent`, 0 `not-observed`. **The observation channel is working and the errands are simply young.** That was not answerable from any shipped verb before this, and it bears on the standing assumption that Butler is blocked on its observation channel: on this evidence it is not, it is short of elapsed time.

## A test that could not fail, removed

A "counts do not leak between calls" test was written here and taken out. Mutation showed it passed **with and without** the defensive copy it claimed to cover, because the zero value is built per call and nothing is shared. It read as coverage of an aliasing hazard and proved nothing about it. The copy is kept — it guards a plausible future hoist to module scope — and the reason now lives at the call site, with a note that it is deliberately untested because no test can distinguish the two while the value stays local.

The two tests that *do* carry the change were mutation-verified: collapsing `UNOBSERVED_REASONS` turns the split assertion red.

Typecheck clean; 185 tests across `src/butler` pass.