### PR TITLE
feat(gate): give a decision a run to point at, and a sentinel for rows without one

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,17 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-25 `feat/correlation-sentinel` — the correlation-id sentinel (the irreversible
+  decision doc 13 §4.1 reserved for the owner), settled by adversarial review first. A gate
+  decision now carries `rv` (writer-stamped record level) and `correlationId` (the run's
+  `taskId`, never `seq`, which collides 255-of-272). Absence of `rv` is the sentinel and is
+  never backfilled — a reader must not default it, since `parsed.rv ?? 0` is a backfill
+  performed invisibly on every load. Consolidates THREE identical declarations of the approval
+  input into one shared type with a REQUIRED `runTaskId`, so a new approval call site is a
+  compile error until it names its run. Found en route: `record()` was silently dropping
+  `workspaceId`, which is why 0 of 272 live rows carry a workspace tag despite the orchestrator
+  stamping every one.
+
 - 2026-08-25 `fix/dashboard-renders-forbid-as-gate` — the dashboard typed a gate decision's
   `action` as `"allow" | "gate"` and rendered `isAllow ? "ALLOW" : "GATE"`, so ADR-0017's
   terminal `forbid` displayed as a GATE with the explain line "vs required higher" — telling

--- a/src/__tests__/gateRecordLevel.test.ts
+++ b/src/__tests__/gateRecordLevel.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The correlation sentinel.
+ *
+ * A gate decision now carries `rv` (the writer's record level) and
+ * `correlationId` (the run's `taskId`). The sentinel is the ABSENCE of `rv`:
+ * a row without it makes no claim, and nothing may be inferred from which
+ * optional fields it lacks.
+ *
+ * That absence is the one thing here that cannot be repaired later — there is
+ * no backfill, and defaulting it on read (`parsed.rv ?? 0`) would be a backfill
+ * performed invisibly on every load. So these assertions are about a property
+ * that has exactly one chance to be right.
+ *
+ * Everything goes through the REAL writer to REAL disk and is read back by a
+ * FRESH instance. Asserting on `record()`'s return value would pass with the
+ * fields missing from the file entirely — which is not hypothetical: a
+ * `workspaceId` that `record()` accepted and never persisted is exactly the bug
+ * this shape of test would have caught the day it shipped.
+ */
+
+import { appendFileSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  correlationOf,
+  GATE_RECORD_VERSION,
+  type RecordGateDecisionInput,
+  WorkerGateDecisionLog,
+} from "../workerGateDecisionLog.js";
+
+let dir: string;
+let file: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "gate-rv-"));
+  file = join(dir, "worker_gate_decisions.jsonl");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const base: RecordGateDecisionInput = {
+  recipeName: "example-recipe",
+  workerId: "w1",
+  toolName: "githubCreateIssue",
+  action: "allow",
+  classKey: "issue:compensable:low",
+  domain: "issue",
+  owned: true,
+  blastTier: "low",
+  reversibility: "compensable",
+  earnedLevel: 4,
+  autonomyCeiling: 4,
+  effectiveLevel: 4,
+  reason: "earned",
+  gatePolicyVersion: "worker-ramp-v1",
+};
+
+/** A row `record()` can never produce again — the never-backfill fixture. */
+const LEGACY = JSON.stringify({
+  seq: 1,
+  decidedAt: 1_756_000_000_000,
+  recipeName: "example-recipe",
+  workerId: "w1",
+  toolName: "t1",
+  action: "allow",
+  classKey: "issue:reversible:low",
+  domain: "issue",
+  owned: true,
+  blastTier: "low",
+  reversibility: "reversible",
+  earnedLevel: 0,
+  autonomyCeiling: 4,
+  effectiveLevel: 0,
+  reason: "r",
+  gatePolicyVersion: "worker-ramp-v0",
+});
+
+function lines(): string[] {
+  return readFileSync(file, "utf-8").trim().split("\n");
+}
+
+describe("the record level reaches disk", () => {
+  it("stamps rv and correlationId on a new row", () => {
+    const log = new WorkerGateDecisionLog({ dir });
+    log.record({ ...base, correlationId: "yaml:example-recipe:1756100000000" });
+    const row = JSON.parse(lines()[0] as string);
+    expect(row.rv).toBe(GATE_RECORD_VERSION);
+    expect(row.correlationId).toBe("yaml:example-recipe:1756100000000");
+  });
+
+  it("survives a fresh read, not just the writing instance's memory", () => {
+    const w = new WorkerGateDecisionLog({ dir });
+    w.record({ ...base, correlationId: "yaml:example-recipe:1756100000000" });
+    const rows = new WorkerGateDecisionLog({ dir }).query({ limit: 10 });
+    expect(rows[0]?.rv).toBe(GATE_RECORD_VERSION);
+    expect(rows[0]?.correlationId).toBe("yaml:example-recipe:1756100000000");
+  });
+});
+
+describe("a pre-sentinel row is left exactly as it was", () => {
+  it("is byte-identical after a later write, and gains no rv", () => {
+    appendFileSync(file, `${LEGACY}\n`);
+    new WorkerGateDecisionLog({ dir }).record({
+      ...base,
+      correlationId: "yaml:example-recipe:1756100000000",
+    });
+    expect(lines()[0]).toBe(LEGACY);
+    expect(Object.hasOwn(JSON.parse(lines()[0] as string), "rv")).toBe(false);
+  });
+
+  it("still has no rv after a round trip through the reader", () => {
+    // Fails on `parsed.rv ?? 0` — a default applied on load is a backfill that
+    // never appears in the file, so it is invisible to the assertion above.
+    appendFileSync(file, `${LEGACY}\n`);
+    const row = new WorkerGateDecisionLog({ dir })
+      .query({ limit: 10 })
+      .find((r) => r.seq === 1);
+    expect(row).toBeDefined();
+    expect(Object.hasOwn(row as object, "rv")).toBe(false);
+  });
+});
+
+describe("correlationOf keeps the absences apart", () => {
+  it("reports a levelless row as making no claim", () => {
+    expect(correlationOf({})).toEqual({ state: "unclaimed" });
+  });
+
+  it("reports a levelled row with no run as a DEFECT, never as 'no run'", () => {
+    // The state that must not exist. Every gate decision happens inside a run,
+    // so a row claiming otherwise would be false rather than informative.
+    expect(correlationOf({ rv: 1 })).toEqual({ state: "defect", rv: 1 });
+  });
+
+  it("links a row that names its run", () => {
+    expect(correlationOf({ rv: 1, correlationId: "yaml:r:1" })).toEqual({
+      state: "linked",
+      taskId: "yaml:r:1",
+    });
+  });
+
+  it("does not claim to have verified a run it never looked for", () => {
+    // Without a `runExists` probe the answer is "linked", not "unresolved":
+    // "we did not look" must not be reported as "we looked and found nothing".
+    expect(correlationOf({ rv: 1, correlationId: "gone" }).state).toBe(
+      "linked",
+    );
+    expect(
+      correlationOf({ rv: 1, correlationId: "gone" }, () => false),
+    ).toEqual({ state: "unresolved", taskId: "gone" });
+  });
+});
+
+describe("every writer-stamped field actually reaches disk", () => {
+  /**
+   * A census, not a spot check. `record()` builds its row as an explicit
+   * literal rather than spreading `input` — deliberate, so an unvetted caller
+   * field cannot reach disk, but it means a NEW field is silently dropped until
+   * someone remembers to add a line.
+   *
+   * `workspaceId` was dropped that way for its entire life: the orchestrator
+   * stamps it on every decision and the literal never copied it, so 0 of 272
+   * rows in the live ledger carry one. This test, written when that field
+   * shipped, would have caught it the same day.
+   */
+  it("persists every field the caller supplied", () => {
+    const log = new WorkerGateDecisionLog({ dir });
+    log.record({
+      ...base,
+      correlationId: "yaml:example-recipe:1756100000000",
+      workspaceId: "ws-abc123",
+    });
+    const row = JSON.parse(lines()[0] as string);
+    for (const [k, v] of Object.entries({
+      correlationId: "yaml:example-recipe:1756100000000",
+      workspaceId: "ws-abc123",
+      rv: GATE_RECORD_VERSION,
+    })) {
+      expect(row, `field "${k}" did not reach disk`).toHaveProperty(k, v);
+    }
+  });
+});
+
+describe("the level is the writer's claim, not the caller's", () => {
+  it("ignores an rv a caller tries to supply", () => {
+    const log = new WorkerGateDecisionLog({ dir });
+    // `rv` is excluded from RecordGateDecisionInput, so this is a type error in
+    // real code; the cast proves the writer still wins at runtime.
+    log.record({ ...base, rv: 99 } as unknown as RecordGateDecisionInput);
+    expect(JSON.parse(lines()[0] as string).rv).toBe(GATE_RECORD_VERSION);
+  });
+});

--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -26,6 +26,14 @@ import { RecipeRunLog } from "../runLog.js";
 import type { RecordGateDecisionInput } from "../workerGateDecisionLog.js";
 import { OutcomeStore } from "../workers/outcomeStore.js";
 
+/**
+ * A stand-in run id for gate inputs. `runTaskId` is required on
+ * `ApprovalRequestInput` so that a new approval call site cannot forget the
+ * join key onto its run; a test that only exercises the decision still has to
+ * name one.
+ */
+const TEST_RUN = "yaml:test-recipe:1756000000000";
+
 /** Seed durable, dwell-separated successes so the worker earns autonomy on
  *  `tool`'s class (ancient timestamps → durable under durable-outcome labels). */
 function seedEarned(dir: string, recipeName: string, tool: string, n = 18) {
@@ -121,7 +129,12 @@ describe("buildWorkerAutonomyGate", () => {
     // auto-allow it just because it is reversible.
     const tierFn = vi.fn(async () => false);
     const g = await buildWorkerAutonomyGate("test-recipe", tierFn, opts);
-    const r = await g!({ toolId: "editText", tier: "high", params: {} });
+    const r = await g!({
+      runTaskId: TEST_RUN,
+      toolId: "editText",
+      tier: "high",
+      params: {},
+    });
     expect(tierFn).toHaveBeenCalledTimes(1);
     expect(r).toBe(false); // tier protection retained
   });
@@ -129,7 +142,12 @@ describe("buildWorkerAutonomyGate", () => {
   it("FLOOR: a reversible step is allowed when the tier fn allows", async () => {
     const tierFn = vi.fn(async () => true);
     const g = await buildWorkerAutonomyGate("test-recipe", tierFn, opts);
-    const r = await g!({ toolId: "editText", tier: "low", params: {} });
+    const r = await g!({
+      runTaskId: TEST_RUN,
+      toolId: "editText",
+      tier: "low",
+      params: {},
+    });
     expect(tierFn).toHaveBeenCalledTimes(1);
     expect(r).toBe(true);
   });
@@ -137,20 +155,35 @@ describe("buildWorkerAutonomyGate", () => {
   it("agent steps defer to the tier fn, never gate forever (M3)", async () => {
     const tierFn = vi.fn(async () => true);
     const g = await buildWorkerAutonomyGate("test-recipe", tierFn, opts);
-    const r = await g!({ toolId: "agent", tier: "medium", params: {} });
+    const r = await g!({
+      runTaskId: TEST_RUN,
+      toolId: "agent",
+      tier: "medium",
+      params: {},
+    });
     expect(tierFn).toHaveBeenCalledTimes(1);
     expect(r).toBe(true);
   });
 
   it("a reversible step flows when there is no tier fn (approvalGate off)", async () => {
     const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-    const r = await g!({ toolId: "editText", tier: "low", params: {} });
+    const r = await g!({
+      runTaskId: TEST_RUN,
+      toolId: "editText",
+      tier: "low",
+      params: {},
+    });
     expect(r).toBe(true);
   });
 
   it("fail-closed: a risky unearned step queues and REJECT → false (M4)", async () => {
     const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    const p = g!({
+      runTaskId: TEST_RUN,
+      toolId: "gitPush",
+      tier: "high",
+      params: {},
+    });
     await tick();
     expect(getApprovalQueue().list()).toHaveLength(1);
     getApprovalQueue().reject(firstCallId());
@@ -159,7 +192,12 @@ describe("buildWorkerAutonomyGate", () => {
 
   it("fail-closed: a risky unearned step CANCEL → false (M4)", async () => {
     const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    const p = g!({
+      runTaskId: TEST_RUN,
+      toolId: "gitPush",
+      tier: "high",
+      params: {},
+    });
     await tick();
     getApprovalQueue().cancel(firstCallId());
     expect(await p).toBe(false);
@@ -167,7 +205,12 @@ describe("buildWorkerAutonomyGate", () => {
 
   it("fail-closed: a risky unearned step EXPIRE → false (M4)", async () => {
     const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    const p = g!({
+      runTaskId: TEST_RUN,
+      toolId: "gitPush",
+      tier: "high",
+      params: {},
+    });
     await tick();
     getApprovalQueue().clear(); // resolves pending as "expired"
     expect(await p).toBe(false);
@@ -175,7 +218,12 @@ describe("buildWorkerAutonomyGate", () => {
 
   it("a risky unearned step APPROVE → true (M4)", async () => {
     const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-    const p = g!({ toolId: "gitPush", tier: "high", params: {} });
+    const p = g!({
+      runTaskId: TEST_RUN,
+      toolId: "gitPush",
+      tier: "high",
+      params: {},
+    });
     await tick();
     getApprovalQueue().approve(firstCallId());
     expect(await p).toBe(true);
@@ -185,6 +233,7 @@ describe("buildWorkerAutonomyGate", () => {
     const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
     const ac = new AbortController();
     const p = g!({
+      runTaskId: TEST_RUN,
       toolId: "gitPush",
       tier: "high",
       params: {},
@@ -209,7 +258,12 @@ describe("buildWorkerAutonomyGate", () => {
       },
     );
     expect(
-      await clean!({ toolId: "githubCreatePR", tier: "high", params: {} }),
+      await clean!({
+        runTaskId: TEST_RUN,
+        toolId: "githubCreatePR",
+        tier: "high",
+        params: {},
+      }),
     ).toBe(true);
 
     // Dangerous live context → the SAME earned action is throttled to a gate
@@ -225,7 +279,12 @@ describe("buildWorkerAutonomyGate", () => {
         }),
       },
     );
-    const p = risky!({ toolId: "githubCreatePR", tier: "high", params: {} });
+    const p = risky!({
+      runTaskId: TEST_RUN,
+      toolId: "githubCreatePR",
+      tier: "high",
+      params: {},
+    });
     await tick();
     expect(getApprovalQueue().list()).toHaveLength(1);
     getApprovalQueue().reject(firstCallId());
@@ -241,7 +300,12 @@ describe("buildWorkerAutonomyGate", () => {
     });
     // provider threw → contextRisk undefined → earned action still flows.
     expect(
-      await gate!({ toolId: "githubCreatePR", tier: "high", params: {} }),
+      await gate!({
+        runTaskId: TEST_RUN,
+        toolId: "githubCreatePR",
+        tier: "high",
+        params: {},
+      }),
     ).toBe(true);
   });
 
@@ -251,14 +315,24 @@ describe("buildWorkerAutonomyGate", () => {
       recordGateDecision: (r) => records.push(r),
     });
     // GATE path: unowned risky gitPush (worker owns vcs-remote, not vcs-push).
-    const p = gate!({ toolId: "gitPush", tier: "high", params: {} });
+    const p = gate!({
+      runTaskId: TEST_RUN,
+      toolId: "gitPush",
+      tier: "high",
+      params: {},
+    });
     await tick();
     getApprovalQueue().reject(firstCallId());
     await p;
     // ALLOW path: reversible editText flows.
-    expect(await gate!({ toolId: "editText", tier: "low", params: {} })).toBe(
-      true,
-    );
+    expect(
+      await gate!({
+        runTaskId: TEST_RUN,
+        toolId: "editText",
+        tier: "low",
+        params: {},
+      }),
+    ).toBe(true);
 
     const gated = records.find((r) => r.toolName === "gitPush");
     const allowed = records.find((r) => r.toolName === "editText");
@@ -320,7 +394,12 @@ describe("buildWorkerAutonomyGate", () => {
       store.grant({ scope: { domains: ["vcs-push"] }, note: "small pushes" });
 
       const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-      const result = await g!({ toolId: "gitPush", tier: "high", params: {} });
+      const result = await g!({
+        runTaskId: TEST_RUN,
+        toolId: "gitPush",
+        tier: "high",
+        params: {},
+      });
 
       expect(result).toBe(true);
       // The point of the whole feature: nobody was asked.
@@ -332,7 +411,12 @@ describe("buildWorkerAutonomyGate", () => {
       const p = store.grant({ scope: { domains: ["vcs-push"] } });
 
       const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-      await g!({ toolId: "gitPush", tier: "high", params: {} });
+      await g!({
+        runTaskId: TEST_RUN,
+        toolId: "gitPush",
+        tier: "high",
+        params: {},
+      });
 
       const exercises = (await permStore()).exercises();
       expect(exercises).toHaveLength(1);
@@ -349,7 +433,12 @@ describe("buildWorkerAutonomyGate", () => {
       const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts, {
         recordGateDecision: (r) => records.push(r),
       });
-      await g!({ toolId: "gitPush", tier: "high", params: {} });
+      await g!({
+        runTaskId: TEST_RUN,
+        toolId: "gitPush",
+        tier: "high",
+        params: {},
+      });
 
       // The gate's own verdict is unchanged — the trust maths still gated it.
       expect(records[0]?.action).toBe("gate");
@@ -362,14 +451,24 @@ describe("buildWorkerAutonomyGate", () => {
       const p = store.grant({ scope: { domains: ["vcs-push"] } });
 
       const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-      expect(await g!({ toolId: "gitPush", tier: "high", params: {} })).toBe(
-        true,
-      );
+      expect(
+        await g!({
+          runTaskId: TEST_RUN,
+          toolId: "gitPush",
+          tier: "high",
+          params: {},
+        }),
+      ).toBe(true);
 
       store.revoke(p.id);
 
       // Same gate instance — a grant cached for the run would keep flowing.
-      const pending = g!({ toolId: "gitPush", tier: "high", params: {} });
+      const pending = g!({
+        runTaskId: TEST_RUN,
+        toolId: "gitPush",
+        tier: "high",
+        params: {},
+      });
       await tick();
       expect(getApprovalQueue().list()).toHaveLength(1);
       getApprovalQueue().reject(firstCallId());
@@ -382,7 +481,12 @@ describe("buildWorkerAutonomyGate", () => {
       store.grant({ scope: { domains: ["shell", "messaging", "vcs-push"] } });
 
       const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-      const pending = g!({ toolId: "runCommand", tier: "high", params: {} });
+      const pending = g!({
+        runTaskId: TEST_RUN,
+        toolId: "runCommand",
+        tier: "high",
+        params: {},
+      });
       await tick();
       expect(getApprovalQueue().list()).toHaveLength(1);
       getApprovalQueue().reject(firstCallId());
@@ -394,7 +498,12 @@ describe("buildWorkerAutonomyGate", () => {
       store.grant({ scope: { domains: ["issue"] } });
 
       const g = await buildWorkerAutonomyGate("test-recipe", undefined, opts);
-      const pending = g!({ toolId: "gitPush", tier: "high", params: {} });
+      const pending = g!({
+        runTaskId: TEST_RUN,
+        toolId: "gitPush",
+        tier: "high",
+        params: {},
+      });
       await tick();
       expect(getApprovalQueue().list()).toHaveLength(1);
       getApprovalQueue().reject(firstCallId());
@@ -409,9 +518,14 @@ describe("buildWorkerAutonomyGate", () => {
       },
     });
     // logging blew up, but the reversible action still flows.
-    expect(await gate!({ toolId: "editText", tier: "low", params: {} })).toBe(
-      true,
-    );
+    expect(
+      await gate!({
+        runTaskId: TEST_RUN,
+        toolId: "editText",
+        tier: "low",
+        params: {},
+      }),
+    ).toBe(true);
   });
 });
 
@@ -536,6 +650,7 @@ forbids:
     const tierFn = vi.fn(async () => true);
     const g = await buildWorkerAutonomyGate("fin-recipe", tierFn, opts);
     const r = await g!({
+      runTaskId: TEST_RUN,
       toolId: "slackPostMessage",
       tier: "high",
       params: {},
@@ -549,7 +664,12 @@ forbids:
     // Guards against the rule over-matching and bricking the worker entirely.
     const tierFn = vi.fn(async () => true);
     const g = await buildWorkerAutonomyGate("fin-recipe", tierFn, opts);
-    const r = await g!({ toolId: "editText", tier: "low", params: {} });
+    const r = await g!({
+      runTaskId: TEST_RUN,
+      toolId: "editText",
+      tier: "low",
+      params: {},
+    });
     expect(r).toBe(true);
   });
 });

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -71,9 +71,17 @@ export interface PendingApproval {
    *
    * TODO(phase-0β-pop): population is deferred — the immediate goal
    * is unblocking the dashboard schema. Computing the link without a
-   * deeper refactor requires sessionId→runSeq mapping that today
+   * deeper refactor requires sessionId→run mapping that today
    * lives behind `personalSignals.source: "recipe_run_log"`. Wiring
    * that explicitly into `handleApprovalRequest` is the follow-up.
+   *
+   * WHEN THAT FOLLOW-UP HAPPENS, DO NOT POPULATE THIS FIELD. `seq` is a
+   * per-instance counter over a file several bridges write, and it
+   * collides — measured 255 distinct values across 272 rows of the live
+   * gate ledger. An approval joined on it lands on an arbitrary one of
+   * the colliding runs. Add a `runTaskId` alongside (or instead), the
+   * same key `ApprovalRequestInput` and the Decision Record's
+   * `correlationId` already use, and retire this one.
    */
   runSeq?: number;
   recipeName?: string;

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -132,16 +132,7 @@ async function makeRecipeApprovalFn(gate: "high" | "all"): Promise<ApprovalFn> {
   };
 }
 
-type ApprovalFn = (input: {
-  toolId: string;
-  tier: import("./riskTier.js").RiskTier;
-  summary?: string;
-  params?: Record<string, unknown>;
-  /** The run's AbortSignal — when it fires, the pending approval resolves
-   * "cancelled" so a cancelled run halts promptly instead of waiting the full
-   * approval TTL (L1). */
-  signal?: AbortSignal;
-}) => Promise<boolean>;
+type ApprovalFn = import("./recipes/approvalRequest.js").ApprovalFn;
 
 /**
  * Worker-autonomy gate (worker-ramp-v0 phase 2, `worker.autonomy` flag, default
@@ -304,6 +295,9 @@ export async function buildWorkerAutonomyGate(
       try {
         ctxOpts?.recordGateDecision?.({
           recipeName,
+          // The run this decision belongs to. Required on the approval input, so
+          // a new call site cannot reach here without naming one.
+          correlationId: input.runTaskId,
           workerId: worker.id,
           toolName: input.toolId,
           action: decision.action,

--- a/src/recipes/approvalRequest.ts
+++ b/src/recipes/approvalRequest.ts
@@ -1,0 +1,43 @@
+/**
+ * The input every approval gate receives, in ONE place.
+ *
+ * This shape was declared three times, structurally identically:
+ * `recipeOrchestration.ts`'s `ApprovalFn`, and inline inside each runner's
+ * `requireApprovalFn` option (`yamlRunner.ts`, `chainedRunner.ts`). Three copies
+ * of a contract is not a duplication smell here — it is how a field gets added
+ * to one path and silently missed on the other, which is precisely the failure
+ * mode `runTaskId` exists to prevent.
+ *
+ * `runTaskId` is REQUIRED, deliberately. It is the join key between a gate
+ * decision and the run that produced it, and an optional key is one that
+ * eventually is not passed. Making it required means adding a new approval call
+ * site is a compile error until that site says which run it belongs to.
+ */
+
+import type { RiskTier } from "../riskTier.js";
+
+export interface ApprovalRequestInput {
+  toolId: string;
+  tier: RiskTier;
+  summary?: string;
+  params?: Record<string, unknown>;
+  /**
+   * The run's identity, verbatim as written to `runs.jsonl` / `run_steps.jsonl`
+   * — `taskId`, never `seq`.
+   *
+   * `seq` is a per-INSTANCE counter over a file shared by several writers, and
+   * it collides: measured 255 distinct values across 272 rows of the live gate
+   * ledger. A join on it silently becomes many-to-one. `taskId` is derived from
+   * the recipe name and its start time and does not have that property.
+   */
+  runTaskId: string;
+  /**
+   * The run's AbortSignal — when it fires, a pending approval resolves
+   * "cancelled" so a cancelled run halts promptly instead of waiting out the
+   * full approval TTL (L1).
+   */
+  signal?: AbortSignal;
+}
+
+/** Every approval gate: the tier gate, the worker-autonomy gate, and any test double. */
+export type ApprovalFn = (input: ApprovalRequestInput) => Promise<boolean>;

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -7,7 +7,7 @@
  *   - Dry-run mode
  */
 
-import { classifyTool, type RiskTier } from "../riskTier.js";
+import { classifyTool } from "../riskTier.js";
 import type { AgentResult } from "./agentExecutor.js";
 import type { ExecutionOptions, StepExecutor } from "./dependencyGraph.js";
 import {
@@ -196,6 +196,16 @@ export interface StepExecutionContext {
   /** Shared per-run budget (admit before dispatch, reconcile after). */
   budget?: RunBudget;
   /**
+   * This run's identity (`taskId`, never `seq`), threaded so a step's approval
+   * can name the run it belongs to.
+   *
+   * It rides on the context rather than being a new parameter because
+   * `executeChainedStep` is minted in `runChainedRecipe` and has exactly one
+   * production caller, inside that same function — so the value is already in
+   * scope at the only place a context is built.
+   */
+  runTaskId?: string;
+  /**
    * Price table loaded ONCE per run and threaded through so each agent step's
    * `computeAgentCallUsage` call avoids a synchronous existsSync/readFileSync
    * round-trip (mirrors the flat runner, which loads it once at run start).
@@ -253,14 +263,7 @@ export interface ExecutionDeps {
    * runner only acts on an explicit rejection. Per-recipe opt-out via
    * `requireApproval: false`.
    */
-  requireApprovalFn?: (input: {
-    toolId: string;
-    tier: RiskTier;
-    summary?: string;
-    params?: Record<string, unknown>;
-    /** Run AbortSignal — cancels the approval wait promptly on run abort (L1). */
-    signal?: AbortSignal;
-  }) => Promise<boolean>;
+  requireApprovalFn?: import("./approvalRequest.js").ApprovalFn;
 }
 
 function nestedRecipeRef(step: ChainedStep): string | undefined {
@@ -679,6 +682,9 @@ export async function executeChainedStep(
         summary: step.agent ? "agent step" : `tool ${approvalToolId}`,
         params: step.agent ? undefined : (resolved as Record<string, unknown>),
         ...(options.signal && { signal: options.signal }), // L1
+        // Join key onto this run's rows — the same id `runChainedRecipe`
+        // writes to the run log, threaded through the step context.
+        runTaskId: ctx.runTaskId ?? "",
       });
       if (!approved) {
         return {
@@ -1482,6 +1488,7 @@ export async function runChainedRecipe(
       depth,
       budget,
       priceTable,
+      runTaskId,
     };
 
     const retryCount = step.retry ?? recipe.on_error?.retry ?? 0;

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -669,15 +669,7 @@ export interface RunnerDeps {
    * runner only has to act on an explicit rejection. Never consulted for
    * automated (cron/webhook/recipe) triggers, so crons can't block mid-run.
    */
-  requireApprovalFn?: (input: {
-    toolId: string;
-    tier: import("../riskTier.js").RiskTier;
-    summary?: string;
-    params?: Record<string, unknown>;
-    /** The run's AbortSignal — lets the approval wait be cancelled promptly
-     * when the run is aborted, instead of blocking for the full TTL (L1). */
-    signal?: AbortSignal;
-  }) => Promise<boolean>;
+  requireApprovalFn?: import("./approvalRequest.js").ApprovalFn;
   /**
    * Worker-autonomy gate (worker.autonomy flag). When set, the approval gate
    * ALSO engages on automated (cron/webhook/recipe) triggers — not just manual
@@ -1413,6 +1405,16 @@ export async function runYamlRecipe(
   // CLI runs fall back to `appendDirect` at end via the existing logDir
   // path. Skip in test mode.
   const recipeStartedAt = now.getTime();
+  /**
+   * This run's identity, minted ONCE.
+   *
+   * The same expression was written out twice (the run-log `startRun` and the
+   * terminal `appendDirect`). Both were in this function over this const, so
+   * they could not diverge — but a join key computed independently in two
+   * places is one edit away from a spine that breaks silently, and there are
+   * now three readers of it rather than two.
+   */
+  const runTaskId = `yaml:${recipe.name}:${recipeStartedAt}`;
   const recipeTriggerKind =
     (recipe.trigger as { type?: string } | undefined)?.type ?? "manual";
   const yamlTriggerKind = (
@@ -1424,7 +1426,7 @@ export async function runYamlRecipe(
   if (deps.runLog && !stepDeps.testMode) {
     try {
       runSeq = deps.runLog.startRun({
-        taskId: `yaml:${recipe.name}:${recipeStartedAt}`,
+        taskId: runTaskId,
         recipeName: recipe.name,
         trigger: yamlTriggerKind,
         createdAt: recipeStartedAt,
@@ -2192,6 +2194,9 @@ export async function runYamlRecipe(
             ? `agent step${step.agent.into ? ` → ${step.agent.into}` : ""}`
             : `tool ${approvalToolId}`,
           params: step.agent ? undefined : resolveParamsForApproval(step, ctx),
+          // The join key onto this run's rows in the run log. Same const the
+          // run-log writes above, never a second expression.
+          runTaskId,
           ...(effectiveRunSignal && { signal: effectiveRunSignal }), // L1
         });
         if (!approved) {
@@ -2925,7 +2930,7 @@ export async function runYamlRecipe(
         const resolvedLogDir = deps.logDir ?? patchworkPath();
         const log = createRecipeRunLog({ dir: resolvedLogDir });
         log.appendDirect({
-          taskId: `yaml:${recipe.name}:${recipeStartedAt}`,
+          taskId: runTaskId,
           recipeName: recipe.name,
           trigger: yamlTriggerKind,
           status: runError ? "error" : "done",

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -78,6 +78,35 @@ export interface GateDecisionRecord {
    */
   workspaceId?: string;
 
+  /**
+   * Record level — the writer's claim about which fields this row is
+   * guaranteed to carry. Stamped by `record()`, never by a caller.
+   *
+   * ABSENT means the row carries NO claim, and nothing may be inferred from
+   * which optional fields it lacks. That is the sentinel: it is the only
+   * pre-sentinel signal obtainable without touching the past, and it is
+   * unrepairable by construction. Do NOT default it on read — `parsed.rv ?? 0`
+   * is a backfill performed on every load, invisible in the file itself.
+   *
+   * NOT monotone in file order: several writers share this file, so an older
+   * bridge can append an un-levelled row after a newer one. It therefore says
+   * nothing about time, and a reader must never render it as "pre-dates" —
+   * that exact conflation shipped once already for `actor`.
+   */
+  rv?: number;
+  /**
+   * The run this decision belongs to: `taskId`, verbatim, as written to
+   * `runs.jsonl` / `run_steps.jsonl`. Never `seq`, which is a per-instance
+   * counter over a shared file and collides (255 distinct across 272 live rows).
+   *
+   * At `rv >= 1` its absence is a WRITER DEFECT, not a state. Every gate
+   * decision happens inside a run — `buildWorkerAutonomyGate` is wired from one
+   * site, inside `fireYamlRecipe` — so "recorded, and legitimately had no run"
+   * cannot occur here. A scheme that could express it would only be able to
+   * express it falsely.
+   */
+  correlationId?: string;
+
   /** Monotonic sequence id within the process — stable for pagination. */
   seq: number;
   /** ms epoch when the decision was made. */
@@ -146,9 +175,23 @@ export interface GateDecisionRecord {
   gatePolicyVersion: string;
 }
 
+/**
+ * The current record level. Bump ONLY when adding a new guarantee, and never
+ * retroactively: a row already on disk claiming level N is a permanent
+ * assertion about what level N meant when it was written, so widening level N
+ * later falsifies rows nobody can go back and fix.
+ */
+export const GATE_RECORD_VERSION = 1 as const;
+
+/**
+ * `rv` is excluded, and that exclusion is load-bearing rather than tidy. If a
+ * caller could supply it, the level would be a claim made by whoever happened
+ * to call `record()` rather than by the writer that actually knows which fields
+ * it stamps — and the whole scheme rests on the level being trustworthy.
+ */
 export type RecordGateDecisionInput = Omit<
   GateDecisionRecord,
-  "seq" | "decidedAt"
+  "seq" | "decidedAt" | "rv"
 >;
 
 const DEFAULT_MEMORY_CAP = 2_000;
@@ -224,6 +267,51 @@ export function isGateAction(v: unknown): v is GateDecisionRecord["action"] {
   return (
     typeof v === "string" && (GATE_ACTIONS as readonly string[]).includes(v)
   );
+}
+
+/**
+ * What a row says about the run it belongs to.
+ *
+ * Three states, and the point of the whole scheme is that they stay distinct:
+ *
+ *  - `unclaimed` — the row carries no record level. Written before the level
+ *    existed, OR by a bridge still running older code. Those two are NOT
+ *    distinguishable and must never be conflated in prose: say "no claim
+ *    recorded", never "pre-dates".
+ *  - `linked`    — the row names its run.
+ *  - `defect`    — the row claims a level that guarantees a correlation id and
+ *    does not carry one. A writer bug, not a state of the world.
+ *
+ * There is deliberately NO "recorded, legitimately had no run". Every gate
+ * decision happens inside a run, so such a row would be a false claim, and a
+ * vocabulary that can express something untrue eventually will.
+ *
+ * `runExists` is optional because most callers have no run log to hand. Absent,
+ * a row that names a run is reported `linked` WITHOUT checking — "we did not
+ * look" is not the same as "we looked and found it", so the caller is never
+ * told more than was actually verified.
+ */
+export type CorrelationState =
+  | { state: "unclaimed" }
+  | { state: "linked"; taskId: string }
+  | { state: "unresolved"; taskId: string }
+  | { state: "defect"; rv: number };
+
+export function correlationOf(
+  rec: Pick<GateDecisionRecord, "rv" | "correlationId">,
+  runExists?: (taskId: string) => boolean,
+): CorrelationState {
+  if (typeof rec.rv !== "number" || !Number.isFinite(rec.rv)) {
+    return { state: "unclaimed" };
+  }
+  const id = rec.correlationId;
+  if (typeof id === "string" && id.length > 0) {
+    if (!runExists) return { state: "linked", taskId: id };
+    return runExists(id)
+      ? { state: "linked", taskId: id }
+      : { state: "unresolved", taskId: id };
+  }
+  return { state: "defect", rv: rec.rv };
 }
 
 export class WorkerGateDecisionLog {
@@ -309,6 +397,19 @@ export class WorkerGateDecisionLog {
     const rec: GateDecisionRecord = {
       seq: this.seq,
       decidedAt: this.now(),
+      rv: GATE_RECORD_VERSION,
+      // `correlationId` and `workspaceId` are copied EXPLICITLY because this
+      // literal enumerates every field rather than spreading `input`. That is a
+      // deliberate shape — a spread would let an unvetted caller field reach
+      // disk — but it also means a new field is silently dropped until someone
+      // adds a line here.
+      //
+      // `workspaceId` was exactly that: `recipeOrchestration` has stamped it on
+      // every decision since the workspace-tag work landed, and this literal
+      // never copied it, so 0 of 272 rows in the live ledger carry one. The tag
+      // was wired end to end and thrown away by the last step.
+      ...(input.correlationId && { correlationId: input.correlationId }),
+      ...(input.workspaceId && { workspaceId: input.workspaceId }),
       recipeName,
       workerId,
       toolName,


### PR DESCRIPTION
Closes the correlation-id sentinel — the irreversible decision reserved for the repo owner, settled by adversarial review before it was taken. **Last of the evidence-spine preconditions; the four before it (#1515, #1516, #1517, #1518) all turned out to be live defects rather than mere prerequisites.**

## Why a sentinel at all

The governance ledgers do not join. `taskId` is on `runs.jsonl` and `run_steps.jsonl` and nowhere else, so a gate decision has never been able to name the run that produced it.

Stamping one onto new rows is irreversible in a specific way. `workerGateDecisionLog` is doctrine that **absence is meaningful and never backfilled** — *"nobody recorded this"* must stay distinguishable from *"we do not know"*. Start stamping without a sentinel and every existing row becomes an orphan indistinguishable from a future row that legitimately had no run. Two different absences collapse into one, permanently.

So: `rv`, a writer-stamped record level. Its **absence** is the sentinel — the row makes no claim, and nothing may be inferred from what it lacks.

## The decision is narrower than it looked

There is deliberately **no** "recorded, and legitimately had no run" state. `buildWorkerAutonomyGate` is wired from exactly one site, inside `fireYamlRecipe`, so every gate decision happens inside a run. `correlationId` is registered as never-legitimately-absent: at `rv >= 1` its absence is a **writer defect**, not a state of the world.

A vocabulary able to express "no run" could only ever express it falsely — which is what killed the `correlationId: null` design the survey started from.

`correlationId` is the run's `taskId`, never `seq`. `seq` is a per-instance counter over a file several bridges write: **255 distinct values across 272 live rows.**

## Three things, landing together

A sentinel that ships ahead of what it certifies is a row carrying a claim its writer cannot honour. So:

1. **One shared `ApprovalRequestInput`.** The shape was declared *three* times, structurally identically. `runTaskId` on it is **required**, so adding an approval call site is a compile error until it names its run. Both existing sites failed to compile until fixed — the property working.
2. **The plumbing.** `yamlRunner` hoists its run id to one const. `chainedRunner` carries it on the existing `StepExecutionContext` — `executeChainedStep` has exactly one production caller, inside the function where the id is minted, so no signature change was needed.
3. **`rv` + `correlationId`**, stamped by the writer. `RecordGateDecisionInput` excludes `rv`, and that exclusion is load-bearing: a caller-suppliable level is a claim by whoever called `record()`, not by the writer that knows what it stamps.

## Found en route, and separately real

**`record()` was silently dropping `workspaceId`.** It builds its row as an explicit literal rather than spreading `input` — deliberate, so an unvetted caller field cannot reach disk, but it means a new field is dropped until someone adds a line.

`recipeOrchestration` has stamped a workspace tag on **every** decision since that work landed, and the writer threw it away every time: **0 of 272 rows in the live ledger carry one.** Now copied, with a field-census test that would have caught it the day it shipped.

## Mutations

| mutation | outcome |
|---|---|
| don't stamp `rv` | 4 fail |
| default it on read (`parsed.rv ?? 0`) | 1 fails |
| drop `correlationId` | 3 fail |
| drop `workspaceId` | 1 fails |
| let a caller supply `rv` | 1 fails |
| unmodified | 10 pass |

The `?? 0` case matters most: it is a backfill performed invisibly on every load, which no assertion over the file itself can see.

Everything is asserted through the real writer to real disk and read back by a **fresh instance**. Asserting on `record()`'s return value passes with the fields missing from the file entirely — exactly how `workspaceId` went unnoticed.

Also corrects a TODO in `approvalQueue` that would have directed the next engineer to populate an approval→run link keyed on `seq`.

Suite: 10,349 green. `typecheck`, `typecheck:tests:core`, and the audit gates all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)