### PR TITLE
feat(butler): you could not look before you leap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,14 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `connect [list]` / `connect <vendor>` / `connect test <vendor>` / `connect disconnect <vendor>` — Connector authorisation from the terminal: list connectors and their status, start an OAuth flow or store a PAT, health-probe one, or revoke one. Documented in `--help` since it shipped and absent from this file until now.
 - `butler <shadow|observe|ingest|promote>` — The errand-outcome channel.
   - `shadow [--json]` — summarise the graded shadow ledger.
+  - `shadow --rows [N] [--json]` — print the INDIVIDUAL graded rows, evidence-bearing
+    ones first. The summary's closing advice is to check a sample against the real
+    errands before promoting, and until this existed there was no way to: `--json` gave
+    the same aggregate, and the only caller of `readShadowRows` was
+    `promoteShadowOutcomes` — the irreversible step. The one piece of code that read the
+    rows was the one that acts on them. Output is **operator data**, like `runstore
+    compare` and `privacy receipts`: it names real installed recipes and carries external
+    record ids, so quote a measurement and never paste the rows.
   - `observe [--file <path>] [--stale-after-days N]` — discover errands from the run log, look up live task state, then grade. **Operator path only**: a recipe step runs AS the worker, and a worker that could observe its own filings could report them completed.
   - `ingest [--file <path>|-]` — grade a JSON array of observations.
   - `promote [--dry-run]` — fold confirmed/junk grades into the trust ledger. Requires `PATCHWORK_FLAG_BUTLER_PROMOTE=1`; reports without writing otherwise, because promotion is one-way (trust replay absorbs a folded row into a checkpoint that deleting the row does not undo).

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -63,7 +63,7 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   the row does not undo). Adds `shadow --rows [N]`, evidence-bearing rows first, with the
   operator-data warning `runstore compare` and `privacy receipts` carry. The wiring test
   is the load-bearing one: mutating the flag lookup makes `--rows` fall silently back to
-  the summary while all six formatter tests still pass. (#TBD)
+  the summary while all six formatter tests still pass. (#1523)
 
 - 2026-08-25 `feat/completion-contracts-trust` — bind the completion contract that already
   runs. `evaluateExpect` has evaluated `recipe.expect` on every non-testMode flat run since

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,17 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-25 `feat/butler-shadow-rows` — `butler shadow` closes by telling the operator to
+  "check a sample against the real errands they describe" before promoting, and gave them
+  no way to do it: the summary was all `--json` printed, and `readShadowRows` had exactly
+  ONE caller in the tree — `promoteShadowOutcomes`, the irreversible step. The only code
+  that read the individual rows was the one that acts on them, which matters because
+  promotion is one-way (trust replay absorbs a folded row into a checkpoint that deleting
+  the row does not undo). Adds `shadow --rows [N]`, evidence-bearing rows first, with the
+  operator-data warning `runstore compare` and `privacy receipts` carry. The wiring test
+  is the load-bearing one: mutating the flag lookup makes `--rows` fall silently back to
+  the summary while all six formatter tests still pass. (#TBD)
+
 - 2026-08-25 `feat/completion-contracts-trust` — bind the completion contract that already
   runs. `evaluateExpect` has evaluated `recipe.expect` on every non-testMode flat run since
   it shipped and persisted `assertionFailures`; the trust fold read `step.status` only, so a

--- a/src/butler/__tests__/shadowRowReview.test.ts
+++ b/src/butler/__tests__/shadowRowReview.test.ts
@@ -1,0 +1,175 @@
+/**
+ * You cannot look before you leap.
+ *
+ * `formatShadowSummary` ends by telling the operator, in its own words, to
+ * "check a sample against the real errands they describe — a disposition that
+ * reads plausibly in aggregate can still be wrong on every individual row".
+ *
+ * There was no way to do that. `patchwork butler shadow` printed the aggregate
+ * and `--json` printed the same aggregate as JSON. The row readers existed and
+ * were exported — and `readShadowRows` had exactly ONE caller in the tree:
+ * `promoteShadowOutcomes`, the irreversible step. The only code that read the
+ * individual rows was the one that acts on them.
+ *
+ * That matters more here than it would elsewhere because promotion is one-way:
+ * trust replay absorbs a folded row into a checkpoint that deleting the row
+ * does not undo. "Review before promoting" is the whole safety property of the
+ * shadow phase, and it was advice with no surface behind it.
+ *
+ * These tests pin the review surface, not the wording.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { formatShadowRows } from "../outcomeIngester.js";
+import type { ShadowOutcomeRow } from "../outcomeShadowLog.js";
+
+function row(over: Partial<ShadowOutcomeRow> = {}): ShadowOutcomeRow {
+  return {
+    ref: "example.create_task:abc-1",
+    disposition: "unknown",
+    reason: "open-recent",
+    gradedAt: Date.UTC(2026, 7, 20, 9, 0, 0),
+    recipe: "example-errand",
+    wouldCountAsEvidence: false,
+    ...over,
+  };
+}
+
+describe("formatShadowRows", () => {
+  it("says so plainly when there is nothing to review", () => {
+    const out = formatShadowRows([]);
+    expect(out).toMatch(/no graded rows/i);
+  });
+
+  it("leads with the rows that would actually move the dial", () => {
+    // 1 consequential row buried behind 3 withheld ones is the real ledger's
+    // shape (8 of 9 withheld when this was written). A reviewer opening this
+    // is deciding whether to promote, so the rows promotion would ACT on have
+    // to be the ones they see first — not sorted under a wall of `unknown`.
+    const rows = [
+      row({ ref: "example.create_task:w-1" }),
+      row({ ref: "example.create_task:w-2" }),
+      row({
+        ref: "example.create_task:real-1",
+        disposition: "confirmed",
+        reason: "completed",
+        wouldCountAsEvidence: true,
+      }),
+      row({ ref: "example.create_task:w-3" }),
+    ];
+    const out = formatShadowRows(rows);
+    const idxEvidence = out.indexOf("real-1");
+    const idxWithheld = out.indexOf("w-1");
+    expect(idxEvidence).toBeGreaterThan(-1);
+    expect(idxWithheld).toBeGreaterThan(-1);
+    expect(idxEvidence).toBeLessThan(idxWithheld);
+  });
+
+  it("marks which rows would become evidence, since that is the decision", () => {
+    const out = formatShadowRows([
+      row({
+        ref: "example.create_task:real-1",
+        disposition: "confirmed",
+        reason: "completed",
+        wouldCountAsEvidence: true,
+      }),
+      row({ ref: "example.create_task:w-1" }),
+    ]);
+    // The distinction is carried in WORDS, not only by ordering or colour — a
+    // reviewer piping this to a file must still be able to tell them apart.
+    expect(out).toMatch(/would become evidence/i);
+    expect(out).toMatch(/withheld/i);
+  });
+
+  it("honours a limit and says what it did not show", () => {
+    // A silent truncation reads as "that was all of them", which is exactly the
+    // wrong impression to give someone deciding whether a sample is
+    // representative.
+    const rows = Array.from({ length: 10 }, (_, i) =>
+      row({ ref: `example.create_task:r-${i}` }),
+    );
+    const out = formatShadowRows(rows, { limit: 3 });
+    expect(out).toMatch(/r-0/);
+    expect(out).not.toMatch(/r-9/);
+    expect(out).toMatch(/7 more|not shown/i);
+  });
+
+  it("warns that the output is operator data", () => {
+    // Same rule as `runstore compare` and `privacy receipts`: these rows name
+    // real installed recipes and carry external record ids for the operator's
+    // own errands. A measurement may be quoted; the rows may not leave the
+    // machine.
+    const out = formatShadowRows([row()]);
+    expect(out).toMatch(/never paste|do not paste|operator data/i);
+  });
+
+  it("renders a row with no recipe without inventing one", () => {
+    // `recipe` is optional on the row. Printing a placeholder that looks like a
+    // recipe name would attribute an errand to something that did not file it.
+    const out = formatShadowRows([row({ recipe: undefined })]);
+    expect(out).toMatch(/example\.create_task:abc-1/);
+    expect(out).not.toMatch(/undefined/);
+  });
+});
+
+/**
+ * The tests above prove the RULE. This proves it is actually WIRED.
+ *
+ * Demonstrated by mutation while writing it: replacing the `--rows` lookup in
+ * `index.ts` with `-1` makes the flag fall silently back to the summary — the
+ * exact pre-existing behaviour — and all six unit tests above still pass. A
+ * formatter nobody can reach is the same as no formatter.
+ */
+describe("butler shadow --rows is reachable from the CLI", () => {
+  const distIndex = path.resolve(
+    import.meta.dirname ?? path.dirname(new URL(import.meta.url).pathname),
+    "../../../dist/index.js",
+  );
+
+  function runCli(args: string[], home: string): string {
+    const r = spawnSync(process.execPath, [distIndex, "butler", ...args], {
+      encoding: "utf8",
+      // An ISOLATED home. The real ledger holds the operator's actual errands,
+      // and a test that read it would put real task refs into CI output.
+      env: { ...process.env, PATCHWORK_HOME: home },
+    });
+    return `${r.stdout}${r.stderr}`;
+  }
+
+  it("prints rows rather than the aggregate", () => {
+    if (!existsSync(distIndex)) {
+      throw new Error("dist/index.js not found — run npm run build first");
+    }
+    const home = mkdtempSync(path.join(os.tmpdir(), "butler-rows-"));
+    try {
+      writeFileSync(
+        path.join(home, "butler_outcome_shadow.jsonl"),
+        `${JSON.stringify({
+          ref: "example.create_task:synthetic-1",
+          disposition: "confirmed",
+          reason: "completed",
+          gradedAt: Date.UTC(2026, 7, 20),
+          recipe: "synthetic-errand",
+          wouldCountAsEvidence: true,
+        })}\n`,
+      );
+
+      const rows = runCli(["shadow", "--rows"], home);
+      // The row itself, which the summary never prints.
+      expect(rows).toContain("example.create_task:synthetic-1");
+      expect(rows).toMatch(/would become evidence/i);
+
+      // And the summary is untouched by the new flag.
+      const summary = runCli(["shadow"], home);
+      expect(summary).not.toContain("example.create_task:synthetic-1");
+      expect(summary).toMatch(/graded row/i);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/butler/outcomeIngester.ts
+++ b/src/butler/outcomeIngester.ts
@@ -48,6 +48,7 @@ import {
   appendShadowOutcome,
   firstSeenByRef,
   SHADOW_REASONS,
+  type ShadowOutcomeRow,
   type ShadowSummary,
   summariseShadowLog,
   UNOBSERVED_REASONS,
@@ -155,6 +156,89 @@ export function ingestErrandOutcomes(
  * next to the number, because the number's whole purpose is to be weighed
  * against it.
  */
+/**
+ * Render the individual graded rows for review.
+ *
+ * `formatShadowSummary` ends by telling the operator to check a sample against
+ * the real errands before promoting. Until this existed there was no way to do
+ * that: `butler shadow` printed the aggregate, `--json` printed the same
+ * aggregate, and the only caller of `readShadowRows` in the tree was
+ * `promoteShadowOutcomes` — the irreversible step. The single piece of code
+ * that read the rows was the one that acts on them.
+ *
+ * That is worth more than a missing flag because promotion is ONE-WAY: trust
+ * replay absorbs a folded row into a checkpoint that deleting the row does not
+ * undo. "Review before promoting" is the entire safety property of the shadow
+ * phase, and it was advice with no surface behind it.
+ *
+ * Rows that WOULD become evidence are printed first, because those are the only
+ * ones promotion acts on — sorting them under a wall of withheld `unknown` rows
+ * (8 of 9 on the real ledger when this was written) buries the decision.
+ *
+ * ## Output is operator data
+ *
+ * Same rule as `runstore compare` and `privacy receipts`: rows name real
+ * installed recipes and carry external record ids for the operator's own
+ * errands. Quote a measurement; never paste the rows.
+ */
+export function formatShadowRows(
+  rows: readonly ShadowOutcomeRow[],
+  opts: { limit?: number } = {},
+): string {
+  if (rows.length === 0) {
+    return [
+      "[butler-shadow] no graded rows to review.",
+      "",
+      "  Nothing has been measured, so there is nothing to check and nothing",
+      "  may be promoted.",
+    ].join("\n");
+  }
+
+  // Evidence-bearing rows first, then most recently graded. Within the two
+  // groups the order is the ledger's own, so a reviewer can find a row again.
+  const ordered = [...rows].sort((a, b) => {
+    if (a.wouldCountAsEvidence !== b.wouldCountAsEvidence) {
+      return a.wouldCountAsEvidence ? -1 : 1;
+    }
+    return a.gradedAt - b.gradedAt;
+  });
+
+  const limit = opts.limit ?? ordered.length;
+  const shown = ordered.slice(0, Math.max(0, limit));
+  const hidden = ordered.length - shown.length;
+  const evidence = rows.filter((r) => r.wouldCountAsEvidence).length;
+
+  const lines = shown.map((r) => {
+    const when = new Date(r.gradedAt).toISOString().replace(".000Z", "Z");
+    // In words, not by colour or position alone — a reviewer piping this to a
+    // file must still be able to tell the two apart.
+    const mark = r.wouldCountAsEvidence
+      ? "would become evidence"
+      : "withheld            ";
+    // `recipe` is optional. No placeholder that reads like a name: attributing
+    // an errand to something that did not file it is worse than saying nothing.
+    const who = r.recipe ? ` recipe=${r.recipe}` : "";
+    return `  ${when}  ${mark}  ${r.disposition.padEnd(9)} ${r.reason.padEnd(18)} ${r.ref}${who}`;
+  });
+
+  return [
+    `[butler-shadow] ${rows.length} graded row(s); ${evidence} would become evidence.`,
+    "",
+    ...lines,
+    ...(hidden > 0
+      ? [
+          "",
+          `  ${hidden} more row(s) not shown — raise --rows to see them. A sample`,
+          "  that looks representative because it was truncated is not one.",
+        ]
+      : []),
+    "",
+    "  These rows are OPERATOR DATA, not a diagnostic blob: they name real",
+    "  installed recipes and carry external record ids. Quote a measurement if",
+    "  you need to; never paste the rows into an issue, a PR or a fixture.",
+  ].join("\n");
+}
+
 export function formatShadowSummary(s: ShadowSummary): string {
   if (s.total === 0) {
     return [

--- a/src/index.ts
+++ b/src/index.ts
@@ -5577,6 +5577,45 @@ if (process.argv[2] === "butler") {
       );
 
       if (args[0] === "shadow") {
+        // `--rows` is the review surface the summary's own closing advice
+        // requires ("check a sample against the real errands they describe").
+        // Before it existed the only caller of `readShadowRows` was
+        // `promoteShadowOutcomes` — the irreversible step — so the one piece of
+        // code that read the rows was the one that acts on them.
+        const rowsIdx = args.findIndex((a) => a === "--rows");
+        if (rowsIdx !== -1) {
+          const { formatShadowRows } = await import(
+            "./butler/outcomeIngester.js"
+          );
+          const { readShadowRows } = await import(
+            "./butler/outcomeShadowLog.js"
+          );
+          const rows = readShadowRows();
+          // `--rows` alone shows every row; `--rows N` caps it. A bad N is
+          // rejected rather than silently treated as "all", which would show
+          // more of the operator's data than they asked for.
+          const raw = args[rowsIdx + 1];
+          let limit: number | undefined;
+          if (raw !== undefined && !raw.startsWith("--")) {
+            const n = Number(raw);
+            if (!Number.isInteger(n) || n <= 0) {
+              process.stderr.write(
+                `[butler-shadow] --rows expects a positive integer, got "${raw}"\n`,
+              );
+              process.exit(1);
+            }
+            limit = n;
+          }
+          if (args.includes("--json")) {
+            const out = limit === undefined ? rows : rows.slice(0, limit);
+            process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+          } else {
+            process.stdout.write(
+              `${formatShadowRows(rows, limit === undefined ? {} : { limit })}\n`,
+            );
+          }
+          process.exit(0);
+        }
         const summary = summariseShadowLog();
         if (args.includes("--json")) {
           process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);


### PR DESCRIPTION
## The gap

`formatShadowSummary` closes by telling the operator, in its own words:

> check a sample against the real errands they describe — a disposition that reads plausibly in aggregate can still be wrong on every individual row

**There was no way to do that.** `butler shadow` printed the aggregate; `--json` printed the same aggregate as JSON. The row readers existed and were exported — and `readShadowRows` had exactly **one** caller in the tree: `promoteShadowOutcomes`, the irreversible step.

The single piece of code that read the individual rows was the one that acts on them.

That is worse than a missing flag, because promotion is **one-way**: trust replay absorbs a folded row into a checkpoint that deleting the row does not undo. Reviewing before promoting is the entire safety property of the shadow phase, and it was advice with no surface behind it.

## What lands

`patchwork butler shadow --rows [N] [--json]`.

- **Evidence-bearing rows print first.** They are the only ones promotion acts on, and on the real ledger they are the minority — 1 of 9 when this was written. Sorting them under a wall of withheld `unknown` rows buries the decision being made.
- **The evidence/withheld distinction is in words**, not position or colour alone, so it survives being piped to a file.
- **A truncated view says how many it did not show.** A silent truncation reads as "that was all of them" to exactly the person trying to judge whether a sample is representative.
- **A bad `--rows` argument exits non-zero** rather than falling back to "all", which would print more of the operator's data than they asked for.

## Operator data, and it says so

Same rule `runstore compare` and `privacy receipts` carry: rows name real installed recipes and hold external record ids for the operator's own errands. Quote a measurement; never paste the rows. The output carries that warning itself.

## Verification

Run against the **live ledger**, not just unit tests — counts cross-check against the existing summary (9 rows, 1 confirmed), and exit codes were checked directly rather than through a pipe.

**The CLI wiring test is the load-bearing one.** Mutating the flag lookup in `index.ts` to `-1` makes `--rows` fall silently back to the summary — the exact pre-existing behaviour — while **all six formatter tests still pass**. A formatter nobody can reach is the same as no formatter. Its fixture writes to an isolated `PATCHWORK_HOME`, because a test that read the real ledger would put real task refs into CI output.

`typecheck`, `typecheck:tests:core`, business-content and lsp-tools gates green; 192 tests across `src/butler` pass.

## Scope

Touches **zero files under `src/recipes/`** — `src/butler/` has no imports from it. Butler subsystem, CLI, and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)