### PR TITLE
fix(gate): stop telling the operator a policy absence is a historical one

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -60,6 +60,14 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   never updated. A roadmap survey on 2026-08-23 then read the stale note, concluded the path
   was dead and #1217 was work pointed at nothing, and ranked it on that basis — while #1217
   had been CLOSED three weeks earlier. Corrects the note and gates its factual half.
+- 2026-08-25 `fix/gate-explain-false-era-claim` — `gate explain` told the operator every
+  actor-less row "pre-dates actor attribution". An actor is stamped only on `allow`
+  (`recipeOrchestration.ts` says why at length: on `gate` the approving human is not known at
+  decision time, on `forbid` nobody acted), so those absences are CURRENT POLICY, not history.
+  Measured on the live ledger: 272 rows, 47 `gate`, all 47 given the false era claim. The
+  two-absences collapse the Decision Record's own doctrine exists to prevent, already shipped,
+  in the surface an operator actually reads. Composes the explanation with `action`; no stored
+  data changes.
 
 - 2026-08-25 `fix/plugin-tools-outside-sandbox-universe` — the agent-step sandbox built its
   universe from two static module constants, so no plugin-registered tool could ever be

--- a/src/__tests__/gateDecisionFormat.test.ts
+++ b/src/__tests__/gateDecisionFormat.test.ts
@@ -236,9 +236,28 @@ describe("formatGateDecision — actor", () => {
 
   it("says so explicitly when nobody was recorded", () => {
     // Omitting the line entirely would read as "attribution not applicable".
-    // The honest signal is that nobody recorded it — which must stay
+    // The honest signal is that nobody is named — which must stay
     // distinguishable from a synthesized "unknown" (ADR-0017: no backfill).
-    expect(formatGateDecision(rec())).toContain("not recorded");
+    //
+    // This assertion used to read `toContain("not recorded")`, and `rec()`
+    // defaults to `action: "gate"`. That pinned a real defect: an actor is
+    // stamped only on `allow`, so a gate row names nobody BY CURRENT POLICY,
+    // and the old unconditional string told the operator it "pre-dates actor
+    // attribution" instead. The intent of this test was always right; only the
+    // words it happened to check were wrong.
+    const out = formatGateDecision(rec());
+    expect(out).toContain("Attributed to:");
+    expect(out).toContain("nobody");
+    expect(out).not.toMatch(/\bunknown\b/i);
+    expect(out).not.toContain("pre-dates");
+  });
+
+  it("an actor-less ALLOW is the one row that really was not recorded", () => {
+    // `allow` does stamp an actor today, so its absence genuinely means nobody
+    // recorded it — the only action for which the era reading is defensible.
+    expect(formatGateDecision(rec({ action: "allow" }))).toContain(
+      "not recorded",
+    );
   });
 });
 

--- a/src/__tests__/gateExplainAttributionReason.test.ts
+++ b/src/__tests__/gateExplainAttributionReason.test.ts
@@ -1,0 +1,91 @@
+/**
+ * `gate explain` told the operator the wrong thing about WHY a decision names
+ * nobody, and it told it about rows written today.
+ *
+ * `formatGateDecision` printed one unconditional line for every actor-less row:
+ *
+ *   Attributed to: not recorded (pre-dates actor attribution)
+ *
+ * But `recipeOrchestration.ts` stamps an actor ONLY on `allow`, and says so at
+ * length: on `gate` "the approving human is not known here", on `forbid`
+ * "nobody acted". Those absences are CURRENT POLICY, not history. Measured
+ * against the live ledger on 2026-08-25: 272 rows, 47 of them `gate`, and every
+ * one of those 47 received the era claim.
+ *
+ * This is the two-absences collapse the Decision Record's own doctrine exists to
+ * prevent — "nobody recorded this" made indistinguishable from "we do not know"
+ * — already shipped, in the one surface an operator actually reads. It is worse
+ * than an omission: an omitted line invites a question, whereas this line
+ * answers it, confidently and wrongly.
+ *
+ * The fix composes the explanation with `action`. No row's DATA changes; only
+ * what the reader is told about it.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { GateDecisionRecord } from "../workerGateDecisionLog.js";
+import { formatGateDecision } from "../workerGateDecisionLog.js";
+
+const base: GateDecisionRecord = {
+  seq: 1,
+  decidedAt: 1_756_000_000_000,
+  recipeName: "example-recipe",
+  workerId: "w1",
+  toolName: "githubCreateIssue",
+  action: "allow",
+  classKey: "issue:compensable:low",
+  domain: "issue",
+  owned: true,
+  blastTier: "low",
+  reversibility: "compensable",
+  earnedLevel: 4,
+  autonomyCeiling: 4,
+  effectiveLevel: 4,
+  reason: "earned",
+  gatePolicyVersion: "worker-ramp-v1",
+};
+
+const attribution = (r: GateDecisionRecord): string =>
+  formatGateDecision(r)
+    .split("\n")
+    .find((l) => l.includes("Attributed to:")) ?? "";
+
+describe("gate explain does not blame history for a policy absence", () => {
+  it("does not claim a GATE row pre-dates attribution", () => {
+    // The bug. 47 of 272 live rows hit this branch.
+    const line = attribution({ ...base, action: "gate" });
+    expect(line).not.toContain("pre-dates");
+    expect(line).toMatch(/approv/i);
+  });
+
+  it("does not claim a FORBID row pre-dates attribution", () => {
+    const line = attribution({ ...base, action: "forbid" });
+    expect(line).not.toContain("pre-dates");
+    expect(line).toMatch(/nobody acted|policy/i);
+  });
+
+  it("still says an actor-less ALLOW was not recorded", () => {
+    // The one case where the era claim is defensible: `allow` DOES stamp an
+    // actor today, so its absence really does mean nobody recorded it.
+    expect(attribution({ ...base, action: "allow" })).toContain("not recorded");
+  });
+
+  it("still names a real actor when one is present (control)", () => {
+    const line = attribution({
+      ...base,
+      actor: { id: "w1", kind: "worker", displayName: "Worker One" },
+    });
+    expect(line).toContain("Worker One");
+    expect(line).not.toContain("not recorded");
+  });
+
+  it("never synthesises an actor for any action", () => {
+    // The absence must stay an absence. ADR-0017 keeps "nobody recorded this"
+    // distinguishable from a synthesized "unknown"; explaining the absence must
+    // not become inventing a value for it.
+    for (const action of ["allow", "gate", "forbid"] as const) {
+      const line = attribution({ ...base, action });
+      expect(line).not.toMatch(/\bunknown\b/i);
+    }
+  });
+});

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -510,6 +510,38 @@ export function describeGateAction(action: string): string {
   }
 }
 
+/**
+ * Why does this row name nobody?
+ *
+ * The line was previously the single unconditional string "not recorded
+ * (pre-dates actor attribution)". That is true only for `allow`. An actor is
+ * stamped ONLY on `allow` (`recipeOrchestration.ts`), and deliberately so:
+ * on `gate` the approving human is not known at decision time, and on `forbid`
+ * nobody acted at all. Those absences are CURRENT POLICY, not history.
+ *
+ * Measured on the live ledger 2026-08-25: of 272 rows, 47 were `gate`, and every
+ * one of them was told it pre-dated a feature that was working correctly. That
+ * is the collapse this module's own doctrine exists to prevent — "nobody
+ * recorded this" made indistinguishable from "we do not know" — and it is worse
+ * than an omission, because an omitted line invites the question while this one
+ * answered it wrongly.
+ *
+ * Explaining an absence is not the same as filling it. Nothing here synthesises
+ * an actor, and no row's stored data changes; only what the reader is told.
+ */
+function attributionAbsenceReason(
+  action: GateDecisionRecord["action"],
+): string {
+  switch (action) {
+    case "gate":
+      return "nobody — a gated decision records no actor by design, because the approving human is not known when the decision is made";
+    case "forbid":
+      return "nobody — workspace policy refused, so no party acted";
+    default:
+      return "not recorded — an autonomous allow normally names the worker, so this row is from before that was stamped";
+  }
+}
+
 export function formatGateDecision(rec: GateDecisionRecord): string {
   const when = new Date(rec.decidedAt).toISOString();
   const verb = describeGateAction(rec.action);
@@ -535,9 +567,11 @@ export function formatGateDecision(rec: GateDecisionRecord): string {
       : rec.actor.id;
     lines.push(`  Attributed to: ${who} — ${rec.actor.kind}`);
   } else {
-    // Say it out loud. A record that simply omits the line reads as though
-    // attribution was not applicable, when in fact nobody recorded it.
-    lines.push("  Attributed to: not recorded (pre-dates actor attribution)");
+    // Say it out loud — a record that simply omits the line reads as though
+    // attribution was not applicable. But WHY it is absent depends on the
+    // action, and one unconditional string collapsed two different absences
+    // into one. See `attributionAbsenceReason`.
+    lines.push(`  Attributed to: ${attributionAbsenceReason(rec.action)}`);
   }
   lines.push(
     `  Effective level used for this decision: L${rec.effectiveLevel}`,


### PR DESCRIPTION
`gate explain` printed one unconditional line for **every** actor-less Decision Record:

```
Attributed to: not recorded (pre-dates actor attribution)
```

## Why that is false

An actor is stamped only on `allow`. `recipeOrchestration.ts` says so at length and gives its reasons:

> - `gate` — the approving human is not known here, and cannot be until the approval path carries an identity
> - `forbid` — nobody acted. Workspace policy refused, and naming the worker would read as though it did something

Those absences are **current policy**. Nothing about them pre-dates anything.

## Measured, live ledger, 2026-08-25

| | |
|---|---|
| rows | 272 |
| by action | 225 `allow` / 47 `gate` / 0 `forbid` |
| no actor | 229 |
| **given a false era claim** | **47** — every `gate` row |

Those 47 were told they pre-dated a feature that was working exactly as designed.

## Why it matters more than the wording

This is the **two-absences collapse this module's own doctrine exists to prevent** — *"nobody recorded this"* must stay distinguishable from *"we do not know"* — already shipped, in the one surface an operator actually reads.

It is worse than an omission. An omitted line invites the question; this one answered it, confidently and wrongly, about rows written today.

## The fix

Composes the explanation with `action`. **Explaining an absence is not filling it**: nothing synthesises an actor, no stored row changes, and a guard asserts the word "unknown" never appears for any action.

| mutation | outcome |
|---|---|
| revert to the unconditional string | 2 fail |
| make the gate branch return `"unknown approver"` | 1 fails (never-synthesise guard) |
| fixed | 5 pass |

## One existing test was changed, not added

`gateDecisionFormat.test.ts`'s *"says so explicitly when nobody was recorded"* asserted `toContain("not recorded")` while its `rec()` helper defaults to `action: "gate"` — so **it pinned the defect**. Its intent was always right (state the absence, never synthesise "unknown"); only the words it happened to check were wrong. It now asserts that intent directly, and a sibling case covers the actor-less `allow` — the one action for which the era reading is defensible.

Suite: 10,329 green, typecheck clean.

Found while settling the correlation-id sentinel, whose entire purpose is preventing this collapse in a ledger that had already suffered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)