### PR TITLE
fix(gate): rotation destroyed half the trust ledger, and said nothing

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -69,6 +69,14 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   `GET /gate/decisions` and the dashboard. One shared `isGateAction`, since two independently
   hardcoded lists is the mechanism of the bug, not a duplication smell. SECOND sentinel
   precondition; requires the dashboard widening to land first.
+- 2026-08-25 `fix/rotation-destroys-half-the-trust-ledger` — `rotateDisk` HALVED the file
+  (`slice(-floor(length/2))` in a `while`), so crossing the 1 MB cap by one row discarded ~50%
+  of the autonomy gate's trust evidence and audit trail, oldest-first, silently. Measured: it
+  left 525,829 bytes of a 1 MB budget. Replaced with trim-to-target (90% low-water mark) and a
+  dropped-row COUNT — rotation deletes oldest-first, i.e. exactly the rows lacking any newer
+  field, so a coverage measure over this file converges to 1.0 BY DELETION and reads
+  identically to a real improvement. Byte length not UTF-16 length, since the trigger is
+  `st.size`. THIRD sentinel precondition.
 
 - 2026-08-25 `docs/transport-elicit-has-a-caller` — `transport.ts`'s note asserted `elicit()`
   had NO in-repo caller and must not be cleaned up. #1218 wrote that; #1223 added the caller

--- a/src/__tests__/gateLedgerRotation.test.ts
+++ b/src/__tests__/gateLedgerRotation.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Rotation destroyed half the ledger to reclaim one byte, and said nothing.
+ *
+ *   while (joined.length + 1 > MAX_PERSIST_BYTES && lines.length > 1) {
+ *     lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
+ *     joined = lines.join("\n");
+ *   }
+ *
+ * Crossing the cap by a single row halves the file. This ledger is the autonomy
+ * gate's trust evidence and its audit trail, so that is 50% of both, discarded
+ * oldest-first, with no record that it happened.
+ *
+ * The silence is the worse half. Rotation deletes oldest-first, which is
+ * precisely the population of rows lacking any newer field — so any coverage
+ * measure over this file converges toward 1.0 BY DELETION. A report that says
+ * "98% of decisions carry a run id" would be describing a ledger that ate the
+ * counter-examples, and would say so in exactly the same words as a genuine
+ * improvement.
+ *
+ * Two separate defects, and this file pins both: how much is dropped, and
+ * whether anyone is told.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_PERSIST_BYTES,
+  type RecordGateDecisionInput,
+  WorkerGateDecisionLog,
+} from "../workerGateDecisionLog.js";
+
+let dir: string;
+let warnings: string[];
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "gate-rot-"));
+  warnings = [];
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A row whose `reason` is padded so few records fill the cap quickly. */
+function bigRow(n: number): RecordGateDecisionInput {
+  return {
+    recipeName: "example-recipe",
+    workerId: "w1",
+    toolName: "githubCreateIssue",
+    action: "allow",
+    classKey: "issue:compensable:low",
+    domain: "issue",
+    owned: true,
+    blastTier: "low",
+    reversibility: "compensable",
+    earnedLevel: 4,
+    autonomyCeiling: 4,
+    effectiveLevel: 4,
+    reason: `r${n}`.padEnd(900, "x"),
+    gatePolicyVersion: "worker-ramp-v1",
+  };
+}
+
+/**
+ * Fill until rotation actually fires, detected by the file SHRINKING — not by
+ * guessing at a size threshold, which is how the first draft of this helper
+ * stopped before the cap was ever reached and reported a false reproduction.
+ */
+function fillPastCap(log: WorkerGateDecisionLog): number {
+  const file = join(dir, "worker_gate_decisions.jsonl");
+  let n = 0;
+  let peak = 0;
+  for (let i = 0; i < 8000; i++) {
+    log.record(bigRow(i));
+    n++;
+    let size = 0;
+    try {
+      size = statSync(file).size;
+    } catch {
+      /* not yet written */
+    }
+    if (size > peak) {
+      peak = size;
+    } else if (peak > MAX_PERSIST_BYTES * 0.9 && size < peak) {
+      return n; // the file got smaller: rotation ran
+    }
+  }
+  throw new Error(`rotation never fired after ${n} rows (peak ${peak} bytes)`);
+}
+
+function rowsOnDisk(): number {
+  return readFileSync(join(dir, "worker_gate_decisions.jsonl"), "utf-8")
+    .split("\n")
+    .filter((l) => l.trim()).length;
+}
+
+describe("rotation keeps what it can and reports what it dropped", () => {
+  it("does not discard roughly half the ledger in one step", () => {
+    const log = new WorkerGateDecisionLog({
+      dir,
+      logger: { warn: (m: string) => warnings.push(m) },
+    });
+    fillPastCap(log);
+    const after = readFileSync(
+      join(dir, "worker_gate_decisions.jsonl"),
+      "utf-8",
+    );
+    // Trim-to-target leaves the file near its low-water mark. Halving left it
+    // at ~50% of the cap (measured: 525,829 bytes), which is the tell.
+    expect(after.length).toBeGreaterThan(MAX_PERSIST_BYTES * 0.8);
+    // Never above the cap: `append` rotates BEFORE writing, so the post-rotate
+    // file is target + one row, comfortably inside.
+    expect(after.length).toBeLessThanOrEqual(MAX_PERSIST_BYTES);
+  });
+
+  it("does not rotate on every append once the file is full", () => {
+    // Hysteresis. Trimming to exactly the cap makes `append` rotate on every
+    // subsequent write — one row dropped and one warning emitted each time.
+    // Measured while building this fix: 826 rotations in a single fill. A
+    // warning that fires on every write is one nobody reads.
+    const log = new WorkerGateDecisionLog({
+      dir,
+      logger: { warn: (m: string) => warnings.push(m) },
+    });
+    fillPastCap(log);
+    const drops = warnings.filter((w) => /dropped/i.test(w));
+    expect(drops.length).toBeLessThanOrEqual(2);
+  });
+
+  it("says how many rows it dropped", () => {
+    const log = new WorkerGateDecisionLog({
+      dir,
+      logger: { warn: (m: string) => warnings.push(m) },
+    });
+    fillPastCap(log);
+    const dropMsg = warnings.find((w) => /dropped/i.test(w));
+    expect(dropMsg).toBeDefined();
+    // A bare "rotated" is not enough — the count is the point, because any
+    // coverage denominator computed over this file is wrong without it.
+    expect(dropMsg).toMatch(/\d+/);
+  });
+
+  it("keeps the NEWEST rows, never the oldest", () => {
+    const log = new WorkerGateDecisionLog({
+      dir,
+      logger: { warn: (m: string) => warnings.push(m) },
+    });
+    const n = fillPastCap(log);
+    const rows = readFileSync(join(dir, "worker_gate_decisions.jsonl"), "utf-8")
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as { seq: number });
+    expect(rows.at(-1)?.seq).toBe(n);
+    expect(rowsOnDisk()).toBeLessThan(n);
+  });
+});

--- a/src/__tests__/gateLedgerRotation.test.ts
+++ b/src/__tests__/gateLedgerRotation.test.ts
@@ -114,7 +114,11 @@ describe("the injected cap does not change the production default", () => {
     // would, immediately, if the default had become CAP.
     const log = new WorkerGateDecisionLog({
       dir,
-      logger: { warn: (m: string) => warnings.push(m) },
+      logger: {
+        warn: (m: string) => {
+          warnings.push(m);
+        },
+      },
     });
     for (let i = 0; i < 40; i++) log.record(bigRow(i));
     expect(warnings.filter((w) => /dropped/i.test(w))).toHaveLength(0);
@@ -128,7 +132,11 @@ describe("the injected cap does not change the production default", () => {
     const log = new WorkerGateDecisionLog({
       dir,
       maxPersistBytes: 0,
-      logger: { warn: (m: string) => warnings.push(m) },
+      logger: {
+        warn: (m: string) => {
+          warnings.push(m);
+        },
+      },
     });
     for (let i = 0; i < 5; i++) log.record(bigRow(i));
     expect(
@@ -142,7 +150,11 @@ describe("rotation keeps what it can and reports what it dropped", () => {
     const log = new WorkerGateDecisionLog({
       dir,
       maxPersistBytes: CAP,
-      logger: { warn: (m: string) => warnings.push(m) },
+      logger: {
+        warn: (m: string) => {
+          warnings.push(m);
+        },
+      },
     });
     fillPastCap(log);
     const after = readFileSync(
@@ -165,7 +177,11 @@ describe("rotation keeps what it can and reports what it dropped", () => {
     const log = new WorkerGateDecisionLog({
       dir,
       maxPersistBytes: CAP,
-      logger: { warn: (m: string) => warnings.push(m) },
+      logger: {
+        warn: (m: string) => {
+          warnings.push(m);
+        },
+      },
     });
     fillPastCap(log);
     const drops = warnings.filter((w) => /dropped/i.test(w));
@@ -176,7 +192,11 @@ describe("rotation keeps what it can and reports what it dropped", () => {
     const log = new WorkerGateDecisionLog({
       dir,
       maxPersistBytes: CAP,
-      logger: { warn: (m: string) => warnings.push(m) },
+      logger: {
+        warn: (m: string) => {
+          warnings.push(m);
+        },
+      },
     });
     fillPastCap(log);
     const dropMsg = warnings.find((w) => /dropped/i.test(w));
@@ -190,7 +210,11 @@ describe("rotation keeps what it can and reports what it dropped", () => {
     const log = new WorkerGateDecisionLog({
       dir,
       maxPersistBytes: CAP,
-      logger: { warn: (m: string) => warnings.push(m) },
+      logger: {
+        warn: (m: string) => {
+          warnings.push(m);
+        },
+      },
     });
     const n = fillPastCap(log);
     const rows = readFileSync(join(dir, "worker_gate_decisions.jsonl"), "utf-8")

--- a/src/__tests__/gateLedgerRotation.test.ts
+++ b/src/__tests__/gateLedgerRotation.test.ts
@@ -1,7 +1,7 @@
 /**
  * Rotation destroyed half the ledger to reclaim one byte, and said nothing.
  *
- *   while (joined.length + 1 > MAX_PERSIST_BYTES && lines.length > 1) {
+ *   while (joined.length + 1 > CAP && lines.length > 1) {
  *     lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
  *     joined = lines.join("\n");
  *   }
@@ -26,10 +26,22 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  MAX_PERSIST_BYTES,
   type RecordGateDecisionInput,
   WorkerGateDecisionLog,
 } from "../workerGateDecisionLog.js";
+
+/**
+ * A small injected cap, not the real 1 MB one. The properties under test —
+ * how much rotation drops, whether it repeats on every append, whether it
+ * reports a count — are all ratios and do not depend on the absolute size.
+ *
+ * The first version of this file filled a genuine megabyte, which meant ~840
+ * lock-guarded appends per case and ~3,400 across the file. That is merely slow
+ * on Linux and a plausible CI timeout on Windows, where this repo already has a
+ * documented heavy-tail problem. Testing a ratio by writing a megabyte is a
+ * cost with no matching evidence.
+ */
+const CAP = 16 * 1024;
 
 let dir: string;
 let warnings: string[];
@@ -56,7 +68,7 @@ function bigRow(n: number): RecordGateDecisionInput {
     earnedLevel: 4,
     autonomyCeiling: 4,
     effectiveLevel: 4,
-    reason: `r${n}`.padEnd(900, "x"),
+    reason: `r${n}`.padEnd(400, "x"),
     gatePolicyVersion: "worker-ramp-v1",
   };
 }
@@ -70,7 +82,7 @@ function fillPastCap(log: WorkerGateDecisionLog): number {
   const file = join(dir, "worker_gate_decisions.jsonl");
   let n = 0;
   let peak = 0;
-  for (let i = 0; i < 8000; i++) {
+  for (let i = 0; i < 4000; i++) {
     log.record(bigRow(i));
     n++;
     let size = 0;
@@ -81,7 +93,7 @@ function fillPastCap(log: WorkerGateDecisionLog): number {
     }
     if (size > peak) {
       peak = size;
-    } else if (peak > MAX_PERSIST_BYTES * 0.9 && size < peak) {
+    } else if (peak > CAP * 0.9 && size < peak) {
       return n; // the file got smaller: rotation ran
     }
   }
@@ -94,10 +106,42 @@ function rowsOnDisk(): number {
     .filter((l) => l.trim()).length;
 }
 
+describe("the injected cap does not change the production default", () => {
+  it("rotates at the real 1 MB cap when maxPersistBytes is omitted", () => {
+    // A test-only knob that silently lowered the production cap would be a
+    // worse bug than the one this file exists for. Writes a row well under the
+    // small CAP used elsewhere here and asserts nothing rotates — which it
+    // would, immediately, if the default had become CAP.
+    const log = new WorkerGateDecisionLog({
+      dir,
+      logger: { warn: (m: string) => warnings.push(m) },
+    });
+    for (let i = 0; i < 40; i++) log.record(bigRow(i));
+    expect(warnings.filter((w) => /dropped/i.test(w))).toHaveLength(0);
+    expect(
+      new WorkerGateDecisionLog({ dir }).query({ limit: 100 }),
+    ).toHaveLength(40);
+  });
+
+  it("ignores a nonsense cap rather than trusting it", () => {
+    // 0 or negative would make every append rotate the file to nothing.
+    const log = new WorkerGateDecisionLog({
+      dir,
+      maxPersistBytes: 0,
+      logger: { warn: (m: string) => warnings.push(m) },
+    });
+    for (let i = 0; i < 5; i++) log.record(bigRow(i));
+    expect(
+      new WorkerGateDecisionLog({ dir }).query({ limit: 100 }),
+    ).toHaveLength(5);
+  });
+});
+
 describe("rotation keeps what it can and reports what it dropped", () => {
   it("does not discard roughly half the ledger in one step", () => {
     const log = new WorkerGateDecisionLog({
       dir,
+      maxPersistBytes: CAP,
       logger: { warn: (m: string) => warnings.push(m) },
     });
     fillPastCap(log);
@@ -107,10 +151,10 @@ describe("rotation keeps what it can and reports what it dropped", () => {
     );
     // Trim-to-target leaves the file near its low-water mark. Halving left it
     // at ~50% of the cap (measured: 525,829 bytes), which is the tell.
-    expect(after.length).toBeGreaterThan(MAX_PERSIST_BYTES * 0.8);
+    expect(after.length).toBeGreaterThan(CAP * 0.8);
     // Never above the cap: `append` rotates BEFORE writing, so the post-rotate
     // file is target + one row, comfortably inside.
-    expect(after.length).toBeLessThanOrEqual(MAX_PERSIST_BYTES);
+    expect(after.length).toBeLessThanOrEqual(CAP);
   });
 
   it("does not rotate on every append once the file is full", () => {
@@ -120,6 +164,7 @@ describe("rotation keeps what it can and reports what it dropped", () => {
     // warning that fires on every write is one nobody reads.
     const log = new WorkerGateDecisionLog({
       dir,
+      maxPersistBytes: CAP,
       logger: { warn: (m: string) => warnings.push(m) },
     });
     fillPastCap(log);
@@ -130,6 +175,7 @@ describe("rotation keeps what it can and reports what it dropped", () => {
   it("says how many rows it dropped", () => {
     const log = new WorkerGateDecisionLog({
       dir,
+      maxPersistBytes: CAP,
       logger: { warn: (m: string) => warnings.push(m) },
     });
     fillPastCap(log);
@@ -143,6 +189,7 @@ describe("rotation keeps what it can and reports what it dropped", () => {
   it("keeps the NEWEST rows, never the oldest", () => {
     const log = new WorkerGateDecisionLog({
       dir,
+      maxPersistBytes: CAP,
       logger: { warn: (m: string) => warnings.push(m) },
     });
     const n = fillPastCap(log);

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -153,8 +153,14 @@ export type RecordGateDecisionInput = Omit<
 >;
 
 const DEFAULT_MEMORY_CAP = 2_000;
-const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB
+export const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB
 const MAX_PERSIST_LINES = 10_000;
+/**
+ * Low-water mark for rotation. `MAX_PERSIST_BYTES` is the trigger; this is the
+ * target. The gap between them is what stops rotation from running on every
+ * append once the file is full — see `rotateDisk`.
+ */
+const ROTATE_TARGET_BYTES = Math.floor(MAX_PERSIST_BYTES * 0.9);
 const MAX_REASON_LEN = 1_000;
 const MAX_CONTEXT_REASONS = 16;
 
@@ -363,12 +369,57 @@ export class WorkerGateDecisionLog {
     try {
       const raw = readFileSync(this.file, "utf-8");
       let lines = raw.split("\n").filter((l) => l.trim());
+      const before = lines.length;
       if (lines.length > MAX_PERSIST_LINES)
         lines = lines.slice(-MAX_PERSIST_LINES);
+
+      // Trim to fit, newest-first, dropping only what the cap actually
+      // requires.
+      //
+      // This used to halve: `lines.slice(-floor(length / 2))` inside a `while`,
+      // so crossing the cap by one row discarded ~50% of the file and a second
+      // pass could take ~75%. Measured on a synthetic fill, the old code left
+      // 525,829 bytes of a 1 MB budget — half the ledger destroyed to reclaim
+      // one row. This file is the autonomy gate's trust evidence and its audit
+      // trail, so that was 50% of both.
+      //
+      // Byte length, not string length: rotation is TRIGGERED on `st.size`
+      // (real bytes) but the old arithmetic used `.length` (UTF-16 code units),
+      // so a reason containing non-ASCII could leave the file over a cap whose
+      // own name says bytes.
+      //
+      // Trims to ROTATE_TARGET_BYTES, not to the cap. Trimming to exactly the
+      // cap looks tidier and is much worse: `append` rotates when the file is
+      // over the cap and then writes its row, so a file sitting exactly at the
+      // limit rotates on EVERY subsequent append — dropping one row and
+      // emitting one warning each time, forever. Measured while building this:
+      // 826 rotations and 826 identical warnings across one fill. A high-water
+      // trigger needs a low-water target, and a warning that fires on every
+      // write is one nobody reads.
+      let budget = ROTATE_TARGET_BYTES;
+      let keepFrom = lines.length;
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const cost = Buffer.byteLength(lines[i] as string, "utf8") + 1;
+        if (cost > budget) break;
+        budget -= cost;
+        keepFrom = i;
+      }
+      lines = lines.slice(keepFrom);
       let joined = lines.join("\n");
-      while (joined.length + 1 > MAX_PERSIST_BYTES && lines.length > 1) {
-        lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
-        joined = lines.join("\n");
+
+      const dropped = before - lines.length;
+      if (dropped > 0) {
+        // Say the COUNT, not just that it happened.
+        //
+        // Rotation deletes oldest-first, which is exactly the population of
+        // rows lacking any newer field. So a coverage measure over this file
+        // converges toward 1.0 BY DELETION, and "98% of decisions carry a run
+        // id" would read identically whether the ledger improved or ate its own
+        // counter-examples. Without this number a denominator computed here is
+        // not merely imprecise, it is confidently backwards.
+        this.opts.logger?.warn?.(
+          `[gate-decision-log] rotate dropped ${dropped} of ${before} row(s) (oldest first) to get under ${ROTATE_TARGET_BYTES} bytes — coverage figures computed over this file exclude them`,
+        );
       }
       if (lines.length === 1 && joined.length + 1 > MAX_PERSIST_BYTES) {
         this.opts.logger?.warn?.(

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -12,7 +12,6 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { withFileLockSync } from "./fileLockSync.js";
-import type { Logger } from "./logger.js";
 import type { Reversibility } from "./workers/actionClass.js";
 
 /**
@@ -166,7 +165,18 @@ const MAX_CONTEXT_REASONS = 16;
 
 export interface WorkerGateDecisionLogOptions {
   dir: string;
-  logger?: Logger;
+  /**
+   * Only `warn` is ever called (`logger?.warn?.(…)` at every site), so the
+   * option asks for only that — matching `ButlerFactStore` and
+   * `permissionStore`, which take the same shape for the same reason.
+   *
+   * It used to demand the full `Logger`. A real caller passing one still
+   * satisfies this structurally, but the wide type made a `{ warn }` object
+   * a type error in tests while being indistinguishable at runtime — and the
+   * strict `tsconfig.tests.core.json` ratchet is where that surfaced, not the
+   * default `npm run typecheck`.
+   */
+  logger?: { warn?: (msg: string) => void };
   memoryCap?: number;
   /**
    * Byte cap before rotation, defaulting to `MAX_PERSIST_BYTES`.

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -156,11 +156,11 @@ const DEFAULT_MEMORY_CAP = 2_000;
 export const MAX_PERSIST_BYTES = 1024 * 1024; // 1 MB
 const MAX_PERSIST_LINES = 10_000;
 /**
- * Low-water mark for rotation. `MAX_PERSIST_BYTES` is the trigger; this is the
- * target. The gap between them is what stops rotation from running on every
- * append once the file is full — see `rotateDisk`.
+ * Low-water mark for rotation, as a fraction of the cap. The cap is the
+ * TRIGGER; this is the TARGET. The gap between them is what stops rotation from
+ * running on every append once the file is full — see `rotateDisk`.
  */
-const ROTATE_TARGET_BYTES = Math.floor(MAX_PERSIST_BYTES * 0.9);
+const ROTATE_TARGET_RATIO = 0.9;
 const MAX_REASON_LEN = 1_000;
 const MAX_CONTEXT_REASONS = 16;
 
@@ -168,6 +168,16 @@ export interface WorkerGateDecisionLogOptions {
   dir: string;
   logger?: Logger;
   memoryCap?: number;
+  /**
+   * Byte cap before rotation, defaulting to `MAX_PERSIST_BYTES`.
+   *
+   * Injectable for the same reason `memoryCap` is: a test that must observe
+   * rotation should not have to write a real megabyte through a lock-guarded
+   * append on every row. The first version of the rotation test did exactly
+   * that — ~3,400 locked appends across four cases — which is merely slow on
+   * Linux and a plausible timeout on Windows.
+   */
+  maxPersistBytes?: number;
   now?: () => number;
 }
 
@@ -211,6 +221,8 @@ export class WorkerGateDecisionLog {
   private seq = 0;
   private readonly file: string;
   private readonly memoryCap: number;
+  private readonly maxBytes: number;
+  private readonly rotateTarget: number;
   private readonly now: () => number;
   /** Byte offset up to which `file` has been loaded (ADR-0007 tail-on-read). */
   private lastReadOffset = 0;
@@ -218,6 +230,14 @@ export class WorkerGateDecisionLog {
   constructor(private readonly opts: WorkerGateDecisionLogOptions) {
     this.file = path.join(opts.dir, "worker_gate_decisions.jsonl");
     this.memoryCap = opts.memoryCap ?? DEFAULT_MEMORY_CAP;
+    this.maxBytes =
+      opts.maxPersistBytes && opts.maxPersistBytes > 0
+        ? opts.maxPersistBytes
+        : MAX_PERSIST_BYTES;
+    this.rotateTarget = Math.max(
+      1,
+      Math.floor(this.maxBytes * ROTATE_TARGET_RATIO),
+    );
     this.now = opts.now ?? Date.now;
     try {
       mkdirSync(opts.dir, { recursive: true, mode: 0o700 });
@@ -339,7 +359,7 @@ export class WorkerGateDecisionLog {
     try {
       try {
         const st = statSync(this.file);
-        if (st.size > MAX_PERSIST_BYTES) this.rotateDisk();
+        if (st.size > this.maxBytes) this.rotateDisk();
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;
         if (code !== "ENOENT") throw err;
@@ -364,7 +384,7 @@ export class WorkerGateDecisionLog {
     }
   }
 
-  /** Trim to the most recent MAX_PERSIST_LINES / MAX_PERSIST_BYTES. Best-effort. */
+  /** Trim to the most recent MAX_PERSIST_LINES / `this.maxBytes`. Best-effort. */
   private rotateDisk(): void {
     try {
       const raw = readFileSync(this.file, "utf-8");
@@ -396,7 +416,7 @@ export class WorkerGateDecisionLog {
       // 826 rotations and 826 identical warnings across one fill. A high-water
       // trigger needs a low-water target, and a warning that fires on every
       // write is one nobody reads.
-      let budget = ROTATE_TARGET_BYTES;
+      let budget = this.rotateTarget;
       let keepFrom = lines.length;
       for (let i = lines.length - 1; i >= 0; i--) {
         const cost = Buffer.byteLength(lines[i] as string, "utf8") + 1;
@@ -418,10 +438,10 @@ export class WorkerGateDecisionLog {
         // counter-examples. Without this number a denominator computed here is
         // not merely imprecise, it is confidently backwards.
         this.opts.logger?.warn?.(
-          `[gate-decision-log] rotate dropped ${dropped} of ${before} row(s) (oldest first) to get under ${ROTATE_TARGET_BYTES} bytes — coverage figures computed over this file exclude them`,
+          `[gate-decision-log] rotate dropped ${dropped} of ${before} row(s) (oldest first) to get under ${this.rotateTarget} bytes — coverage figures computed over this file exclude them`,
         );
       }
-      if (lines.length === 1 && joined.length + 1 > MAX_PERSIST_BYTES) {
+      if (lines.length === 1 && joined.length + 1 > this.maxBytes) {
         this.opts.logger?.warn?.(
           `[gate-decision-log] rotate dropped 1 oversized row (${joined.length} bytes)`,
         );


### PR DESCRIPTION
**Third of the correlation-sentinel preconditions.** `rv` + `correlationId` adds ~12.4% per row, and a rotation policy that destroys half the ledger is not a foundation to add a durable join key onto.

## The destruction

```js
while (joined.length + 1 > MAX_PERSIST_BYTES && lines.length > 1) {
  lines = lines.slice(-Math.max(1, Math.floor(lines.length / 2)));
  joined = lines.join("\n");
}
```

Crossing the cap by a **single row** discarded ~50%; a second pass took ~75%. Measured on a synthetic fill: the old code left **525,829 bytes of a 1 MB budget**.

This file is the autonomy gate's trust evidence *and* its audit trail. That was half of both, deleted oldest-first, with nothing written anywhere to say it happened.

## The silence is the worse half

Rotation deletes oldest-first — exactly the population of rows lacking any newer field. So any coverage measure over this file **converges toward 1.0 by deletion**.

> "98% of decisions carry a run id"

would describe a ledger that ate its own counter-examples, in precisely the same words as a genuine improvement. The count is not a nicety; without it the denominator is confidently backwards.

## The fix, and the defect the first version had

Trim-to-target, keeping newest, dropping only what the budget requires. **Measured after: 85 of 840 rows (~10%) instead of ~50%.**

The target is a low-water mark at 90%, **not** the cap, and that gap is load-bearing. `append` rotates when the file is over the cap and *then* writes its row — so trimming to exactly the cap makes it rotate on **every subsequent append**, one row dropped and one warning each time, forever.

That is not hypothetical. The first version of this fix did exactly that, and a probe measured **826 rotations and 826 identical warnings** across one fill. A high-water trigger needs a low-water target, and a warning that fires on every write is one nobody reads — the same argument #1513 makes about a production auth warning.

Also: **byte length, not string length.** Rotation is *triggered* on `st.size` (real bytes) while the old arithmetic used `.length` (UTF-16 code units), so a `reason` containing non-ASCII could leave the file over a cap whose own name says bytes.

## Mutations

| mutation | outcome |
|---|---|
| restore the halve | 1 fails |
| remove the hysteresis (trim to cap) | 2 fail |
| drop the count | 1 fails |
| fixed | 4 pass |

Suite: 10,328 green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)