### PR TITLE
fix(gate): a forbid decision was written correctly and dropped by every reader

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -62,6 +62,13 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   colour), widens the type, adds the missing `td-gate-verb-forbid` style on the shared
   `--err-text` token. Unknown actions fall back to the forbid presentation. FIRST of the
   sentinel preconditions — must land before `consumeRawJsonl` accepts `forbid`.
+- 2026-08-25 `fix/forbid-rows-dropped-on-read` — `record()` validated all three actions while
+  `consumeRawJsonl` accepted only `allow` and `gate`, so a `forbid` row was written correctly
+  and dropped by every subsequent read — surviving in the writing process's memory ring and
+  vanishing at the next restart. ADR-0017's terminal state was invisible in `gate explain`,
+  `GET /gate/decisions` and the dashboard. One shared `isGateAction`, since two independently
+  hardcoded lists is the mechanism of the bug, not a duplication smell. SECOND sentinel
+  precondition; requires the dashboard widening to land first.
 
 - 2026-08-25 `docs/transport-elicit-has-a-caller` — `transport.ts`'s note asserted `elicit()`
   had NO in-repo caller and must not be cleaned up. #1218 wrote that; #1223 added the caller

--- a/src/__tests__/forbidRowSurvivesDiskRoundTrip.test.ts
+++ b/src/__tests__/forbidRowSurvivesDiskRoundTrip.test.ts
@@ -1,0 +1,100 @@
+/**
+ * A `forbid` decision was written to disk correctly and then discarded by every
+ * reader.
+ *
+ * `record()` validates and accepts all three actions (`:219-225`). But
+ * `consumeRawJsonl` — the loader every fresh instance runs — rejected the row:
+ *
+ *   if (… || (parsed.action !== "allow" && parsed.action !== "gate")) continue;
+ *
+ * So a `forbid` survived only in the writing process's in-memory ring and
+ * vanished at the next restart. `gate explain`, `GET /gate/decisions` and the
+ * dashboard pane all read through this loader, which means ADR-0017's terminal
+ * state — the one whose entire purpose is to be visible and unappealable — was
+ * invisible in every surface an operator has.
+ *
+ * The live ledger holds 0 `forbid` rows (272 rows: 225 allow / 47 gate), so
+ * nothing observable is being recovered here. That is not reassurance: forbid
+ * rules are opt-in via `forbidPolicy`, so the first operator to write one would
+ * have got silence, and silence from a deny-list reads as "nothing was
+ * forbidden".
+ *
+ * The round trip goes through REAL DISK and a FRESH INSTANCE deliberately.
+ * Asserting on `record()`'s return value, or on the same instance's `query()`,
+ * passes with the bug fully present — the row is in memory either way.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type RecordGateDecisionInput,
+  WorkerGateDecisionLog,
+} from "../workerGateDecisionLog.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "gate-forbid-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const base: Omit<RecordGateDecisionInput, "action"> = {
+  recipeName: "example-recipe",
+  workerId: "w1",
+  toolName: "githubCreateIssue",
+  classKey: "issue:irreversible:high",
+  domain: "issue",
+  owned: true,
+  blastTier: "high",
+  reversibility: "irreversible",
+  earnedLevel: 0,
+  autonomyCeiling: 4,
+  effectiveLevel: 0,
+  reason: "forbidden by workspace policy",
+  gatePolicyVersion: "worker-ramp-v1",
+};
+
+describe("a forbid row survives a disk round trip", () => {
+  it("is still there when a fresh instance reads the file", () => {
+    const w = new WorkerGateDecisionLog({ dir });
+    w.record({ ...base, action: "forbid" });
+    w.record({ ...base, action: "allow" });
+
+    // Fresh instance = the loader path. This is the assertion that failed.
+    const rows = new WorkerGateDecisionLog({ dir }).query({ limit: 10 });
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.action).sort()).toEqual(["allow", "forbid"]);
+  });
+
+  it("the SAME instance always saw it — which is why this went unnoticed", () => {
+    // Control. Proves the test above fails for a read reason and not a write
+    // one, and pins why an in-memory assertion would have been useless.
+    const w = new WorkerGateDecisionLog({ dir });
+    w.record({ ...base, action: "forbid" });
+    expect(w.query({ limit: 10 })).toHaveLength(1);
+  });
+
+  it("still rejects a row whose action is genuinely unrecognised", () => {
+    // The loader's validation must narrow, not vanish. A row with a nonsense
+    // action is malformed and should still be skipped.
+    const w = new WorkerGateDecisionLog({ dir });
+    w.record({ ...base, action: "allow" });
+    const { appendFileSync } = require("node:fs") as typeof import("node:fs");
+    appendFileSync(
+      join(dir, "worker_gate_decisions.jsonl"),
+      `${JSON.stringify({
+        seq: 99,
+        decidedAt: 1_756_000_000_000,
+        workerId: "w1",
+        toolName: "t",
+        action: "sideways",
+      })}\n`,
+    );
+    const rows = new WorkerGateDecisionLog({ dir }).query({ limit: 10 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.action).toBe("allow");
+  });
+});

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -177,6 +177,29 @@ export interface GateDecisionQuery {
   limit?: number;
 }
 
+/**
+ * The three terminal actions a Decision Record may carry (ADR-0017).
+ *
+ * Shared because the writer and the reader each hardcoded their own list and
+ * drifted: `record()` validated all three while the loader accepted only
+ * `allow` and `gate`, so a `forbid` row was written correctly and then dropped
+ * by every subsequent read. It survived in the writing process's memory ring
+ * and vanished at the next restart — leaving the one state whose whole purpose
+ * is to be visible and unappealable invisible in `gate explain`, in
+ * `GET /gate/decisions` and on the dashboard.
+ *
+ * One literal, two call sites. The same reason `AGENT_STEP_TOOL` lives in one
+ * place: two independent copies of a list is not a duplication smell here, it
+ * is the mechanism of the bug.
+ */
+export const GATE_ACTIONS = ["allow", "gate", "forbid"] as const;
+
+export function isGateAction(v: unknown): v is GateDecisionRecord["action"] {
+  return (
+    typeof v === "string" && (GATE_ACTIONS as readonly string[]).includes(v)
+  );
+}
+
 export class WorkerGateDecisionLog {
   private records: GateDecisionRecord[] = [];
   private seq = 0;
@@ -216,11 +239,7 @@ export class WorkerGateDecisionLog {
     if (!workerId) throw new Error("workerId is required");
     if (!toolName) throw new Error("toolName is required");
     if (!classKey) throw new Error("classKey is required");
-    if (
-      input.action !== "allow" &&
-      input.action !== "gate" &&
-      input.action !== "forbid"
-    ) {
+    if (!isGateAction(input.action)) {
       throw new Error(`invalid action: ${String(input.action)}`);
     }
 
@@ -458,7 +477,9 @@ export class WorkerGateDecisionLog {
           typeof parsed.seq !== "number" ||
           typeof parsed.workerId !== "string" ||
           typeof parsed.toolName !== "string" ||
-          (parsed.action !== "allow" && parsed.action !== "gate")
+          // Narrowed, not removed: a genuinely unrecognised action is still a
+          // malformed row and is still skipped.
+          !isGateAction(parsed.action)
         ) {
           continue;
         }


### PR DESCRIPTION
**Second of the correlation-sentinel preconditions.** Ordered after #1516: unblocking this loader is the first moment a `forbid` row can reach a screen, and until the dashboard widening lands that screen renders it as a gate.

## The asymmetry

`record()` validates and accepts all three ADR-0017 actions. `consumeRawJsonl` — the loader every fresh instance runs — accepted only two:

```js
(parsed.action !== "allow" && parsed.action !== "gate")  →  skip
```

A `forbid` row reached disk intact and was discarded on the way back. It survived only in the **writing process's in-memory ring** and vanished at the next restart.

`gate explain`, `GET /gate/decisions` and the dashboard pane all read through that loader. The one state whose entire purpose is to be visible and unappealable was invisible in every surface an operator has.

## Nothing observable is recovered — and that is not reassurance

The live ledger holds **0 forbid rows** (272 total: 225 allow / 47 gate). Forbid rules are opt-in through `forbidPolicy`, so the *first* operator to write one would have got silence — and silence from a deny-list reads as **"nothing was forbidden"**, the most dangerous possible misreading of that surface.

## The fix

One shared `isGateAction`, used by both sites. The writer and reader each hardcoded their own copy of the list and drifted; two independent copies is not a duplication smell here, it is the mechanism. Same reasoning as `AGENT_STEP_TOOL` living in one place after both *its* sites drifted.

The validation is **narrowed, not removed** — a genuinely unrecognised action is still malformed and still skipped.

| mutation | outcome |
|---|---|
| restore the two-value check | fails (forbid dropped again) |
| replace the check with `false` | fails (nonsense row accepted) |
| fixed | 3 pass |

## Why the test goes through real disk

Asserting on `record()`'s return value, or querying the *same* instance, **passes with the bug fully present** — the row is in memory either way. A control test pins exactly that, so the failure is provably a read defect and not a write one.

Suite: 10,329 green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)