### PR TITLE
fix(dashboard): warn when the bypass opens production with no password set

### DIFF
--- a/dashboard/src/middleware.authBypass.test.ts
+++ b/dashboard/src/middleware.authBypass.test.ts
@@ -1,0 +1,128 @@
+/** @vitest-environment node */
+/**
+ * `DASHBOARD_ALLOW_UNAUTHENTICATED=1` bypasses the dashboard auth gate. In
+ * production that is a serious state, and the middleware already has a loud
+ * `DANGEROUS:` warning for it — but the warning lives in the SECOND branch:
+ *
+ *   if (!expected || !secret) {                       // no password configured
+ *     if (production && !ALLOW) return 503;
+ *     return next();                                  // <- open, and SILENT
+ *   }
+ *   if (ALLOW) {
+ *     if (production && expected) { console.error("DANGEROUS…"); return 503; }
+ *     ...
+ *   }
+ *
+ * So whether an operator is warned depends on whether a password HAPPENS to be
+ * configured — and the strictly less secure configuration, no password at all,
+ * is the silent one. The severity signal is inverted exactly where it matters.
+ *
+ * These tests assert the warning on the bypass path and, in the other
+ * direction, that development stays quiet — a warning that fires on every local
+ * `npm run dev` is one people learn to scroll past, which is how a real one gets
+ * missed.
+ *
+ * `ALLOW_UNAUTHENTICATED` is captured at module scope, so each case must set the
+ * environment and then re-import.
+ */
+
+import type { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIG = {
+  allow: process.env.DASHBOARD_ALLOW_UNAUTHENTICATED,
+  pw: process.env.DASHBOARD_PASSWORD,
+  secret: process.env.DASHBOARD_SESSION_SECRET,
+  nodeEnv: process.env.NODE_ENV,
+};
+
+function setNodeEnv(v: string): void {
+  // NODE_ENV is readonly in the Next type augmentation; the runtime value is
+  // what the middleware reads. `vi.stubEnv` handles the descriptor vitest's
+  // env proxy insists on (configurable AND enumerable).
+  vi.stubEnv("NODE_ENV", v as "production" | "development" | "test");
+}
+
+async function runMiddleware(env: {
+  production: boolean;
+  password?: string;
+  secret?: string;
+  allow: boolean;
+}) {
+  setNodeEnv(env.production ? "production" : "development");
+  if (env.password === undefined) delete process.env.DASHBOARD_PASSWORD;
+  else process.env.DASHBOARD_PASSWORD = env.password;
+  if (env.secret === undefined) delete process.env.DASHBOARD_SESSION_SECRET;
+  else process.env.DASHBOARD_SESSION_SECRET = env.secret;
+  if (env.allow) process.env.DASHBOARD_ALLOW_UNAUTHENTICATED = "1";
+  else delete process.env.DASHBOARD_ALLOW_UNAUTHENTICATED;
+
+  vi.resetModules();
+  const { middleware } = await import("./middleware");
+  const { NextRequest } = await import("next/server");
+  const req = new NextRequest("http://localhost/runs") as NextRequest;
+  return middleware(req);
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  for (const [k, v] of [
+    ["DASHBOARD_ALLOW_UNAUTHENTICATED", ORIG.allow],
+    ["DASHBOARD_PASSWORD", ORIG.pw],
+    ["DASHBOARD_SESSION_SECRET", ORIG.secret],
+  ] as const) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+/** Did anything logged mention the bypass loudly? */
+function warned(): boolean {
+  return (errSpy.mock.calls.flat() as unknown[]).some(
+    (a) => typeof a === "string" && a.includes("DASHBOARD_ALLOW_UNAUTHENTICATED"),
+  );
+}
+
+describe("production auth bypass must announce itself", () => {
+  it("warns when the bypass opens production with NO password configured", async () => {
+    // The silent branch. Auth is off, in production, and nothing says so.
+    const res = await runMiddleware({ production: true, allow: true });
+    expect(res.status).toBe(200); // still open — behaviour deliberately unchanged
+    expect(warned()).toBe(true);
+  });
+
+  it("warns when the bypass is set in production WITH a password (control)", async () => {
+    // Pre-existing behaviour: this branch already warned, and refuses.
+    const res = await runMiddleware({
+      production: true,
+      password: "pw",
+      secret: "s".repeat(32),
+      allow: true,
+    });
+    expect(res.status).toBe(503);
+    expect(warned()).toBe(true);
+  });
+});
+
+describe("the warning stays quiet where the bypass is legitimate", () => {
+  it("does NOT warn in development with no password", async () => {
+    const res = await runMiddleware({ production: false, allow: true });
+    expect(res.status).toBe(200);
+    expect(warned()).toBe(false);
+  });
+
+  it("does NOT warn when the bypass is not set at all", async () => {
+    // Production with no password and no bypass still refuses, and the refusal
+    // message is the signal — no extra warning needed.
+    const res = await runMiddleware({ production: true, allow: false });
+    expect(res.status).toBe(503);
+    expect(warned()).toBe(false);
+  });
+});

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -136,6 +136,23 @@ export async function middleware(req: NextRequest) {
         { status: 503 },
       );
     }
+    // Reaching here in production means the bypass flag turned the 503 above
+    // OFF: the dashboard is serving unauthenticated in production. The twin
+    // warning below fires only when a password IS configured, so without this
+    // the LESS secure configuration — no password at all — was the silent one.
+    // Severity signalling inverted exactly where it mattered.
+    //
+    // Warn, do not refuse. Setting the flag is an explicit operator choice and
+    // refusing here would break a deployment that is working as its owner
+    // intended; the message is the whole change.
+    if (process.env.NODE_ENV === "production") {
+      console.error(
+        "[dashboard] DANGEROUS: DASHBOARD_ALLOW_UNAUTHENTICATED=1 is set in production " +
+          "with no DASHBOARD_PASSWORD/DASHBOARD_SESSION_SECRET configured. The dashboard " +
+          "is serving every request unauthenticated. Unset DASHBOARD_ALLOW_UNAUTHENTICATED " +
+          "and configure both to enable authentication.",
+      );
+    }
     return NextResponse.next();
   }
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -84,6 +84,14 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   test asserting the scoping in BOTH directions; a happy-path-only test would pass equally
   well if the scope were widened to every request, which is a credential leak rather than an
   attribution loss. Both mutations verified to fail.
+- 2026-08-25 `fix/warn-when-production-auth-bypassed` — the middleware's loud `DANGEROUS:`
+  warning for `DASHBOARD_ALLOW_UNAUTHENTICATED=1` lived in the branch reached only when a
+  password IS configured. The other branch (no password at all, so strictly less secure)
+  returned `next()` in production silently, because the bypass flag turns its 503 off. Whether
+  an operator was warned depended on whether a password happened to be set, and the worse
+  configuration was the quiet one. Warns, does not refuse — the flag is an explicit choice and
+  refusing would break a deployment working as intended. Both directions mutation-tested,
+  including that development stays quiet.
 
 - 2026-08-24 `fix/attribution-secret-reachability` — #1509: ADR-0020 attribution was shipped
   and unreachable on nearly every launch path — `src/index.ts` builds its dotenv candidates


### PR DESCRIPTION
## The inversion

`DASHBOARD_ALLOW_UNAUTHENTICATED=1` turns the dashboard auth gate off. The middleware already has a loud `DANGEROUS:` warning for that in production — but it lives in the **second** branch, reached only when a password *is* configured:

```js
if (!expected || !secret) {                  // no password configured
  if (production && !ALLOW) return 503;
  return next();                             // <- open, and SILENT
}
if (ALLOW) {
  if (production && expected) { console.error("DANGEROUS…"); return 503; }
  ...
}
```

So whether an operator is warned depended on whether a password **happened** to be configured — and the strictly less secure configuration, no password at all, was the silent one.

Note the bypass flag is also what turns the 503 in that first branch off. Setting it in production therefore both opens the dashboard **and** suppresses the only message that would have mentioned it.

## Warns, does not refuse

Setting the flag is an explicit operator choice, and refusing here would break a deployment working as its owner intended. **The message is the whole change** — allow/deny behaviour is untouched, pinned by a test asserting the response is still 200.

## Asserted in both directions

Development stays quiet. A warning that fires on every local `npm run dev` is one people learn to scroll past, which is how a real one gets missed.

| mutation | outcome |
|---|---|
| drop the production guard (warn everywhere) | dev-quiet test fails |
| original code | target test fails, 3 controls pass |
| fixed | 4 pass |

The branch was **untested entirely** before this — the existing `middleware.test.ts` only compiles the matcher regex and never invokes `middleware()`.

Dashboard suite: 127 files / 1303 green, typecheck clean.

Found while verifying a hazard noted alongside identity Phase 0; not live on the machine it was found on (that install has both a password and a session secret configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)