### PR TITLE
fix(identity): make the attribution secret reachable from where init writes it

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,14 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-24 `fix/attribution-secret-reachability` — #1509: ADR-0020 attribution was shipped
+  and unreachable on nearly every launch path — `src/index.ts` builds its dotenv candidates
+  from `import.meta.url`, so it read `<install-dir>/.env` (destroyed by
+  `npm run install:global`) and never `$PATCHWORK_HOME/.env`. Measured: all three live
+  bridges lacked the variable while the secret sat correctly on disk. Adds a single-key
+  Node-side reader injected into `dashboardSession` — not a second dotenv load, because
+  agent subprocesses inherit `process.env` wholesale. — main session
+
 - 2026-08-24 `feat/butler-shadow-reason-breakdown` — #1508: `butler shadow` reported one
   `unknown` count covering two opposite situations — `open-recent` (looked; errand still in
   flight, so wait) and `not-observed` (could not look, so go fix the path). The rows always

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -34,7 +34,12 @@ import {
 } from "./featureFlags.js";
 import { FileLock } from "./fileLock.js";
 import { createApproverResolver } from "./identity/approverFromSession.js";
+import {
+  __setSessionSecretFallback,
+  hasSessionSecret,
+} from "./identity/dashboardSession.js";
 import { describeRoster, loadRoster } from "./identity/roster.js";
+import { readSessionSecretFromHome } from "./identity/sessionSecretFile.js";
 import { buildEnforcementReminder } from "./instructionsUtils.js";
 import { LockFileManager } from "./lockfile.js";
 import { Logger } from "./logger.js";
@@ -1260,31 +1265,40 @@ export class Bridge {
     // ADR-0020 Phase A: attribute approve/reject to the member whose dashboard
     // session cookie the request carries.
     //
-    // Only wired when `DASHBOARD_SESSION_SECRET` is in the BRIDGE's own
-    // environment. Whether it is there depends on how the bridge was launched,
-    // and the original note here was wrong about it:
+    // The secret is resolved from the environment FIRST and from
+    // `$PATCHWORK_HOME/.env` second — the file `patchwork init` writes.
     //
-    //   - `patchwork init` writes the secret to `~/.patchwork/.env` FIRST
-    //     (commands/patchworkInit.ts) and then also to `dashboard/.env.local`.
-    //     It does NOT write it "into the dashboard's env alone".
-    //   - The bridge's own dotenv loader reads `<install-dir>/.env`, never
-    //     `~/.patchwork/.env`, so `init` alone does not put it here.
-    //   - BUT `scripts/start-all.sh` (--no-tmux) does `set -a; source
-    //     ~/.patchwork/.env` and then launches the bridge from that shell, so
-    //     on that path the bridge DOES inherit it and attribution is wired.
-    //     The tmux path sources it after the bridge pane is already running,
-    //     so there it does not.
+    // That fallback exists because attribution was shipped and unreachable on
+    // nearly every launch path. The dotenv loader in `src/index.ts` builds its
+    // candidates from `import.meta.url`, so it reads `<install-dir>/.env` (which
+    // `npm run install:global` destroys) and never `$PATCHWORK_HOME/.env`.
+    // `scripts/start-all.sh --no-tmux` is the sole path that worked, and only
+    // because it sources the file into the shell before launching; launchd, the
+    // tmux path and a bare `patchwork start` did not. Measured 2026-08-24: all
+    // three live bridges lacked the variable while the secret sat correctly on
+    // disk, so every approval was unattributed despite correct setup.
     //
-    // Either way this is safe and additive: with no `members.json` the
-    // resolver refuses an implicit roster and stamps nobody, so a decision is
-    // recorded unattributed exactly as before. What is NOT true is that
-    // attribution is off on every unchanged install — say what the code does,
-    // not what would be tidier.
+    // Injected rather than written into `process.env`: `claudeDriver.ts` spawns
+    // agents with `{ ...process.env }`, so exporting it would hand the secret to
+    // every agent subprocess. `readSessionSecretFromHome` reads ONE key for the
+    // same reason — a second dotenv load would also ship `DASHBOARD_PASSWORD`.
+    //
+    // The condition asks `hasSessionSecret()` rather than re-reading the
+    // environment, so this site and `dashboardSession.ts` cannot disagree about
+    // whether a secret is reachable. Two independent reads of `process.env` is
+    // exactly how one site gains a fallback and its neighbour silently does not.
+    //
+    // Still safe and additive: with no `members.json` the resolver refuses an
+    // implicit roster and stamps nobody, so a decision is recorded unattributed
+    // exactly as before.
     //
     // The roster is captured by reference to the one already loaded above
     // rather than re-read per approval, matching the load-once contract the
     // roster and credential store both document.
-    if ((process.env.DASHBOARD_SESSION_SECRET ?? "") !== "") {
+    if ((process.env.DASHBOARD_SESSION_SECRET ?? "") === "") {
+      __setSessionSecretFallback(readSessionSecretFromHome());
+    }
+    if (hasSessionSecret()) {
       const roster = this.server.roster;
       this.server.resolveApprover = createApproverResolver({
         rosterFor: () => roster,

--- a/src/identity/__tests__/sessionSecretReachability.test.ts
+++ b/src/identity/__tests__/sessionSecretReachability.test.ts
@@ -1,0 +1,146 @@
+/**
+ * ADR-0020 attribution is shipped and, on most launch paths, UNREACHABLE.
+ *
+ * Measured on the live machine 2026-08-24: all three running bridges lacked
+ * `DASHBOARD_SESSION_SECRET` in their environment, while the secret sat on disk
+ * in `~/.patchwork/.env` exactly where `patchwork init` wrote it. So every
+ * approval those bridges recorded was unattributed despite correct setup, and
+ * "attribution is off" was indistinguishable from "nobody authenticated".
+ *
+ * The cause is the dotenv loader in `src/index.ts`: its candidates are built
+ * from `import.meta.url`, so it reads `<install-dir>/.env` — which
+ * `npm run install:global` destroys on every reinstall — and never
+ * `$PATCHWORK_HOME/.env`. `start-all.sh --no-tmux` works only because that
+ * script sources the file into the shell first; launchd, the tmux path and a
+ * bare `patchwork start` do not.
+ *
+ * ── Why the fix is a Node-side reader plus an injected fallback ─────────────
+ *
+ * `dashboardSession.ts` is imported by the DASHBOARD's Edge middleware
+ * (`dashboard/src/lib/session.ts:43`), where `node:` imports are unavailable
+ * and a build failure locks every user out of the dashboard. So the file read
+ * cannot live there. It lives in a Node-only module and is injected.
+ *
+ * And it is injected rather than written into `process.env`, because
+ * `claudeDriver.ts:295` spawns agents with `{ ...process.env }` — putting the
+ * secret there would hand it to every agent subprocess to solve a problem that
+ * needs one value in one process.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __setSessionSecretFallback,
+  signSession,
+  verifySession,
+} from "../dashboardSession.js";
+import { readSessionSecretFromHome } from "../sessionSecretFile.js";
+
+let home = "";
+const SECRET = "0123456789abcdef0123456789abcdef";
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(os.tmpdir(), "pw-secret-"));
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  __setSessionSecretFallback(undefined);
+});
+
+function writeEnv(body: string): void {
+  writeFileSync(path.join(home, ".env"), body, "utf-8");
+}
+
+describe("readSessionSecretFromHome", () => {
+  it("finds the key patchwork init writes", () => {
+    writeEnv(
+      `DASHBOARD_PASSWORD=hunter2\nDASHBOARD_SESSION_SECRET=${SECRET}\n`,
+    );
+    expect(readSessionSecretFromHome(home)).toBe(SECRET);
+  });
+
+  it("returns undefined when the file has no such key", () => {
+    writeEnv("DASHBOARD_PASSWORD=hunter2\n");
+    expect(readSessionSecretFromHome(home)).toBeUndefined();
+  });
+
+  it("returns undefined when there is no file at all", () => {
+    expect(readSessionSecretFromHome(home)).toBeUndefined();
+  });
+
+  it("ignores a commented-out key rather than reading it as a value", () => {
+    writeEnv(`#DASHBOARD_SESSION_SECRET=${SECRET}\n`);
+    expect(readSessionSecretFromHome(home)).toBeUndefined();
+  });
+
+  it("strips surrounding quotes, as the loader in index.ts does", () => {
+    writeEnv(`DASHBOARD_SESSION_SECRET="${SECRET}"\n`);
+    expect(readSessionSecretFromHome(home)).toBe(SECRET);
+  });
+
+  it("reads ONLY the session secret, never the neighbouring passwords", () => {
+    // The whole reason this is a single-key reader rather than a second dotenv
+    // load: agent subprocesses inherit the bridge's env wholesale, so a broad
+    // load would hand them DASHBOARD_PASSWORD to deliver one unrelated value.
+    writeEnv(
+      `DASHBOARD_PASSWORD=hunter2\nPASSWORD=hunter3\nDASHBOARD_SESSION_SECRET=${SECRET}\n`,
+    );
+    readSessionSecretFromHome(home);
+    expect(process.env.DASHBOARD_PASSWORD).toBeUndefined();
+    expect(process.env.PASSWORD).toBeUndefined();
+  });
+
+  it("does not put the secret into process.env either", () => {
+    writeEnv(`DASHBOARD_SESSION_SECRET=${SECRET}\n`);
+    expect(readSessionSecretFromHome(home)).toBe(SECRET);
+    // Injected, not exported — `claudeDriver.ts` spawns with `{ ...process.env }`.
+    expect(process.env.DASHBOARD_SESSION_SECRET).toBeUndefined();
+  });
+});
+
+describe("the injected fallback makes a session verifiable", () => {
+  it("verifies a signed session when only the fallback is set", async () => {
+    // This is the whole bug: with the env var absent, the secret was
+    // unreachable and every session was unverifiable, so no approval could
+    // ever name a member.
+    expect(process.env.DASHBOARD_SESSION_SECRET).toBeUndefined();
+    __setSessionSecretFallback(SECRET);
+
+    const cookie = await signSession({ memberId: "m-1" });
+    const res = await verifySession(cookie);
+
+    expect(res.valid).toBe(true);
+    expect(res.memberId).toBe("m-1");
+  });
+
+  it("still refuses everything when no secret is reachable at all", async () => {
+    __setSessionSecretFallback(SECRET);
+    const cookie = await signSession({ memberId: "m-1" });
+
+    __setSessionSecretFallback(undefined);
+    // No secret means no verification means no actor — and an absent actor
+    // already means "nobody recorded this". Failing closed here is correct.
+    expect((await verifySession(cookie)).valid).toBe(false);
+  });
+
+  it("lets the environment variable win over the fallback", async () => {
+    // Precedence matters: an operator who exports the variable is making a
+    // deliberate choice, and a file on disk must not silently override it.
+    __setSessionSecretFallback("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    process.env.DASHBOARD_SESSION_SECRET = SECRET;
+    try {
+      const cookie = await signSession({ memberId: "m-2" });
+      __setSessionSecretFallback("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+      const res = await verifySession(cookie);
+      expect(res.valid).toBe(true);
+      expect(res.memberId).toBe("m-2");
+    } finally {
+      process.env.DASHBOARD_SESSION_SECRET = undefined;
+      delete process.env.DASHBOARD_SESSION_SECRET;
+    }
+  });
+});

--- a/src/identity/dashboardSession.ts
+++ b/src/identity/dashboardSession.ts
@@ -33,8 +33,46 @@
 export const SESSION_COOKIE_NAME = "patchwork_session";
 export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+/**
+ * Secret supplied by the Node-side host when the environment does not carry
+ * one. Set by the bridge from `$PATCHWORK_HOME/.env` — see
+ * `sessionSecretFile.ts` for why that read cannot happen in this module.
+ *
+ * A plain variable, deliberately: no `node:` import may appear here, because
+ * the dashboard's Edge middleware imports this file and a build failure there
+ * locks every user out of the dashboard.
+ *
+ * The Edge consumer never calls the setter, so its behaviour is unchanged —
+ * `undefined` fallback, environment only.
+ */
+let sessionSecretFallback: string | undefined;
+
+/**
+ * Injection point for the Node host. Underscore-prefixed because it is not part
+ * of the session API — nothing but the bridge's startup and tests should call it.
+ */
+export function __setSessionSecretFallback(secret: string | undefined): void {
+  sessionSecretFallback = secret;
+}
+
+/**
+ * Whether a secret is reachable at all, by either route.
+ *
+ * Exported so the bridge's wiring condition and this module cannot disagree
+ * about what "attribution is available" means. They were two separate reads of
+ * `process.env` before, which is precisely how one site gains a fallback and
+ * its neighbour silently does not.
+ */
+export function hasSessionSecret(): boolean {
+  return getSecret() !== "";
+}
+
 function getSecret(): string {
-  return process.env.DASHBOARD_SESSION_SECRET ?? "";
+  // Environment wins. An operator who exports the variable is making a
+  // deliberate choice, and a file on disk must not silently override it.
+  const fromEnv = process.env.DASHBOARD_SESSION_SECRET;
+  if (fromEnv !== undefined && fromEnv !== "") return fromEnv;
+  return sessionSecretFallback ?? "";
 }
 
 function base64url(bytes: ArrayBuffer | Uint8Array): string {

--- a/src/identity/sessionSecretFile.ts
+++ b/src/identity/sessionSecretFile.ts
@@ -1,0 +1,85 @@
+/**
+ * Read `DASHBOARD_SESSION_SECRET` out of `$PATCHWORK_HOME/.env` — the file
+ * `patchwork init` writes and the bridge never read.
+ *
+ * ## Why this module exists at all
+ *
+ * ADR-0020 attribution shipped and was unreachable on most launch paths. The
+ * dotenv loader in `src/index.ts` builds its candidates from `import.meta.url`,
+ * so it reads `<install-dir>/.env` — a path `npm run install:global` destroys
+ * on every reinstall — and never `$PATCHWORK_HOME/.env`. Measured on the live
+ * machine 2026-08-24: all three running bridges lacked the variable while the
+ * secret sat correctly on disk, so every approval they recorded was
+ * unattributed despite the operator having done exactly the right setup.
+ *
+ * `scripts/start-all.sh --no-tmux` is the one path that works, and only because
+ * it sources the file into the shell before launching. launchd, the tmux path
+ * and a bare `patchwork start` all leave attribution off.
+ *
+ * ## Why it reads ONE key rather than loading the file
+ *
+ * `claudeDriver.ts:295` spawns agent subprocesses with `{ ...process.env }`.
+ * Loading this file into the environment would hand `DASHBOARD_PASSWORD` and
+ * whatever else it holds to every agent the bridge runs, in order to deliver
+ * one unrelated value. So this returns the secret to its caller and writes
+ * nothing to `process.env`.
+ *
+ * ## Why it is not in `dashboardSession.ts`
+ *
+ * That module is imported by the dashboard's Edge middleware
+ * (`dashboard/src/lib/session.ts:43`), where `node:` imports are unavailable.
+ * A `node:fs` import there breaks the dashboard build in middleware, which is
+ * the one place a failure locks every user out. The read is Node-only, so it
+ * lives here and is injected.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { patchworkHome } from "../patchworkHome.js";
+
+const KEY = "DASHBOARD_SESSION_SECRET";
+
+/**
+ * Returns the secret, or `undefined` when the file, the key or the value is
+ * absent.
+ *
+ * Fail-soft by construction: an unreadable or malformed file yields
+ * `undefined`, which leaves attribution exactly where it was — off, with
+ * decisions recorded unattributed. That is the pre-existing behaviour and the
+ * correct one, since an absent actor already means "nobody recorded this" and
+ * must never be filled in with a guess.
+ */
+export function readSessionSecretFromHome(dir?: string): string | undefined {
+  const file = path.join(dir ?? patchworkHome(), ".env");
+  if (!existsSync(file)) return undefined;
+
+  let text: string;
+  try {
+    text = readFileSync(file, "utf-8");
+  } catch {
+    return undefined;
+  }
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    // A commented-out key is not a key. Reading one would silently arm
+    // attribution with a value the operator had deliberately disabled.
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    if (trimmed.slice(0, eq).trim() !== KEY) continue;
+
+    // Quote handling mirrors the loader in `src/index.ts` so the same file
+    // means the same thing to both readers. Deliberately does NOT strip inline
+    // comments: a `#` inside a generated hex secret is not a comment, and
+    // truncating a secret silently produces a value that verifies nothing.
+    const value = trimmed
+      .slice(eq + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    return value === "" ? undefined : value;
+  }
+  return undefined;
+}


### PR DESCRIPTION
ADR-0020 Phase A attribution is built and wired — and on nearly every launch path it could not work.

The dotenv loader in `src/index.ts` builds its candidates from `import.meta.url`, so it reads `<install-dir>/.env` — a path `npm run install:global` destroys on every reinstall — and never `$PATCHWORK_HOME/.env`, which is the file `patchwork init` actually writes.

## Measured before fixing

All three live bridges lacked `DASHBOARD_SESSION_SECRET` in their environment (`ps eww <pid>`), while the secret sat correctly on disk where init had put it. Every approval those bridges recorded was unattributed **despite the operator having done exactly the right setup** — and "attribution is off" is indistinguishable from "nobody authenticated", so nothing ever surfaced it. `scripts/start-all.sh --no-tmux` is the single path that worked, and only because it sources the file into the shell before launching; launchd, the tmux path and a bare `patchwork start` did not.

## Two constraints rule out the obvious fix

**Not a second dotenv candidate.** `claudeDriver.ts:295` spawns agents with `{ ...process.env }`, so loading that file would hand `DASHBOARD_PASSWORD` and everything beside it to every agent subprocess, to deliver one unrelated value. `readSessionSecretFromHome` reads **one key**, returns it, and writes nothing to `process.env`.

**Not in `dashboardSession.ts`.** That module is imported by the dashboard's Edge middleware (`dashboard/src/lib/session.ts:43`), where `node:` imports are unavailable — its own comment notes a failure there locks every user out of the dashboard. So the read is Node-only and injected through a plain variable.

`hasSessionSecret()` exists so `bridge.ts` and `dashboardSession.ts` cannot disagree about whether a secret is reachable. They were two independent reads of `process.env`, which is precisely how one site gains a fallback and its neighbour silently does not.

## Behaviour

Precedence unchanged — the environment variable still wins, so an operator who exports it is never overridden by a file. Absent both, behaviour is byte-identical to before: no resolver, decisions unattributed, which remains correct because an absent actor already means *"nobody recorded this"*.

## Verification

- **On a real bridge, not just unit tests.** Started with the variable unset, it now logs `approval attribution ON`. That line could not print before — the condition was false, so the resolver was never installed.
- Mutating the fallback away turns two tests red.
- Dashboard `next build` passes with `ƒ Middleware 34.4 kB` compiled — the check that actually covers the Edge constraint, which a typecheck alone would not.
- 108 identity tests pass; bridge typecheck clean.

## Not addressed here

The roster is still absent on this machine, so attribution reports "ON, but members.json is absent". That is a separate setup step, and the log already distinguishes it from the failure this PR fixes.