### PR TITLE
feat(privacy): a boundary receipt could not name the run that produced it

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -64,6 +64,19 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   operator-data warning `runstore compare` and `privacy receipts` carry. The wiring test
   is the load-bearing one: mutating the flag lookup makes `--rows` fall silently back to
   the summary while all six formatter tests still pass. (#1523)
+- 2026-08-25 `feat/boundary-receipt-correlation` — the second ledger joins. A boundary
+  receipt now carries `correlationId` (the run's `taskId`, never `seq`) behind an `rv`
+  record level, the protocol #1519 settled for the gate ledger. `recipeName` said WHICH
+  recipe to fix; an hourly recipe still produced receipts no reader could tell apart.
+  The reason this was not a one-liner: one write site, four dep-builders, and
+  `buildChainedDeps` is called from three places BEFORE `runChainedRecipe` computes its
+  run id — so the chained path had nothing to pass. Closed with a cell created by
+  `buildChainedDeps` and filled by the runner, rather than filling the field on the flat
+  path only, which would have repeated the `stepId` this same ledger once declared, never
+  supplied, and removed rather than wired. Also fixes the READER, which enumerated fields
+  explicitly and would have dropped both new ones — #1517's defect, caught before shipping
+  rather than after. Sentinel: a receipt is never written outside a run, so absence of
+  `correlationId` at `rv >= 1` is a writer defect, not a state. (#TBD)
 
 - 2026-08-25 `feat/completion-contracts-trust` — bind the completion contract that already
   runs. `evaluateExpect` has evaluated `recipe.expect` on every non-testMode flat run since

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -76,7 +76,7 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   supplied, and removed rather than wired. Also fixes the READER, which enumerated fields
   explicitly and would have dropped both new ones — #1517's defect, caught before shipping
   rather than after. Sentinel: a receipt is never written outside a run, so absence of
-  `correlationId` at `rv >= 1` is a writer defect, not a state. (#TBD)
+  `correlationId` at `rv >= 1` is a writer defect, not a state. (#1522)
 
 - 2026-08-25 `feat/completion-contracts-trust` — bind the completion contract that already
   runs. `evaluateExpect` has evaluated `recipe.expect` on every non-testMode flat run since

--- a/src/privacy/__tests__/receiptCorrelation.test.ts
+++ b/src/privacy/__tests__/receiptCorrelation.test.ts
@@ -1,0 +1,302 @@
+/**
+ * A boundary receipt has to name the RUN that produced it.
+ *
+ * `recipeName` (#1474) tells an auditor which of 80 recipes to go and fix. It
+ * does not tell them WHICH RUN — and a recipe that dispatches hourly produces a
+ * receipt an hour that are indistinguishable from one another. The gate ledger
+ * solved this in #1519: `correlationId` is the run's `taskId`, never `seq`,
+ * which collided 255-of-272 on the live log.
+ *
+ * ## Why the field could not simply be added
+ *
+ * There is ONE write site (`recordBoundaryDecisionFn` in `yamlRunner`), reached
+ * from four dep-builders. Three sit inside `runYamlRecipe`, where `runTaskId`
+ * is already a local const. The fourth is `buildChainedDeps`, and it is called
+ * from `recipeOrchestration`, `replayRun` and `commands/recipe` BEFORE
+ * `runChainedRecipe` computes its `runTaskId` — so at deps-build time the
+ * chained path has no run id to give.
+ *
+ * Filling the field on the flat path only would repeat the `stepId` this exact
+ * ledger already declared, never supplied, and REMOVED rather than wired: a
+ * declared-but-empty field tells a reader that attribution exists when it does
+ * not. A half-covered join is worse than no join, because its absences stop
+ * meaning one thing.
+ *
+ * So both runners are covered here, and the chained case is the load-bearing
+ * test. A logic test on `record()` alone passes with every line of plumbing
+ * deleted.
+ *
+ * ## The sentinel
+ *
+ * Every receipt is written from inside a run: all three chained call sites
+ * dispatch into `runChainedRecipe`, which always computes a `runTaskId`, and
+ * the flat sites are inside `runYamlRecipe`. So — exactly as the gate ledger
+ * concluded — "recorded, legitimately no run" CANNOT occur here. A missing
+ * `correlationId` at `rv >= 1` is a WRITER DEFECT, not a state, and absence of
+ * `rv` means the row pre-dates this and is never backfilled.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  BOUNDARY_RECORD_VERSION,
+  BoundaryReceiptLog,
+} from "../boundaryReceiptLog.js";
+import { summariseBoundaryReceipts } from "../boundaryReceipts.js";
+
+let dir: string;
+let home: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(os.tmpdir(), "receipt-corr-"));
+  home = join(dir, "home");
+  mkdirSync(home, { recursive: true });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** The ENFORCING key. Reaching for `privacy.shadow` here would prove nothing. */
+function writeConfig(): void {
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify({
+      privacy: {
+        destinations: {
+          "test-local": {
+            type: "local",
+            classifications: ["public", "internal", "personal"],
+            drivers: ["local"],
+          },
+          "test-remote": {
+            type: "remote",
+            classifications: ["public", "internal"],
+            drivers: ["claude", "claude-code", "subprocess"],
+          },
+        },
+      },
+    }),
+  );
+}
+
+type Receipt = {
+  rv?: number;
+  correlationId?: string;
+  recipeName?: string;
+  decision?: string;
+};
+
+function readReceipts(): Receipt[] {
+  try {
+    return readFileSync(join(home, "boundary_receipts.jsonl"), "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Receipt);
+  } catch {
+    return [];
+  }
+}
+
+async function withHome<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.PATCHWORK_HOME;
+  // PATCHWORK_HOME, not a spy on `os.homedir`: a namespace spy misses named
+  // imports and has previously let a test write to the developer's real store.
+  process.env.PATCHWORK_HOME = home;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.PATCHWORK_HOME;
+    else process.env.PATCHWORK_HOME = prev;
+  }
+}
+
+describe("the receipt ledger's record level", () => {
+  it("stamps `rv` on every receipt, with no way for a caller to forge it", () => {
+    const log = new BoundaryReceiptLog({ dir });
+    const r = log.record({
+      decision: "ALLOW",
+      classification: "public",
+      destinationId: "d",
+      destinationType: "local",
+      reason: "ok",
+      correlationId: "yaml:x:1",
+    });
+    expect(r.rv).toBe(BOUNDARY_RECORD_VERSION);
+    expect(r.correlationId).toBe("yaml:x:1");
+  });
+
+  it("omits `correlationId` rather than writing an empty one", () => {
+    const log = new BoundaryReceiptLog({ dir });
+    const r = log.record({
+      decision: "ALLOW",
+      classification: "public",
+      destinationId: "d",
+      destinationType: "local",
+      reason: "ok",
+    });
+    // Absent, never `""` or null: a reader must be able to tell "no claim" from
+    // "claim broken", and an empty string is neither.
+    expect("correlationId" in r).toBe(false);
+    expect(r.rv).toBe(BOUNDARY_RECORD_VERSION);
+  });
+});
+
+describe("a boundary receipt names the run that produced it", () => {
+  it("FLAT runner: the receipt's correlationId is the run's taskId", async () => {
+    writeConfig();
+    await withHome(async () => {
+      const { runYamlRecipe } = await import("../../recipes/yamlRunner.js");
+      await runYamlRecipe(
+        {
+          name: "flat-corr",
+          trigger: { type: "manual" },
+          steps: [
+            {
+              id: "think",
+              agent: {
+                prompt: "hi",
+                driver: "claude-code",
+                data_policy: { classification: "personal" },
+              },
+            },
+          ],
+        } as never,
+        {
+          testMode: true,
+          logDir: dir,
+          readFile: () => {
+            throw new Error("nope");
+          },
+          writeFile: () => {},
+          appendFile: () => {},
+          mkdir: () => {},
+          gitLogSince: () => "",
+          gitStaleBranches: () => "",
+          getDiagnostics: () => "",
+          claudeFn: async () => "ok",
+        } as never,
+      );
+    });
+
+    const receipts = readReceipts();
+    expect(receipts.length).toBeGreaterThan(0);
+    for (const r of receipts) {
+      expect(r.rv).toBe(BOUNDARY_RECORD_VERSION);
+      // The flat runner's identity shape. Never `seq`.
+      expect(r.correlationId).toMatch(/^yaml:flat-corr:\d+$/);
+    }
+  });
+
+  it("CHAINED runner: the receipt's correlationId is the run's taskId", async () => {
+    writeConfig();
+    await withHome(async () => {
+      const { runChainedRecipe } = await import(
+        "../../recipes/chainedRunner.js"
+      );
+      const { buildChainedDeps } = await import("../../recipes/yamlRunner.js");
+      const runnerDeps = {
+        testMode: true,
+        logDir: dir,
+        readFile: () => {
+          throw new Error("nope");
+        },
+        writeFile: () => {},
+        appendFile: () => {},
+        mkdir: () => {},
+        gitLogSince: () => "",
+        gitStaleBranches: () => "",
+        getDiagnostics: () => "",
+        claudeFn: async () => "ok",
+        claudeCodeFn: async () => "ok",
+      } as never;
+      const chainedDeps = buildChainedDeps(
+        runnerDeps,
+        undefined,
+        "chained-corr",
+      );
+      await runChainedRecipe(
+        {
+          name: "chained-corr",
+          steps: [
+            {
+              id: "think",
+              agent: {
+                prompt: "hi",
+                driver: "claude-code",
+                data_policy: { classification: "personal" },
+              },
+            },
+          ],
+        } as never,
+        {
+          env: {},
+          maxConcurrency: 1,
+          maxDepth: 3,
+          dryRun: false,
+        } as never,
+        chainedDeps,
+      );
+    });
+
+    const receipts = readReceipts();
+    // The load-bearing assertion. This is the path whose deps are built before
+    // the run id exists; without the plumbing it produces receipts with no
+    // correlationId while the flat test above still passes.
+    expect(receipts.length).toBeGreaterThan(0);
+    for (const r of receipts) {
+      expect(r.rv).toBe(BOUNDARY_RECORD_VERSION);
+      expect(r.correlationId).toMatch(/^chained:chained-corr:\d+$/);
+    }
+  });
+});
+
+describe("the reader carries the join through", () => {
+  it("does not drop `rv` / `correlationId` on the way out", () => {
+    // A ledger whose reader discards the field is the #1517 defect: rows
+    // written correctly and dropped by every reader, so the feature is
+    // invisible and looks unbuilt. `view()` enumerates fields explicitly, which
+    // is the right shape and the reason a new field needs a line adding.
+    const log = new BoundaryReceiptLog({ dir: home });
+    log.record({
+      decision: "LOCAL_ONLY",
+      classification: "personal",
+      destinationId: "test-remote",
+      destinationType: "remote",
+      reason: "nope",
+      correlationId: "yaml:reader-check:7",
+    });
+
+    const summary = summariseBoundaryReceipts({ dir: home });
+    const row = summary.recent[0];
+    expect(row?.correlationId).toBe("yaml:reader-check:7");
+    expect(row?.rv).toBe(BOUNDARY_RECORD_VERSION);
+  });
+
+  it("leaves a pre-protocol row's absent `rv` absent, never defaulted to 0", () => {
+    // The sentinel. `parsed.rv ?? 0` on read is a backfill performed invisibly
+    // on every load, and it would make a row that made no claim
+    // indistinguishable from one that claimed level 0.
+    writeFileSync(
+      join(home, "boundary_receipts.jsonl"),
+      `${JSON.stringify({
+        seq: 1,
+        at: 1,
+        decision: "ALLOW",
+        classification: "public",
+        destinationId: "d",
+        destinationType: "local",
+        reason: "old row",
+      })}\n`,
+    );
+    const summary = summariseBoundaryReceipts({ dir: home });
+    expect(summary.recorded).toBe(1);
+    expect("rv" in (summary.recent[0] ?? {})).toBe(false);
+  });
+});

--- a/src/privacy/boundaryReceiptLog.ts
+++ b/src/privacy/boundaryReceiptLog.ts
@@ -32,6 +32,36 @@ import path from "node:path";
 
 import type { BoundaryDecision, Classification } from "./dataPolicy.js";
 
+/**
+ * Writer-stamped record level for this ledger.
+ *
+ * `rv: N` asserts: for every field registered as known from level <= N, that
+ * field is present, or its registered not-applicable condition held. Same
+ * protocol the gate ledger adopted in #1519, and adopted here for the same
+ * reason — a reader must be able to tell "no claim was made" from "a claim was
+ * made and honoured" from "a claim was made and broken".
+ *
+ * ## Field registry
+ *
+ * - `correlationId` (level 1) — **never legitimately absent.** Every receipt is
+ *   written from inside a run: the flat write sites are inside `runYamlRecipe`,
+ *   and all three chained dep-builders dispatch into `runChainedRecipe`, which
+ *   always computes a `runTaskId`. So there is no "decided outside any run"
+ *   state for this ledger to represent. Its absence at `rv >= 1` is a WRITER
+ *   DEFECT, not a state.
+ *
+ * ## What absence of `rv` means, and why it is never repaired
+ *
+ * A row with no `rv` pre-dates this protocol. That is the sentinel, and it is
+ * unrepairable by construction: there is no backfill, and `parsed.rv ?? 0` on
+ * read would be a backfill performed invisibly on every load. Never default it.
+ *
+ * Do NOT read "no `rv`" as "old". A stale bridge writing un-`rv`'d rows today
+ * is indistinguishable from a row written months ago — the mistake already
+ * found shipped elsewhere and fixed as #1515.
+ */
+export const BOUNDARY_RECORD_VERSION = 1;
+
 /** Clip so a runaway reason cannot bloat the audit log. */
 const MAX_REASON = 500;
 const DEFAULT_MEMORY_CAP = 500;
@@ -39,6 +69,22 @@ const DEFAULT_MEMORY_CAP = 500;
 export interface BoundaryReceipt {
   seq: number;
   at: number;
+  /**
+   * Writer-stamped record level — see `BOUNDARY_RECORD_VERSION`. Optional on
+   * the TYPE because rows written before this protocol have none, and that
+   * absence is the sentinel. Always present on rows this constructor writes.
+   */
+  rv?: number;
+  /**
+   * The run this decision belongs to — the run log's `taskId`, never `seq`.
+   *
+   * `seq` is a per-INSTANCE counter over a file eight construction sites write,
+   * so it collides across concurrent bridges (255 distinct over 272 rows when
+   * measured on the gate ledger). A join key that collides is not a join key.
+   *
+   * Registered as never legitimately absent at `rv >= 1`.
+   */
+  correlationId?: string;
   decision: BoundaryDecision;
   /** What the step DECLARED it was carrying. */
   classification: Classification;
@@ -65,6 +111,12 @@ export interface BoundaryReceipt {
 }
 
 export interface RecordBoundaryReceiptInput {
+  /**
+   * The run this decision belongs to (`taskId`). Deliberately NOT `rv` — the
+   * record level is the WRITER's claim about its own completeness, so a caller
+   * that could set it could forge it.
+   */
+  correlationId?: string;
   decision: BoundaryDecision;
   classification: Classification;
   categories?: string[];
@@ -145,6 +197,8 @@ export class BoundaryReceiptLog {
     const receipt: BoundaryReceipt = {
       seq: ++this.seq,
       at: this.now(),
+      rv: BOUNDARY_RECORD_VERSION,
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
       decision: input.decision,
       classification: input.classification,
       destinationId: input.destinationId,

--- a/src/privacy/boundaryReceipts.ts
+++ b/src/privacy/boundaryReceipts.ts
@@ -62,6 +62,14 @@ export function boundaryReceiptsPath(dir?: string): string {
 export interface BoundaryReceiptView {
   seq?: number;
   at: number;
+  /**
+   * Writer-stamped record level, carried through verbatim. ABSENT means the row
+   * pre-dates the protocol — never defaulted to 0 on read, which would be a
+   * backfill performed invisibly on every load.
+   */
+  rv?: number;
+  /** The run that produced this receipt (`taskId`, never `seq`). */
+  correlationId?: string;
   decision: BoundaryDecision;
   classification: Classification;
   categories?: string[];
@@ -132,6 +140,15 @@ function view(r: Record<string, unknown>): BoundaryReceiptView | null {
   const dt = str("destinationType");
   return {
     ...(typeof r.seq === "number" ? { seq: r.seq } : {}),
+    // `rv` and `correlationId` are copied EXPLICITLY because this literal
+    // enumerates every field rather than spreading `r`. That shape is
+    // deliberate — a spread would let arbitrary file content reach a caller —
+    // but it also means a newly-written field is silently dropped until someone
+    // adds a line here, which is precisely how a `forbid` decision came to be
+    // written correctly and discarded by every reader (#1517), and how
+    // `workspaceId` was thrown away by the last step of its own pipeline.
+    ...(typeof r.rv === "number" ? { rv: r.rv } : {}),
+    ...(str("correlationId") ? { correlationId: str("correlationId") } : {}),
     at: r.at,
     decision: r.decision as BoundaryDecision,
     classification: (str("classification") ?? "internal") as Classification,

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -242,6 +242,16 @@ function toChainedAgentResult(v: string | AgentResult): AgentResult {
 }
 
 export interface ExecutionDeps {
+  /**
+   * Cell holding this run's identity (`taskId`), created by `buildChainedDeps`
+   * and filled by `runChainedRecipe` at the top of the run.
+   *
+   * It exists because the deps are built before the run id does: the three
+   * callers of `buildChainedDeps` construct deps and only then dispatch here.
+   * Dispatch-time writers (the boundary receipt ledger) read `.current`, by
+   * which point it is set.
+   */
+  runTaskIdRef?: { current?: string };
   executeTool: ToolExecutor;
   executeAgent: AgentExecutor;
   loadNestedRecipe: (
@@ -1245,6 +1255,12 @@ export async function runChainedRecipe(
   ) as "cron" | "webhook" | "recipe";
   const taskIdPrefix = options.taskIdPrefix ?? "chained";
   const runTaskId = `${taskIdPrefix}:${recipe.name}:${runStartedAt}`;
+  // Publish this run's identity to dispatch-time writers (the boundary receipt
+  // ledger). `buildChainedDeps` ran BEFORE this line — its callers build deps
+  // and only then dispatch here — so the id cannot be passed as a value and is
+  // handed over through the shared cell it created. Same const the run log
+  // writes below, never a second expression.
+  if (deps.runTaskIdRef) deps.runTaskIdRef.current = runTaskId;
   let runSeq: number | undefined;
   if (depth === 0 && options.runLog) {
     try {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1636,7 +1636,7 @@ export async function runYamlRecipe(
         ...(providerOptions && { providerOptions }),
         ...(dataPolicy !== undefined && { boundary: { dataPolicy } }),
       },
-      buildAgentExecutorDeps(stepDeps, deps),
+      buildAgentExecutorDeps(stepDeps, deps, undefined, runTaskId),
     );
     runBudget.reconcile(
       // Prefer the driver executeAgent actually resolved+ran; fall back to
@@ -1740,7 +1740,7 @@ export async function runYamlRecipe(
           boundary: { dataPolicy: input.dataPolicy },
         }),
       },
-      buildAgentExecutorDeps(stepDeps, deps),
+      buildAgentExecutorDeps(stepDeps, deps, undefined, runTaskId),
     );
     runBudget.reconcile(
       agentReturn.servedBy?.driver ?? input.driver ?? "auto",
@@ -2318,7 +2318,7 @@ export async function runYamlRecipe(
                 boundary: { dataPolicy: agentCfg.data_policy },
               }),
             },
-            buildAgentExecutorDeps(stepDeps, deps),
+            buildAgentExecutorDeps(stepDeps, deps, undefined, runTaskId),
           );
           agentResult = agentReturn.text;
           runBudget.reconcile(
@@ -3648,6 +3648,17 @@ function buildAgentExecutorDeps(
       disallowedTools?: string[];
     },
   ) => Promise<string | AgentResult>,
+  /**
+   * The run this dispatch belongs to (`taskId`, never `seq`) — stamped onto the
+   * boundary receipt so an auditor can join a refusal to the run that caused it.
+   *
+   * A parameter rather than a `StepDeps` field because the CHAINED path builds
+   * its deps before `runChainedRecipe` computes the id, so there is nothing to
+   * put on `StepDeps` at construction time. The chained caller resolves it from
+   * the `runTaskIdRef` cell on its own deps at dispatch time, by which point
+   * the run has started; the flat caller passes its local const directly.
+   */
+  runTaskId?: string,
 ): AgentExecutorDeps {
   const claudeCliFn = claudeCodeFnOverride ?? stepDeps.claudeCodeFn;
   return {
@@ -3720,6 +3731,11 @@ function buildAgentExecutorDeps(
           // dispatch was refused and not which of 80 recipes to go and fix.
           // `BoundaryReceipt` has declared the field the whole time.
           ...(stepDeps.recipeName && { recipeName: stepDeps.recipeName }),
+          // The run this refusal belongs to. `recipeName` says WHICH recipe to
+          // go and fix; without this an hourly recipe produces a receipt an
+          // hour that no reader can tell apart. Never `seq` — it collides
+          // across concurrent bridges.
+          ...(runTaskId && { correlationId: runTaskId }),
           decision: r.decision as BoundaryDecisionValue,
           classification: r.classification as ClassificationValue,
           destinationId: r.destinationId,
@@ -4250,6 +4266,17 @@ export function buildChainedDeps(
    */
   recipeName?: string,
 ): import("./chainedRunner.js").ExecutionDeps {
+  // A cell for this run's identity, handed back on the returned deps and filled
+  // in by `runChainedRecipe` once it computes `runTaskId`.
+  //
+  // It has to be a cell rather than a value because of an ordering problem no
+  // call site can fix: this function runs in `recipeOrchestration`, `replayRun`
+  // and `commands/recipe` BEFORE the runner those callers then dispatch to has
+  // computed an id. Returning the cell — rather than asking each caller to make
+  // one — is deliberate: a caller that forgot would emit receipts asserting
+  // `rv >= 1` while omitting a field registered as never legitimately absent,
+  // which is a false claim made silently at the one site nobody re-checks.
+  const runTaskIdRef: { current?: string } = {};
   const stepDeps = resolveStepDeps(
     runnerDeps,
     recipeName !== undefined ? { recipeName } : undefined,
@@ -4355,7 +4382,14 @@ export function buildChainedDeps(
           enforceSandbox: true,
         }),
       },
-      buildAgentExecutorDeps(stepDeps, runnerDeps, claudeCodeFnOverride),
+      buildAgentExecutorDeps(
+        stepDeps,
+        runnerDeps,
+        claudeCodeFnOverride,
+        // Read at DISPATCH time, not build time — by now `runChainedRecipe` has
+        // computed and published the run's `taskId`.
+        runTaskIdRef.current,
+      ),
     );
   };
 
@@ -4464,6 +4498,8 @@ export function buildChainedDeps(
     executeTool,
     executeAgent,
     loadNestedRecipe,
+    // The cell `runChainedRecipe` fills with this run's `taskId`. See above.
+    runTaskIdRef,
     // Tier-1 #4 (audit 2026-06-22): forward the approval gate into the chained
     // path so it is no longer flat-only. Undefined when the bridge didn't
     // inject one (approvalGate == "off") — the chained gate then no-ops.


### PR DESCRIPTION
The second ledger joins the spine. Follows the `rv` protocol #1519 settled for the gate ledger.

## What was missing

`recipeName` (#1474) tells an auditor which of 80 recipes to go and fix. It does not say **which run** — so a recipe dispatching hourly produced receipts no reader could tell apart. `correlationId` is the run's `taskId`, **never `seq`**, which collided 255-of-272 where it was measured.

## Why this was not a one-liner

There is **one** write site, reached from **four** dep-builders. Three sit inside `runYamlRecipe`, where `runTaskId` is already a local const. The fourth is `buildChainedDeps` — called from `recipeOrchestration`, `replayRun` and `commands/recipe` **before** `runChainedRecipe` computes its id. At deps-build time the chained path had nothing to pass.

Closed with a cell created by `buildChainedDeps` and filled by the runner at the top of the run, read at dispatch time.

The alternative — filling the field on the flat path only — would have repeated the `stepId` **this exact ledger** declared, never supplied, and removed rather than wired, on the grounds that a declared-but-empty field tells a reader that attribution exists when it does not. A half-covered join is worse than no join, because its absences stop meaning one thing.

## The reader would have dropped it

`view()` enumerates fields explicitly rather than spreading. That is the right shape — a spread would let arbitrary file content reach a caller — but it means a newly-written field is discarded until someone adds a line.

Without that line this ships as #1517 did: **rows written correctly and dropped by every reader**, so the feature looks unbuilt. Caught before shipping rather than after, and there is a test pinning it.

## The sentinel, registered rather than assumed

Every receipt is written from inside a run: the flat sites are in `runYamlRecipe`, and all three chained callers dispatch into `runChainedRecipe`, which always computes an id. So — exactly as doc-level analysis concluded for the gate ledger — **"recorded, legitimately no run" cannot occur here**. A missing `correlationId` at `rv >= 1` is a WRITER DEFECT, not a state.

Absence of `rv` means the row pre-dates the protocol and is never backfilled. The reader must not default it: `?? 0` on read is a backfill performed invisibly on every load. There is a test for that too.

`rv` is stamped by the writer and absent from `RecordBoundaryReceiptInput`, so a caller cannot forge the claim.

## Verification — by mutation, not assertion

- **Removing the chained publish leaves the flat test passing and fails only the chained one.** That is precisely the half-covered join the test exists to prevent, and it is why the chained case is the load-bearing test rather than the logic test on `record()`, which passes with every line of plumbing deleted.
- Removing the reader's `correlationId` line fails the reader test.
- Both mutations were confirmed applied by `grep` before running.
- `typecheck`, `typecheck:tests:core`, business-content and lsp-tools gates green. **1904 tests** across `src/privacy`, `src/recipes` and `src/workers` pass.

## Not in scope

`privacy_shadow.jsonl`, `outcome-log.jsonl`, `permission_exercises.jsonl` and `worker_trust/` still carry no correlation id. Each needs its own sentinel answer — the question "can this row legitimately have no run?" has a different answer per ledger and must not be assumed from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)