### PR TITLE
fix(workers): a plugin tool could never enter the agent-step sandbox

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,14 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-25 `fix/plugin-tools-outside-sandbox-universe` — the agent-step sandbox built its
+  universe from two static module constants, so no plugin-registered tool could ever be
+  enumerated, classified or denied. Measured under one worker and one empty store:
+  `decideWorkerAction` returned `gate` for both a plugin tool and `slackPostMessage`, and only
+  the latter reached `--disallowed-tools`. Threads the live registry in through a thunk (not a
+  snapshot — `--plugin-watch` would otherwise reopen it) and narrows the other-domain
+  exemption, which alone is inert because an unknown name infers `tier=medium, domain=other`.
+
 - 2026-08-24 `fix/attribution-secret-reachability` — #1509: ADR-0020 attribution was shipped
   and unreachable on nearly every launch path — `src/index.ts` builds its dotenv candidates
   from `import.meta.url`, so it read `<install-dir>/.env` (destroyed by

--- a/src/__tests__/bridgePassesPluginToolsToSandbox.test.ts
+++ b/src/__tests__/bridgePassesPluginToolsToSandbox.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The agent-step sandbox builds its universe from `TIER_MAP ∪ DOMAIN_BY_TOOL`,
+ * both static module constants. A plugin registers its MCP tools at runtime, so
+ * no plugin tool could ever be enumerated, classified, or added to
+ * `--disallowed-tools` — leaving it callable by a worker's agent subprocess at
+ * any trust level, while the recipe path gated the very same tool.
+ *
+ * `disallowedToolsForAgentStep` now accepts the live names, and
+ * `buildWorkerAgentDisallowedTools` forwards them. Both of those are covered by
+ * behavioural tests. Neither can see whether `Bridge` actually SUPPLIES the
+ * list — and a fix nobody supplies an argument to is the whole failure mode
+ * being closed here: the previous code was correct, enforced, and pointed at a
+ * set that structurally could not contain the tool.
+ *
+ * WHY THIS TEST READS SOURCE. The deps object is constructed inline inside
+ * `Bridge`, behind a recipes-directory probe and a live `RecipeOrchestrator`;
+ * there is no seam to inject a fake through without standing up a bridge. A
+ * hand-injected dependency would prove the logic and not the path, and the path
+ * is the defect. Crude, but it is the thing that would regress. Replace with a
+ * behavioural test if a seam is ever added.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const BRIDGE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "bridge.ts",
+);
+
+describe("Bridge supplies plugin tool names to the agent-step sandbox", () => {
+  const src = readFileSync(BRIDGE, "utf8");
+
+  it("constructs RecipeOrchestration exactly once", () => {
+    // Pins the assertions below to a single known call site. A second one would
+    // make "the key is present somewhere" stop meaning "present on the path".
+    const sites = src.match(/new RecipeOrchestration\(/g) ?? [];
+    expect(sites).toHaveLength(1);
+  });
+
+  it("passes pluginToolNames in that constructor call", () => {
+    const start = src.indexOf("new RecipeOrchestration({");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, src.indexOf("});", start));
+    expect(block).toContain("pluginToolNames:");
+  });
+
+  it("reads the registry through a thunk, not a captured snapshot", () => {
+    // `--plugin-watch` hot-reloads the registry. A value captured once goes
+    // stale, and stale here means a newly-registered tool silently drops back
+    // out of the sandbox universe — the same hole, reopened by a later edit.
+    const start = src.indexOf("pluginToolNames:");
+    expect(start).toBeGreaterThan(-1);
+    const decl = src.slice(start, start + 240);
+    expect(decl).toMatch(/pluginToolNames:\s*\(\)\s*=>/);
+    // and it must consult the watcher's current view, like the tool registry does
+    expect(decl).toContain("pluginWatcher?.getTools()");
+  });
+});

--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -456,6 +456,35 @@ describe("buildWorkerAgentDisallowedTools (agent-step bypass)", () => {
     expect(list).not.toContain("editText");
     expect(list).not.toContain("getGitStatus");
   });
+
+  /**
+   * A plugin's tools are registered at runtime, so they are absent from both
+   * static maps the sandbox universe is built from and were never denied —
+   * callable by the agent subprocess at any trust level, while the recipe path
+   * gated the same tool. This asserts the third argument actually reaches
+   * `disallowedToolsForAgentStep`; the classification half is covered in
+   * `workers/__tests__/workerGate.test.ts`.
+   */
+  it("denies a plugin tool once its name is passed through", async () => {
+    const without = await buildWorkerAgentDisallowedTools("test-recipe", opts);
+    expect(without).not.toContain("im_send");
+
+    const withPlugin = await buildWorkerAgentDisallowedTools(
+      "test-recipe",
+      opts,
+      ["im_send"],
+    );
+    expect(withPlugin).toContain("im_send");
+    expect(withPlugin).toContain("mcp__patchwork__im_send");
+  });
+
+  it("an empty plugin list leaves the deny list byte-identical", async () => {
+    // The no-`--plugin` case is every default install; it must not shift.
+    const base = await buildWorkerAgentDisallowedTools("test-recipe", opts);
+    expect(
+      await buildWorkerAgentDisallowedTools("test-recipe", opts, []),
+    ).toEqual(base);
+  });
 });
 
 describe("buildWorkerAutonomyGate — manifest forbid rules reach ENFORCEMENT", () => {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1407,6 +1407,12 @@ export class Bridge {
           activityLog: this.activityLog,
           workerGateDecisionLog: this.workerGateDecisionLog,
           workdir: this.config.workspace,
+          // Same live-list idiom the tool registry uses above: prefer the
+          // watcher's current view so a hot-reloaded plugin is covered too.
+          pluginToolNames: () =>
+            (this.pluginWatcher?.getTools() ?? this.pluginTools).map(
+              (t) => t.schema.name,
+            ),
           logger: this.logger,
         });
         this.recipeOrchestration.wireServerFns();

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -422,6 +422,7 @@ export async function buildWorkerAutonomyGate(
 export async function buildWorkerAgentDisallowedTools(
   recipeName: string,
   trustOpts?: import("./workers/runWorkerShadow.js").RunWorkerShadowOpts,
+  pluginTools?: readonly string[],
 ): Promise<string[] | null> {
   try {
     const { isEnabled, FLAG_WORKER_AUTONOMY } = await import(
@@ -438,7 +439,11 @@ export async function buildWorkerAgentDisallowedTools(
     const { disallowedToolsForAgentStep } = await import(
       "./workers/workerGate.js"
     );
-    const list = disallowedToolsForAgentStep(trust.worker, trust.store);
+    const list = disallowedToolsForAgentStep(
+      trust.worker,
+      trust.store,
+      pluginTools && pluginTools.length > 0 ? { pluginTools } : undefined,
+    );
     return list.length ? list : null;
   } catch {
     return null;
@@ -501,6 +506,19 @@ export interface RecipeOrchestrationDeps {
     | import("./workerGateDecisionLog.js").WorkerGateDecisionLog
     | null;
   workdir: string;
+  /**
+   * The tool names a plugin registered at runtime, read fresh on every call.
+   *
+   * A THUNK, not a snapshot: `--plugin-watch` hot-reloads the registry, so a
+   * list captured at construction goes stale the first time a plugin is edited
+   * — and going stale here means a newly-registered tool silently leaves the
+   * agent-step sandbox's universe again, which is the exact hole this closes.
+   *
+   * Optional: absent (or empty) leaves the sandbox byte-identical to the
+   * pre-plugin behaviour, which is correct for every bridge started without
+   * `--plugin`.
+   */
+  pluginToolNames?: () => string[];
   logger: { info?: (s: string) => void; warn?: (s: string) => void };
 }
 
@@ -1625,6 +1643,8 @@ export class RecipeOrchestration {
     // the per-step gate). Null for non-worker recipes → agent steps unchanged.
     const agentDisallowedTools = await buildWorkerAgentDisallowedTools(
       opts.name,
+      undefined,
+      this.deps.pluginToolNames?.(),
     );
     // Independent of FLAG_WORKER_AUTONOMY — see resolveWorkerIdForRecipe's
     // doc comment. Feeds executeStep's per-worker allowedTools policy check.

--- a/src/workers/__tests__/workerGate.test.ts
+++ b/src/workers/__tests__/workerGate.test.ts
@@ -525,3 +525,70 @@ describe("disallowedToolsForAgentStep — forbidden tools must be sandboxed", ()
     expect(blocked).not.toContain("getGitStatus");
   });
 });
+
+describe("disallowedToolsForAgentStep — plugin tools must reach the universe", () => {
+  /**
+   * The sandbox's universe is `TIER_MAP ∪ DOMAIN_BY_TOOL` — two static module
+   * constants. A plugin registers its MCP tools at runtime, so no plugin tool
+   * can ever appear in either, and the loop that builds `--disallowed-tools`
+   * never sees it. The agent subprocess could therefore call it at any trust
+   * level: exactly the bypass this function's own doc comment says it closes.
+   *
+   * Measured before the fix, under one worker and one empty store:
+   * `decideWorkerAction` returned "gate" for BOTH `im_send` (the shipped
+   * example plugin's only tool) and `slackPostMessage`, and only
+   * `slackPostMessage` reached the deny list.
+   *
+   * Two things had to change and the first ALONE IS INERT — which is the whole
+   * reason this block asserts on the deny list and not on the universe. An
+   * unknown tool infers `tier=medium, domain=other`, so the over-block guard
+   * skips it even once it is enumerated. That guard justifies itself by naming
+   * built-in reads (getDiagnostics, searchWorkspace, goToDefinition); a plugin
+   * tool is not one of those but an unclassified third-party side effect, so it
+   * does not inherit their benefit of the doubt.
+   */
+  const w = () => parseWorker({ id: "w", name: "W", owns: ["fs-write"] });
+
+  it("agrees with decideWorkerAction, which gates that same tool (control)", () => {
+    // Pins that the next test is not passing for a trivial reason: the gate
+    // really does refuse this tool, so the sandbox omitting it was a
+    // divergence between the two and not a deliberate carve-out.
+    const d = decideWorkerAction(
+      w(),
+      "im_send",
+      undefined,
+      new WorkerLevelStore(),
+    );
+    expect(d.action).toBe("gate");
+  });
+
+  it("blocks a plugin tool the gate would have queued for approval", () => {
+    const blocked = disallowedToolsForAgentStep(w(), new WorkerLevelStore(), {
+      pluginTools: ["im_send"],
+    });
+    expect(blocked).toContain("im_send");
+    expect(blocked).toContain("mcp__patchwork__im_send");
+  });
+
+  it("does not strip the harmless built-in reads the guard protects", () => {
+    // The over-block guard is NARROWED, not removed: only names the caller
+    // declared as plugin tools lose the exemption.
+    const blocked = disallowedToolsForAgentStep(w(), new WorkerLevelStore(), {
+      pluginTools: ["im_send"],
+    });
+    expect(blocked).not.toContain("getDiagnostics");
+    expect(blocked).not.toContain("searchWorkspace");
+  });
+
+  it("changes nothing for tools that were already enumerated", () => {
+    // Additivity. Fails if the fix over-blocks — the only difference between
+    // the two lists must be the plugin names themselves.
+    const base = disallowedToolsForAgentStep(w(), new WorkerLevelStore());
+    const withPlugin = disallowedToolsForAgentStep(
+      w(),
+      new WorkerLevelStore(),
+      { pluginTools: ["im_send"] },
+    );
+    expect(withPlugin.filter((t) => !t.endsWith("im_send"))).toEqual(base);
+  });
+});

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -429,14 +429,27 @@ export function decideWorkerAction(
 export function disallowedToolsForAgentStep(
   worker: WorkerManifest,
   store: WorkerLevelStore,
+  opts?: { pluginTools?: readonly string[] },
 ): string[] {
   // Universe = the canonical risk-tier map (broad MCP coverage) ∪ the worker
-  // subsystem's own tool→domain map (adds messaging/http TIER_MAP omits).
-  // Neither alone is complete; the union is the best enumerable approximation of
-  // the risky tool surface.
+  // subsystem's own tool→domain map (adds messaging/http TIER_MAP omits) ∪ the
+  // tool names a PLUGIN registered at runtime.
+  //
+  // The first two are static module constants, so before `pluginTools` existed
+  // the universe structurally could not contain a plugin tool: it was never
+  // enumerated, never classified, and never added to `--disallowed-tools`. A
+  // worker's agent step could call it at any trust level while the recipe path
+  // gated the very same tool — the bypass this function exists to close, open
+  // by omission rather than by decision.
+  //
+  // Passed in rather than imported because the registry is per-process and
+  // mutable (`--plugin-watch` hot-reloads it); this module stays pure and the
+  // caller, which holds the live list, supplies it.
+  const pluginTools = new Set(opts?.pluginTools ?? []);
   const universe = new Set([
     ...Object.keys(getRiskTierMap()),
     ...knownActionTools(),
+    ...pluginTools,
   ]);
   const blocked = new Set<string>();
   const forbidRules = parseForbidRules(worker.forbids).rules;
@@ -476,7 +489,19 @@ export function disallowedToolsForAgentStep(
     // issue) are always blocked. The recipe's explicit tool STEPS still gate on
     // their own class — this list is defense-in-depth, not the only gate.
     const ac = classifyActionClass(toolName);
-    if (ac.domain === "other" && classifyTool(toolName) !== "high") continue;
+    // A plugin tool is exempt from the exemption. Enumerating it above is on
+    // its own INERT: an unregistered name infers `tier=medium, domain=other`,
+    // so this guard would skip it and the deny list would be unchanged — a fix
+    // that lints clean and never fires. The carve-out is justified by the reads
+    // it names, all of which are built-ins the agent needs to do its job; a
+    // plugin tool is not one of them but an unclassified third-party side
+    // effect, so it does not inherit their benefit of the doubt.
+    if (
+      ac.domain === "other" &&
+      classifyTool(toolName) !== "high" &&
+      !pluginTools.has(toolName)
+    )
+      continue;
     // Emit BOTH naming forms the subprocess might use: the bare name (native CC
     // tools like `Bash`, and any non-namespaced match) AND the bridge MCP form
     // `mcp__patchwork__<tool>` (how claude -p sees bridge tools under


### PR DESCRIPTION
## The defect

`disallowedToolsForAgentStep` builds its universe from `TIER_MAP ∪ DOMAIN_BY_TOOL` — two static module constants. A plugin registers its MCP tools at runtime, so **no plugin tool could ever be enumerated, classified, or added to `--disallowed-tools`.** The agent subprocess could call it at any trust level.

That is the exact bypass the function's own doc comment says it exists to close: *"without this a worker could do via its agent exactly the risky action the gate would otherwise have queued."*

Measured before the fix — one worker, one empty store, `decideWorkerAction` returning the same verdict for both:

| tool | class | verdict | in deny list |
|---|---|---|---|
| `im_send` | `other:irreversible:medium` | `gate` | **no** |
| `slackPostMessage` | `messaging` | `gate` | yes |

Ungoverned **by omission rather than by decision** — the sandbox was correct, enforced, and pointed at a set that structurally could not contain the tool.

## The fix, and why one half alone is inert

Two changes, and **adding the names to the universe does nothing on its own**. An unregistered name infers `tier=medium, domain=other`, so the over-block guard skips it and the deny list is unchanged — a fix that lints clean and never fires.

That guard justifies itself by naming built-in reads (`getDiagnostics`, `searchWorkspace`, `goToDefinition`) the agent needs to do its job. A plugin tool is not one of those; it is an unclassified third-party side effect, so it does not inherit their benefit of the doubt.

Both halves were mutation-tested: **removing either one fails the reproduction test.**

The registry is passed as a **thunk, not a snapshot**. `--plugin-watch` hot-reloads it, and a captured value would go stale — stale here meaning a newly-registered tool silently drops back out of the universe, the same hole reopened by a later edit. Mirrors the live-list idiom the tool registry already uses.

## Blast radius

**Additive.** A bridge started without `--plugin` supplies no names and the deny list is byte-identical — asserted by a test, not assumed.

**Latent rather than live** on the machine this was found on: the autonomy gate is on, but neither bridge loads a plugin. The shipped example plugin's README walks a user through opening it.

## Tests

- Reproduction + control in `workers/__tests__/workerGate.test.ts` — the control asserts the gate really does refuse that tool, so the sandbox omitting it was a divergence and not a carve-out.
- Pass-through and byte-identical-when-empty in `recipeOrchestration.workerGate.test.ts`.
- `bridgePassesPluginToolsToSandbox.test.ts` reads source to assert `Bridge` actually **supplies** the list. The deps object is constructed inline behind a live `RecipeOrchestrator` with no seam to inject through, and a hand-injected dependency would prove the logic and not the path — the path being the defect. Follows the precedent set by `automationTriggerSourceCarriesRecipe.test.ts`.

Full suite: 10,323 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)