### PR TITLE
fix(dashboard): a forbidden action was shown as one needing more approval

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -10198,6 +10198,12 @@ details[open] .traces-detail-arrow { transform: rotate(90deg); }
 .td-gate-verb { color: #e0b054; font-weight: 600; letter-spacing: 0.02em; }
 [data-theme="paper"] .td-gate-verb { color: var(--warn-text); }
 .td-gate-verb-allow { color: var(--ok-text); }
+/* ADR-0017 `forbid` — a terminal state, not a stronger gate. It must not
+   read as the amber GATE it previously rendered as: same colour would say
+   "needs approval" while the word says no approval unlocks it. Uses the
+   shared error token so it tracks the theme, including [data-theme="paper"],
+   rather than pinning a literal that would only be checked in one mode. */
+.td-gate-verb-forbid { color: var(--err-text); }
 .td-gate-arrow { opacity: 0.6; }
 .td-gate-explain {
   font-size: var(--fs-xs);

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/workerTrust";
 import { describeNextRun, humanizeSchedule } from "@/lib/humanSchedule";
 import { classifyPendingAction, reversibilityRank } from "@/lib/actionClass";
+import { type GateAction, gateActionLabel } from "@/lib/gateAction";
 import { BlastBadge } from "@/components/patchwork";
 import { usePaneShortcut } from "@/hooks/usePaneShortcuts";
 import { isNoiseEvent } from "@/lib/activityNoise";
@@ -174,7 +175,11 @@ interface GateDecisionRecord {
   workerId: string;
   toolName: string;
   classKey: string;
-  action: "allow" | "gate";
+  // Widened to include ADR-0017's terminal `forbid`. This interface is a
+  // hand-copied slim mirror of `src/workerGateDecisionLog.ts` — the dashboard
+  // is a separate package and cannot import from `src/` — so it does not track
+  // the source type automatically and drifted silently once already.
+  action: GateAction;
   owned: boolean;
   earnedLevel: number;
   autonomyCeiling: number;
@@ -221,15 +226,13 @@ function GateRow({
     minute: "2-digit",
     hour12: false,
   });
-  const isAllow = d.action === "allow";
+  const label = gateActionLabel(d.action);
   return (
     <div className={`td-gate-row-wrap${indent ? " td-gate-row-indent" : ""}`}>
       <button type="button" className="td-gate-row" aria-expanded={isOpen} onClick={onToggle}>
         <span className="td-gate-row-top">
           <span className="mono td-muted td-gate-time">{hhmm}</span>
-          <span className={`td-gate-verb${isAllow ? " td-gate-verb-allow" : ""}`}>
-            {isAllow ? "ALLOW" : "GATE"}
-          </span>
+          <span className={`td-gate-verb${label.className}`}>{label.verb}</span>
           <span className="td-gate-arrow" aria-hidden="true">→</span>
           <span className="td-gate-result">{gateLevelPhrase(d.effectiveLevel)}</span>
         </span>
@@ -242,7 +245,7 @@ function GateRow({
           <div>
             effective L{d.effectiveLevel} ({gateLevelPhrase(d.effectiveLevel)})
             {" vs required "}
-            {d.action === "allow" ? "— none (allowed)" : "higher"}
+            {label.requiredPhrase}
           </div>
           <div>
             earned L{d.earnedLevel} · autonomy ceiling L{d.autonomyCeiling}

--- a/dashboard/src/lib/__tests__/gateAction.test.ts
+++ b/dashboard/src/lib/__tests__/gateAction.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { gateActionLabel } from "../gateAction";
+
+/**
+ * The bug this guards: `page.tsx` typed `action` as `"allow" | "gate"` and
+ * rendered `isAllow ? "ALLOW" : "GATE"`, so a `forbid` row was presented to the
+ * operator as a gate — with the explain line reading "vs required higher", i.e.
+ * go and get more approval.
+ *
+ * ADR-0017: `forbid` is not a stronger gate. No approval unlocks it. Showing it
+ * as one inverts the terminal state's whole purpose.
+ */
+describe("gateActionLabel", () => {
+  it("does not present forbid as a gate", () => {
+    const f = gateActionLabel("forbid");
+    expect(f.verb).not.toBe("GATE");
+    expect(f.verb).toBe("FORBID");
+  });
+
+  it("never tells the operator that more approval would unlock a forbid", () => {
+    // The specific inversion. "higher" was the old text.
+    const f = gateActionLabel("forbid");
+    expect(f.requiredPhrase).not.toContain("higher");
+    expect(f.requiredPhrase).toMatch(/no approval/i);
+  });
+
+  it("distinguishes the three in WORDS, not only in colour", () => {
+    // ControlBoundary holds this property for the boundary screen; it must not
+    // be lost here. Greyscale and colour-blind readers get the same distinction.
+    const verbs = (["allow", "gate", "forbid"] as const).map(
+      (a) => gateActionLabel(a).verb,
+    );
+    expect(new Set(verbs).size).toBe(3);
+    const phrases = (["allow", "gate", "forbid"] as const).map(
+      (a) => gateActionLabel(a).requiredPhrase,
+    );
+    expect(new Set(phrases).size).toBe(3);
+  });
+
+  it("says a gate needs a named person", () => {
+    expect(gateActionLabel("gate").requiredPhrase).toMatch(/named person/i);
+  });
+
+  it("keeps allow visually distinct and marked as needing nothing", () => {
+    const a = gateActionLabel("allow");
+    expect(a.verb).toBe("ALLOW");
+    expect(a.className).toContain("allow");
+    expect(a.requiredPhrase).toContain("none");
+  });
+
+  it("treats an unrecognised action as not permitted, never as allowed", () => {
+    // A future fourth terminal state must not default to looking permitted.
+    const u = gateActionLabel("something_new");
+    expect(u.requiredPhrase).not.toContain("allowed");
+    expect(u.requiredPhrase).toMatch(/not permitted/i);
+    expect(u.className).not.toContain("allow");
+  });
+});
+
+/**
+ * The module above is only worth having if the page actually uses it. `GateRow`
+ * is not exported (page.tsx is one large client component), so there is no seam
+ * to render it through without standing up the whole page — and a
+ * hand-constructed render would prove the module, not the path.
+ *
+ * The path is the defect: the old code derived the verb inline from a boolean,
+ * which is exactly what let a third action fall silently into the else-branch.
+ */
+describe("the page actually uses it", () => {
+  const src = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "../../app/page.tsx"),
+    "utf8",
+  );
+
+  it("renders the verb through gateActionLabel", () => {
+    expect(src).toContain("gateActionLabel(");
+  });
+
+  it("no longer derives the verb from a two-way boolean", () => {
+    // `const isAllow = d.action === "allow"` then `isAllow ? "ALLOW" : "GATE"`.
+    // Any third action lands in the else-branch and is mislabelled.
+    expect(src).not.toMatch(/isAllow\s*\?\s*"ALLOW"\s*:\s*"GATE"/);
+    expect(src).not.toContain('const isAllow =');
+  });
+
+  it("does not pin the action type to two values", () => {
+    // The narrow type is what made the mislabelling invisible to tsc.
+    expect(src).not.toMatch(/action:\s*"allow"\s*\|\s*"gate"\s*;/);
+  });
+});

--- a/dashboard/src/lib/gateAction.ts
+++ b/dashboard/src/lib/gateAction.ts
@@ -1,0 +1,64 @@
+/**
+ * How a Decision Record's `action` is presented, in one place.
+ *
+ * The dashboard used to derive this inline as `const isAllow = d.action ===
+ * "allow"` and render `isAllow ? "ALLOW" : "GATE"`, with the explain line
+ * reading "vs required — higher". Its `action` was typed `"allow" | "gate"`,
+ * so a `forbid` row fell into the else-branch and was shown to the operator as
+ * a gate: a thing that needs MORE approval.
+ *
+ * ADR-0017 says the opposite. `forbid` is not a stronger gate — it means no
+ * earned trust and no human approval unlocks the action. Telling an operator to
+ * go and get approval for it inverts the entire point of the terminal state.
+ *
+ * The wording follows `ControlBoundary.tsx`, which already distinguishes these
+ * in WORDS and not only colour ("A named person must say yes" vs "No approval
+ * can unlock these"), so the difference survives greyscale and a colour-blind
+ * reader. That property is easy to lose when a second surface invents its own
+ * vocabulary, which is the reason this is shared rather than copied.
+ */
+
+export type GateAction = "allow" | "gate" | "forbid";
+
+export interface GateActionLabel {
+  /** Short uppercase verb shown in the row. */
+  verb: string;
+  /** Modifier appended to `td-gate-verb`; empty for the neutral case. */
+  className: string;
+  /** Completes "effective Lx vs required …". */
+  requiredPhrase: string;
+}
+
+const LABELS: Readonly<Record<GateAction, GateActionLabel>> = {
+  allow: {
+    verb: "ALLOW",
+    className: " td-gate-verb-allow",
+    requiredPhrase: "— none (allowed)",
+  },
+  gate: {
+    verb: "GATE",
+    className: "",
+    requiredPhrase: "higher — a named person must say yes",
+  },
+  forbid: {
+    verb: "FORBID",
+    className: " td-gate-verb-forbid",
+    requiredPhrase: "— no approval can unlock this",
+  },
+};
+
+/**
+ * Unknown actions fall back to the FORBID presentation deliberately. A value
+ * this UI does not recognise must not be shown as permitted, and of the three
+ * the only safe guess is the one that tells the operator to stop. The row still
+ * says what it does not know, via the verb.
+ */
+export function gateActionLabel(action: string): GateActionLabel {
+  return (
+    LABELS[action as GateAction] ?? {
+      verb: action.toUpperCase(),
+      className: " td-gate-verb-forbid",
+      requiredPhrase: "— unrecognised decision, treat as not permitted",
+    }
+  );
+}

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,15 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-25 `fix/dashboard-renders-forbid-as-gate` — the dashboard typed a gate decision's
+  `action` as `"allow" | "gate"` and rendered `isAllow ? "ALLOW" : "GATE"`, so ADR-0017's
+  terminal `forbid` displayed as a GATE with the explain line "vs required higher" — telling
+  the operator to seek more approval for the one thing no approval unlocks. Extracts the
+  labels to `lib/gateAction.ts` sharing ControlBoundary's wording (distinct in WORDS, not only
+  colour), widens the type, adds the missing `td-gate-verb-forbid` style on the shared
+  `--err-text` token. Unknown actions fall back to the forbid presentation. FIRST of the
+  sentinel preconditions — must land before `consumeRawJsonl` accepts `forbid`.
+
 - 2026-08-25 `docs/transport-elicit-has-a-caller` — `transport.ts`'s note asserted `elicit()`
   had NO in-repo caller and must not be cleaned up. #1218 wrote that; #1223 added the caller
   (`recipes/elicitMissingVars.ts`) eight days later and closed #1217 with it, and the note was


### PR DESCRIPTION
**First of the correlation-sentinel preconditions.** It must land *before* `consumeRawJsonl` is taught to accept `forbid`, or unblocking the loader turns a currently-invisible row into a visibly wrong one.

## The defect

`page.tsx` typed a gate decision's `action` as `"allow" | "gate"` and rendered:

```tsx
const isAllow = d.action === "allow";
...
{isAllow ? "ALLOW" : "GATE"}
...
{d.action === "allow" ? "— none (allowed)" : "higher"}
```

ADR-0017's third terminal state fell into the else-branch. A `forbid` decision — *no earned trust and no human approval unlocks this action* — was displayed as a **GATE** whose requirement was **"higher"**, i.e. go and get approval.

That is not a cosmetic mislabel. It inverts the entire point of the state, on the one screen an operator reads.

## Why tsc could not see it

The interface is a **hand-copied slim mirror** of `src/workerGateDecisionLog.ts` — the dashboard is a separate package and cannot import from `src/` — so it does not track the source type and had already drifted.

## The fix

Extracts presentation to `lib/gateAction.ts`, **sharing `ControlBoundary`'s vocabulary rather than inventing a second one**:

| action | verb | required |
|---|---|---|
| `allow` | ALLOW | — none (allowed) |
| `gate` | GATE | higher — a named person must say yes |
| `forbid` | FORBID | — no approval can unlock this |

That distinction is carried in **words**, not only colour, so it survives greyscale and a colour-blind reader — a property easy to lose the moment a second surface writes its own strings.

Adds the `td-gate-verb-forbid` style the new class needs, on the shared `--err-text` token so it tracks both themes rather than pinning a literal only ever checked in one.

**An unrecognised action falls back to the forbid presentation deliberately.** A value this UI does not understand must not render as permitted; of the three, the only safe guess is the one that tells the operator to stop.

## Wiring asserted separately from logic

`GateRow` is not exported, so a hand-constructed render would prove the module and not the path — and the path is the defect, since deriving a three-way label from a boolean is exactly what let the third value fall through.

| mutation | outcome |
|---|---|
| revert the page to the inline boolean | 2 fail |
| restore `"higher"` for forbid | 1 fails |
| fixed | 9 pass |

Dashboard: 1308 tests green, typecheck clean, `tokens:check` / `lint:inline-fontsize` / `lint:vocabulary` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)