### PR TITLE
feat(workers): failing a completion contract cost a worker nothing

### DIFF
--- a/dashboard/public/schema/recipe.v1.json
+++ b/dashboard/public/schema/recipe.v1.json
@@ -325,6 +325,7 @@
                       "gemini",
                       "anthropic",
                       "codex",
+                      "subprocess",
                       "local"
                     ],
                     "description": "Driver for agent execution"
@@ -798,6 +799,7 @@
                                     "gemini",
                                     "anthropic",
                                     "codex",
+                                    "subprocess",
                                     "local"
                                   ],
                                   "description": "Driver for agent execution"
@@ -1270,6 +1272,7 @@
                                         "gemini",
                                         "anthropic",
                                         "codex",
+                                        "subprocess",
                                         "local"
                                       ],
                                       "description": "Driver for agent execution"
@@ -1617,7 +1620,7 @@
     },
     "expect": {
       "type": "object",
-      "description": "Optional assertions for mocked recipe tests",
+      "description": "Completion contract for the run: assertions that must hold once the recipe finishes. Evaluated on EVERY non-testMode run, not only under `recipe test` — a violation is persisted as `assertionFailures` and withholds the run's trust evidence from the owning worker.",
       "properties": {
         "stepsRun": {
           "type": "number",

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -66,7 +66,7 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   "assertions for mocked recipe tests" — the docs and the code disagreed about what it was,
   which is the likeliest reason zero shipped templates use it. Measured before landing: 0 of
   1404 runs in the live log carry `assertionFailures`, so nothing is re-labelled
-  retroactively. (#TBD)
+  retroactively. (#1520)
 
 - 2026-08-25 `feat/correlation-sentinel` — the correlation-id sentinel (the irreversible
   decision doc 13 §4.1 reserved for the owner), settled by adversarial review first. A gate

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,20 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-25 `feat/completion-contracts-trust` — bind the completion contract that already
+  runs. `evaluateExpect` has evaluated `recipe.expect` on every non-testMode flat run since
+  it shipped and persisted `assertionFailures`; the trust fold read `step.status` only, so a
+  run that violated its declared postcondition still folded each ok step as earned trust —
+  failing a completion contract cost a worker nothing. The run-level signal now reaches
+  `foldOutcome`, which WITHHOLDS every step of a violating run (neither credit nor penalty,
+  the same shape as the agent-step and unkeyable-action rules). Passed as a parameter to
+  `foldOutcome` rather than checked in `ingestRun`, so the live dial and the cold-start
+  backtest cannot drift. Also corrects the schema description, which called the feature
+  "assertions for mocked recipe tests" — the docs and the code disagreed about what it was,
+  which is the likeliest reason zero shipped templates use it. Measured before landing: 0 of
+  1404 runs in the live log carry `assertionFailures`, so nothing is re-labelled
+  retroactively. (#TBD)
+
 - 2026-08-25 `feat/correlation-sentinel` — the correlation-id sentinel (the irreversible
   decision doc 13 §4.1 reserved for the owner), settled by adversarial review first. A gate
   decision now carries `rv` (writer-stamped record level) and `correlationId` (the run's

--- a/schemas/recipe.v1.json
+++ b/schemas/recipe.v1.json
@@ -288,6 +288,7 @@
                       "gemini",
                       "anthropic",
                       "codex",
+                      "subprocess",
                       "local"
                     ],
                     "description": "Driver for agent execution"
@@ -723,6 +724,7 @@
                                     "gemini",
                                     "anthropic",
                                     "codex",
+                                    "subprocess",
                                     "local"
                                   ],
                                   "description": "Driver for agent execution"
@@ -1156,6 +1158,7 @@
                                         "gemini",
                                         "anthropic",
                                         "codex",
+                                        "subprocess",
                                         "local"
                                       ],
                                       "description": "Driver for agent execution"
@@ -1478,7 +1481,7 @@
     },
     "expect": {
       "type": "object",
-      "description": "Optional assertions for mocked recipe tests",
+      "description": "Completion contract for the run: assertions that must hold once the recipe finishes. Evaluated on EVERY non-testMode run, not only under `recipe test` — a violation is persisted as `assertionFailures` and withholds the run's trust evidence from the owning worker.",
       "properties": {
         "stepsRun": {
           "type": "number",

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -946,7 +946,12 @@ function generateRecipeSchema(
       },
       expect: {
         type: "object",
-        description: "Optional assertions for mocked recipe tests",
+        description:
+          "Completion contract for the run: assertions that must hold once " +
+          "the recipe finishes. Evaluated on EVERY non-testMode run, not only " +
+          "under `recipe test` — a violation is persisted as " +
+          "`assertionFailures` and withholds the run's trust evidence from " +
+          "the owning worker.",
         properties: {
           stepsRun: {
             type: "number",

--- a/src/workers/__tests__/runWorkerShadow.test.ts
+++ b/src/workers/__tests__/runWorkerShadow.test.ts
@@ -179,6 +179,43 @@ describe("loadWorkerTrustForRecipe (live-gate entry)", () => {
     expect(board.some((b) => b.classKey.startsWith("fs-write"))).toBe(true);
   });
 
+  it("withholds a run that violated its completion contract, end to end from disk", () => {
+    // Wiring test, not a logic test: `assertionFailures` is persisted on the run
+    // and has to survive readRuns -> RunRecord.contractViolated -> foldOutcome
+    // before it can reach the dial. Asserting the fold rule alone would pass
+    // with the disk mapping deleted, which is how the rule was absent for its
+    // whole life while `evaluateExpect` ran on every non-testMode run.
+    const log = new RecipeRunLog({ dir });
+    log.appendDirect({
+      taskId: "broke-its-contract",
+      recipeName: "release-notes",
+      trigger: "recipe",
+      status: "done", // the RUN reports done — only the postcondition failed
+      createdAt: 0,
+      doneAt: 1,
+      durationMs: 1,
+      assertionFailures: [
+        {
+          assertion: "outputs.notes",
+          expected: "release notes",
+          actual: undefined,
+          message: "expected release notes, got none",
+        },
+      ],
+      stepResults: [
+        { id: "s1", tool: "editText", status: "ok", durationMs: 1 },
+        { id: "s2", tool: "getGitStatus", status: "ok", durationMs: 1 },
+      ],
+    });
+    const trust = loadWorkerTrustForRecipe("release-notes", {
+      workersDir: WORKERS_DIR,
+      patchworkDir: dir,
+    });
+    expect(trust).not.toBeNull();
+    // Two ok steps that would each be evidence in the control case above.
+    expect(trust?.store.board("release-notes-worker")).toEqual([]);
+  });
+
   it("retains a worker's evidence behind >500 unrelated runs (ring not just window)", () => {
     // Stronger than the 150-run case: the in-memory ring defaults to 500, so a
     // worker run buried behind >500 unrelated runs would be evicted from the ring

--- a/src/workers/__tests__/shadowObserver.test.ts
+++ b/src/workers/__tests__/shadowObserver.test.ts
@@ -426,3 +426,53 @@ describe("foldOutcome — junk demotes immediately, before the durability window
     ).toEqual({ fold: true, good: false });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Completion contracts: a run that violated its declared postcondition
+// ---------------------------------------------------------------------------
+
+describe("completion contracts (run-level expect)", () => {
+  it("withholds every step of a run whose completion contract failed", () => {
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    // Three ok steps a worker would normally earn full credit for — but the
+    // run as a whole violated its declared postcondition.
+    obs.ingestRun({
+      recipeName: "release-notes",
+      at: 1000,
+      contractViolated: true,
+      steps: [
+        { tool: "file.write", status: "ok" },
+        { tool: "file.write", status: "ok" },
+        { tool: "file.write", status: "ok" },
+      ],
+    });
+    const [report] = obs.report();
+    const evidence = report!.board.reduce((n, r) => n + r.observations, 0);
+    expect(evidence).toBe(0);
+  });
+
+  it("still folds the same steps when the contract held", () => {
+    const obs = new WorkerShadowObserver([release], { cfg: CFG });
+    obs.ingestRun({
+      recipeName: "release-notes",
+      at: 1000,
+      steps: [
+        { tool: "file.write", status: "ok" },
+        { tool: "file.write", status: "ok" },
+        { tool: "file.write", status: "ok" },
+      ],
+    });
+    const [report] = obs.report();
+    const evidence = report!.board.reduce((n, r) => n + r.observations, 0);
+    expect(evidence).toBe(3);
+  });
+
+  it("withholds a failed step too — neither credit nor penalty", () => {
+    const decision = foldOutcome(
+      { tool: "file.write", status: "error" },
+      1000,
+      { windowMs: DEFAULT_DURABILITY_WINDOW_MS, contractViolated: true },
+    );
+    expect(decision.fold).toBe(false);
+  });
+});

--- a/src/workers/backtest.ts
+++ b/src/workers/backtest.ts
@@ -118,6 +118,11 @@ export function backtestWorker(
       // foldOutcome): junk → bad, unknown/null → withheld, pending → withheld.
       const decision = foldOutcome(step, run.at, {
         now,
+        // Run-level completion contract — carried so the backtest labels an
+        // outcome exactly as the live dial does. Omitting it here is the
+        // flat-vs-chained divergence in miniature: a rule that covers one of
+        // two callers looks correct in both and agrees in neither.
+        ...(run.contractViolated && { contractViolated: true }),
         windowMs,
         outcomeStore: opts.outcomeStore,
       });

--- a/src/workers/runWorkerShadow.ts
+++ b/src/workers/runWorkerShadow.ts
@@ -111,6 +111,11 @@ function readRuns(patchworkDir: string, recipeNames?: string[]): RunRecord[] {
     return rows.map((r) => ({
       recipeName: r.recipeName,
       at: r.doneAt ?? r.startedAt ?? r.createdAt,
+      // The run's completion contract (`recipe.expect`). Persisted on the run
+      // since `evaluateExpect` shipped and never read by the dial, so a run
+      // that violated its declared postcondition still folded its ok steps as
+      // earned trust. Withholding, not penalising — see `foldOutcome`.
+      ...((r.assertionFailures?.length ?? 0) > 0 && { contractViolated: true }),
       steps: (r.stepResults ?? []).map((s) => ({
         tool: s.tool,
         status: s.status,

--- a/src/workers/shadowObserver.ts
+++ b/src/workers/shadowObserver.ts
@@ -37,6 +37,19 @@ export interface RunRecord {
   recipeName: string;
   /** epoch ms */
   at: number;
+  /**
+   * The run violated its declared completion contract — `recipe.expect`
+   * produced at least one assertion failure (`RecipeRun.assertionFailures`).
+   *
+   * A completion contract is a postcondition on the JOB, not on any one step,
+   * so it is recorded here and not per-step. Until this field existed the fold
+   * could not see it at all: `evaluateExpect` has run on every non-testMode
+   * flat run since it shipped, persisted its failures, and the dial read
+   * `step.status` only — so a run that demonstrably did not finish its job
+   * still folded each ok step as positive trust evidence. Failing a
+   * postcondition cost a worker nothing.
+   */
+  contractViolated?: boolean;
   steps: Array<{
     tool?: string;
     status: "ok" | "skipped" | "error";
@@ -150,6 +163,7 @@ type FoldStep = Pick<RunRecord["steps"][number], "tool" | "status" | "output">;
  * junk check runs BEFORE the durability window — a human rejection is durable
  * evidence of failure the moment it lands, so it demotes instantly, like any
  * outright failure; only confirmed/unknown successes wait out the window):
+ *   - run violated its completion contract     → WITHHOLD (every step; see below)
  *   - agent (reasoning) step, ANY status       → WITHHOLD (not a durable action; see below)
  *   - failure (status ≠ ok)                    → count, good:false (durable evidence of failure)
  *   - success, no `now`                        → count, good:true (back-compat status-only)
@@ -179,9 +193,36 @@ export function foldOutcome(
      * success carrying no URL earned full trust with no confirmation.
      */
     strictOutcomeJoin?: boolean;
+    /**
+     * The enclosing run violated its declared completion contract. Passed in
+     * from `RunRecord.contractViolated` by every caller, so the run-level
+     * signal reaches the ONE place that decides how an outcome is labelled.
+     *
+     * Deliberately a parameter here rather than a check in `ingestRun`: the
+     * live dial and the cold-start backtest both fold through this function
+     * precisely so they cannot disagree about what an outcome means, and a
+     * run-level rule applied in only one of them is that drift by another
+     * name.
+     */
+    contractViolated?: boolean;
   },
 ): FoldDecision {
   if (!step.tool) return { fold: false };
+  // The run did not finish the job it declared. Withhold EVERY step in it —
+  // neither credit nor penalty — which is the same shape as the agent-step and
+  // unkeyable-action rules below: evidence that cannot be tied to a completed
+  // job is not credited, and is not turned into a penalty either.
+  //
+  // Withheld rather than counted `good: false` on purpose. A completion
+  // contract is an assertion about the RUN, so reading it as a verdict on each
+  // individual action would demote steps that did exactly what they were asked,
+  // and would hand anyone writing a sloppy `expect` a way to destroy a worker's
+  // earned trust. Withholding only ever removes evidence, so it can never
+  // widen autonomy by accident.
+  //
+  // Placed FIRST, ahead of the failure branch, so the rule is the whole run
+  // without exception. A branch that ran earlier would be a path around it.
+  if (opts.contractViolated) return { fold: false };
   // An agent (reasoning) step is NOT evidence, in either direction.
   //
   // The gate already decided this: `decideWorkerAction` carves `agent` out
@@ -385,6 +426,7 @@ export class WorkerShadowObserver {
         now: this.now,
         windowMs: this.durabilityWindowMs,
         outcomeStore: this.outcomeStore,
+        ...(run.contractViolated && { contractViolated: true }),
       });
       if (!decision.fold) continue;
       this.store.apply(


### PR DESCRIPTION
## What

`recipe.expect` is a postcondition on the **job**. `evaluateExpect` has computed it on every non-`testMode` flat run since it shipped ([yamlRunner.ts:2837](../blob/main/src/recipes/yamlRunner.ts#L2837)), and `assertionFailures` is persisted on the run and rendered in the dashboard.

The trust fold never saw it. `RunRecord` had no such field, so `ingestRun` folded `step.status` alone — a run that demonstrably did not finish its job still credited each ok step as earned trust. **Failing a completion contract cost a worker nothing.**

## The rule

The run-level signal now reaches `foldOutcome`, which **withholds every step of a violating run** — neither credit nor penalty.

That is the same shape as the agent-step and unkeyable-action rules already there: evidence that cannot be tied to a completed job is not credited, and is not turned into a verdict on the individual actions either. Reading it as a penalty would demote steps that did exactly what they were asked, and would hand anyone writing a sloppy `expect` a way to destroy a worker's earned trust. Withholding only ever removes evidence, so it can never widen autonomy by accident.

Passed as a `foldOutcome` **parameter** rather than checked inside `ingestRun`. That function exists so the live dial and the cold-start backtest cannot disagree about what an outcome means, and a run-level rule applied in one of two callers is that drift by another name.

## Blast radius — measured, not assumed

**0 of 1404** runs across the live run log and its rotation archive carry `assertionFailures`. Nothing is re-labelled retroactively; the mechanism is corrected *before* anything depends on it.

## Also

- The schema called this *"Optional assertions for mocked recipe tests"* while the code evaluated it on every real run. The docs and the code disagreed about what the feature **is**, which is the likeliest reason no shipped template uses it.
- Regenerating the schema picked up **pre-existing drift**: `subprocess` was missing from the committed driver enum. Additive, and it is a real driver. Called out rather than folded in silently.

## Verification

- Failing test first: 2 of 3 new tests failed before the change, the control (contract held → 3 observations) passed — so the harness could see evidence and the failures were real.
- **Mutation check on the wiring**: removing the `readRuns` disk mapping fails the end-to-end test; `grep` confirmed the mutation applied (0 occurrences) before running. Asserting the fold rule alone passes with `readRuns` reverted, which is how this rule was absent for its whole life.
- `typecheck`, `typecheck:tests:core`, `schema:check` (0 breaking), lsp-tools, in-flight, business-content all green. 1793 tests across `src/workers` + `src/recipes` pass.

## Deliberately not in scope

- Teaching `patchwork halts` to see it ([haltCategory.ts:243](../blob/main/src/recipes/haltCategory.ts#L243) requires `status==='error'`).
- Shipping a template that uses `expect`.
- Run-level `expect` for the chained runner, which has none (step-level only).
- The `when:`-guard semantics — a step `expect` is *skipped, not failed*, when its step did not run. That is a decision, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)