### PR TITLE
docs(transport): elicit() has had a caller since #1223

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,13 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-25 `docs/transport-elicit-has-a-caller` — `transport.ts`'s note asserted `elicit()`
+  had NO in-repo caller and must not be cleaned up. #1218 wrote that; #1223 added the caller
+  (`recipes/elicitMissingVars.ts`) eight days later and closed #1217 with it, and the note was
+  never updated. A roadmap survey on 2026-08-23 then read the stale note, concluded the path
+  was dead and #1217 was work pointed at nothing, and ranked it on that basis — while #1217
+  had been CLOSED three weeks earlier. Corrects the note and gates its factual half.
+
 - 2026-08-25 `fix/plugin-tools-outside-sandbox-universe` — the agent-step sandbox built its
   universe from two static module constants, so no plugin-registered tool could ever be
   enumerated, classified or denied. Measured under one worker and one empty store:

--- a/src/__tests__/elicitHasAProductionCaller.test.ts
+++ b/src/__tests__/elicitHasAProductionCaller.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `McpTransport.elicit()` carries a doc comment that makes a claim about its own
+ * call sites. That claim has been wrong before, and expensively.
+ *
+ * #1218 wrote "NO IN-REPO CALLER — deliberate, do not clean up", audited with a
+ * `git grep`. #1223 added the first caller eight days later and did not update
+ * the note. A roadmap survey on 2026-08-23 then read the stale note, concluded
+ * the path was dead and that #1217 was scheduled work pointed at nothing, and
+ * ranked the item on that basis — while #1217 had in fact been CLOSED by #1223
+ * three weeks earlier.
+ *
+ * A comment that instructs the reader ("do not clean this up, it is unused") is
+ * load-bearing, so its factual half gets a gate. This fails in BOTH directions:
+ * if the caller is removed, or if the comment reverts to claiming there is none.
+ *
+ * It reads source because the claim IS about source. There is no runtime
+ * behaviour that distinguishes "has a caller" from "documented as having one".
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (rel: string) => readFileSync(path.join(SRC, rel), "utf8");
+
+describe("elicit() and the comment that describes its callers", () => {
+  it("still has its production caller, on a live branch", () => {
+    // `elicitMissingVars` is reached from recipeOrchestration when a manual run
+    // would otherwise halt on a missing required var.
+    expect(read("recipes/elicitMissingVars.ts")).toContain("elicit(");
+    const orch = read("recipeOrchestration.ts");
+    expect(orch).toContain("elicitMissingVars(");
+
+    // Pin the GUARD EXPRESSION, not merely the identifier. An earlier draft of
+    // this test asserted only that the string `server.elicitFn` appeared
+    // somewhere in the file — which stayed true when the branch condition was
+    // replaced with `false`, leaving the call present and permanently dead. A
+    // test that survives its own subject being disabled is worse than none.
+    expect(orch).toMatch(
+      /if\s*\(\s*missingDeclarations\.length\s*>\s*0\s*&&\s*server\.elicitFn\s*\)/,
+    );
+  });
+
+  it("the transport comment does not claim the path is unused", () => {
+    // The exact wording that went stale. If it ever comes back, so has the bug.
+    const t = read("transport.ts");
+    expect(t).not.toContain("NO IN-REPO CALLER");
+    expect(t).toContain("HAS A CALLER");
+  });
+
+  it("the bridge still wires elicitFn to the transport", () => {
+    // The middle link. Without it the caller above is unreachable at runtime
+    // and the comment would be true again by accident.
+    expect(read("bridge.ts")).toContain("transport.elicit(");
+  });
+});

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -416,14 +416,27 @@ export class McpTransport {
    * @param requestedSchema JSON Schema describing the shape of the expected response.
    * @param timeoutMs Maximum time to wait for a response (default: 5 minutes).
    *
-   * NO IN-REPO CALLER — deliberate, do not "clean up". Audited 2026-08-01:
-   * `git grep '\.elicit('` matches only this definition. The implementation is
-   * complete and works if called; it is unused, not rotted. Deleting it would
-   * also orphan the client half we ship — `claude-ide-bridge-plugin/hooks/
-   * hooks.json` + `scripts/elicitation.sh`, which pre-answer file/path fields
-   * from the active editor — plus the advertisements at :1035 and
-   * `src/mcpRoutes.ts:63` and three docs. Wiring a caller (e.g. the recipe
-   * approval prompt, today a dashboard/phone round-trip) is tracked in #1217.
+   * HAS A CALLER since #1223 — `src/recipes/elicitMissingVars.ts`, reached from
+   * `recipeOrchestration.ts` when a manual run would otherwise halt with
+   * `missing_required_vars`. That closed #1217.
+   *
+   * This note previously asserted the opposite — that no in-repo caller existed
+   * and that `git grep` matched only this definition — audited 2026-08-01. The
+   * exact former wording is deliberately not repeated here: a guard test
+   * (`__tests__/elicitHasAProductionCaller.test.ts`) fails if it reappears, and
+   * quoting it would trip that gate. #1218 wrote it, #1223
+   * added the caller eight days later and did not come back for it, and the
+   * grep it cites has returned a real caller ever since. It is corrected rather
+   * than deleted because it did not merely go out of date quietly: a roadmap
+   * survey on 2026-08-23 read it, concluded this path was dead and #1217 was
+   * scheduled work pointed at nothing, and ranked the item accordingly. A stale
+   * comment that instructs the reader is worse than no comment.
+   *
+   * Still do not "clean up" — the reason simply changed from "unused but
+   * complete" to "used". Deleting it would ALSO orphan the client half we ship
+   * — `claude-ide-bridge-plugin/hooks/hooks.json` + `scripts/elicitation.sh`,
+   * which pre-answer file/path fields from the active editor — plus the
+   * advertisements at :1035 and `src/mcpRoutes.ts:63` and three docs.
    * Note this path is WS-only: it requires
    * `activeWs`, so Streamable-HTTP and stdio sessions can never use it.
    *


### PR DESCRIPTION
`transport.ts` carried a note asserting `elicit()` had **no in-repo caller**, audited 2026-08-01 with a `git grep`, instructing maintainers not to "clean it up" because it was unused-but-complete.

## What actually happened

| | |
|---|---|
| #1218 | wrote the "no caller, do not delete" note |
| #1223 | added the first caller — `src/recipes/elicitMissingVars.ts`, reached from `recipeOrchestration.ts` when a manual run would otherwise halt on `missing_required_vars` — and **closed #1217** with it |
| — | the note was never updated; the grep it cites has returned a real caller ever since |

## Why correct it rather than quietly delete it

It did not go out of date harmlessly. A roadmap survey on 2026-08-23 read the note, concluded the path was dead and that **#1217 was scheduled work pointed at nothing**, and ranked the item on that basis — while #1217 had been closed three weeks earlier. A stale comment that *instructs* the reader is worse than no comment.

The instruction still stands. Only its reason changed: from "unused but complete" to "used".

## The guard

Adds a test for the factual half, failing in **both** directions — if the caller is removed, or if the note reverts to claiming there is none. It reads source because the claim *is* about source; no runtime behaviour distinguishes "has a caller" from "documented as having one".

**The first draft of that guard was too weak, which is worth recording.** It asserted only that the string `server.elicitFn` appeared somewhere in `recipeOrchestration.ts` — and that stayed true when the branch condition was replaced with `false`, leaving the call present and permanently dead. A test that survives its own subject being disabled is worse than none. It now pins the guard expression.

| mutation | outcome |
|---|---|
| branch condition → `false` (call present, dead) | fails |
| call renamed away | fails |
| unmodified | 3 pass |

Suite: 767 files / 10,326 green, typecheck clean. Comment + test only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)