### PR TITLE
feat(recipes): an artifact could not cite the run that produced it

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,18 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-25 `feat/run-id-in-templates` — a published artifact could not cite the run that
+  produced it. The flat runner injected `date`/`time`/`YYYY`… into the template context but
+  never the run's own identity, and `{{taskId}}` failed template-ref lint outright, so an
+  audit pack or reconciliation workbook had no way to name its own run — the ledger knew
+  the `taskId`, the document could not reach it. Same join the gate ledger and boundary
+  receipts now carry, and the same rule: `taskId`, never `seq`. `runTaskId` was declared
+  ~140 lines BELOW the context, so it is lifted rather than recomputed — two expressions
+  that look identical drift on the first edit to either. Injected AFTER the env/seed
+  spreads, unlike `date`, so a recipe variable cannot shadow it: an absent id is
+  recoverable, a confidently wrong one is not. Verified end to end — the artifact's id and
+  the run-log row's `taskId` are identical strings. (#TBD)
+
 - 2026-08-25 `feat/butler-shadow-rows` — `butler shadow` closes by telling the operator to
   "check a sample against the real errands they describe" before promoting, and gave them
   no way to do it: the summary was all `--json` printed, and `readShadowRows` had exactly

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -64,7 +64,7 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   that look identical drift on the first edit to either. Injected AFTER the env/seed
   spreads, unlike `date`, so a recipe variable cannot shadow it: an absent id is
   recoverable, a confidently wrong one is not. Verified end to end — the artifact's id and
-  the run-log row's `taskId` are identical strings. (#TBD)
+  the run-log row's `taskId` are identical strings. (#1524)
 
 - 2026-08-25 `feat/butler-shadow-rows` — `butler shadow` closes by telling the operator to
   "check a sample against the real errands they describe" before promoting, and gave them

--- a/src/recipes/__tests__/runIdInTemplates.test.ts
+++ b/src/recipes/__tests__/runIdInTemplates.test.ts
@@ -1,0 +1,112 @@
+/**
+ * An artifact could not cite the run that produced it.
+ *
+ * The flat runner injects `date`, `time` and the `YYYY`/`ISO_NOW` family into
+ * the template context, but never the run's own identity. So a recipe that
+ * publishes a document — an audit pack, a reconciliation workbook, a report
+ * somebody signs — had no way to print the run it came from. The run ledger
+ * knows the `taskId`; the artifact could not reach it.
+ *
+ * That is the same join this codebase has been closing everywhere else: a gate
+ * decision now carries `correlationId`, and so does a boundary receipt. Both
+ * are the run's `taskId`, never `seq` — `seq` is a per-instance counter over a
+ * file several construction sites write, so it collides across concurrent
+ * bridges. An artifact naming a colliding id is worse than one naming none.
+ *
+ * `{{taskId}}` previously failed template-ref lint outright ("Unknown template
+ * reference"), so nothing could depend on it and this is purely additive.
+ *
+ * ## Why it is NOT overridable
+ *
+ * `date` and the `YYYY` family sit BEFORE the `envCtx` / `seedContext` spreads,
+ * so a recipe variable of the same name wins. `taskId` deliberately sits after
+ * them. It is an attribution, not a convenience: a recipe that shadowed it
+ * would publish a document naming a run that did not produce it, which is the
+ * "never write a claim you cannot honour" rule in a different costume. A false
+ * attribution is worse than an absent one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runYamlRecipe } from "../yamlRunner.js";
+
+const BASE_DEPS = {
+  testMode: true,
+  readFile: () => {
+    throw new Error("no reads in this test");
+  },
+  writeFile: () => {},
+  appendFile: () => {},
+  mkdir: () => {},
+  gitLogSince: () => "",
+  gitStaleBranches: () => "",
+  getDiagnostics: () => "",
+  claudeFn: async () => "ok",
+};
+
+/** Capture what a `file.write` step would have written. */
+function captureRun(content: string): Promise<string[]> {
+  const written: string[] = [];
+  return runYamlRecipe(
+    {
+      name: "run-id-probe",
+      trigger: { type: "manual" },
+      allowWrites: ["file.write"],
+      steps: [
+        {
+          id: "w",
+          tool: "file.write",
+          path: "~/.patchwork/probe.txt",
+          content,
+        },
+      ],
+    } as never,
+    {
+      ...BASE_DEPS,
+      writeFile: (_p: string, c: string) => {
+        written.push(c);
+      },
+    } as never,
+  ).then(() => written);
+}
+
+describe("{{taskId}} — an artifact can name its own run", () => {
+  it("renders the run's taskId, in the run log's own shape", async () => {
+    const written = await captureRun("run={{taskId}}");
+    expect(written).toHaveLength(1);
+    // `yaml:<recipe>:<startedAt>` — the shape `runs.jsonl` records, so the
+    // value is a real join key rather than a decorative string.
+    expect(written[0]).toMatch(/^run=yaml:run-id-probe:\d+$/);
+  });
+
+  it("is the SAME id the run log records, not a second expression", async () => {
+    // The failure this guards is subtle: computing the id twice from `now()`
+    // looks identical and drifts the moment either expression changes. Two
+    // renders inside one run must agree with each other.
+    const written = await captureRun("a={{taskId}} b={{taskId}}");
+    const m = written[0]?.match(/^a=(\S+) b=(\S+)$/);
+    expect(m).not.toBeNull();
+    expect(m?.[1]).toBe(m?.[2]);
+  });
+
+  it("passes template-ref lint, which it previously failed", async () => {
+    const { validateRecipeDefinition } = await import("../validation.js");
+    const result = validateRecipeDefinition({
+      name: "lint-probe",
+      trigger: { type: "manual" },
+      allowWrites: ["file.write"],
+      steps: [
+        {
+          id: "w",
+          tool: "file.write",
+          path: "~/.patchwork/x.txt",
+          content: "{{taskId}}",
+        },
+      ],
+    } as never);
+    const refIssues = result.issues.filter(
+      (i) => i.level === "error" && /taskId/.test(i.message),
+    );
+    expect(refIssues).toEqual([]);
+  });
+});

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -1351,6 +1351,9 @@ function validateTemplateReferences(
     "YYYY-MM",
     "YYYY-MM-DD",
     "ISO_NOW",
+    // The run's own identity (`yaml:<recipe>:<startedAt>`), injected by the
+    // flat runner so a published artifact can cite the run that produced it.
+    "taskId",
     "HH",
     "MM",
     "SS",

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -1266,6 +1266,25 @@ export async function runYamlRecipe(
   // redaction. See PR body / docs/recipe-feature-investigation-2026-06-05.md.
   const secretKeys = new Set<string>(Object.keys(envCtx));
 
+  const recipeStartedAt = now.getTime();
+  /**
+   * This run's identity, minted ONCE.
+   *
+   * The same expression was written out twice (the run-log `startRun` and the
+   * terminal `appendDirect`). Both were in this function over this const, so
+   * they could not diverge — but a join key computed independently in two
+   * places is one edit away from a spine that breaks silently, and there are
+   * now FOUR readers of it: those two, the approval seam, and `{{taskId}}` in
+   * the template context below.
+   *
+   * Lifted above the context construction for that last reader. It was
+   * declared ~140 lines further down, after `ctx` was already built, so the
+   * only way to expose it to templates without moving it would have been to
+   * recompute it — two expressions that look identical and drift on the first
+   * edit to either.
+   */
+  const runTaskId = `yaml:${recipe.name}:${recipeStartedAt}`;
+
   const iso = now.toISOString();
   const ctx: RunContext = {
     date: iso.slice(0, 10),
@@ -1282,6 +1301,12 @@ export async function runYamlRecipe(
     SS: iso.slice(17, 19),
     ...envCtx,
     ...seedContext,
+    // AFTER the spreads, unlike `date` and the YYYY family, which a recipe
+    // variable may deliberately override. This one is an attribution, not a
+    // convenience: a recipe that shadowed it would publish a document naming a
+    // run that did not produce it. An absent id is recoverable; a confidently
+    // wrong one is not.
+    taskId: runTaskId,
   };
 
   // Merge the recipe's declared allowWrites with any caller-supplied
@@ -1404,17 +1429,6 @@ export async function runYamlRecipe(
   // as in flight. Only when a long-lived `runLog` is provided (bridge path);
   // CLI runs fall back to `appendDirect` at end via the existing logDir
   // path. Skip in test mode.
-  const recipeStartedAt = now.getTime();
-  /**
-   * This run's identity, minted ONCE.
-   *
-   * The same expression was written out twice (the run-log `startRun` and the
-   * terminal `appendDirect`). Both were in this function over this const, so
-   * they could not diverge — but a join key computed independently in two
-   * places is one edit away from a spine that breaks silently, and there are
-   * now three readers of it rather than two.
-   */
-  const runTaskId = `yaml:${recipe.name}:${recipeStartedAt}`;
   const recipeTriggerKind =
     (recipe.trigger as { type?: string } | undefined)?.type ?? "manual";
   const yamlTriggerKind = (


### PR DESCRIPTION
## The gap

The flat runner injects `date`, `time` and the `YYYY`/`ISO_NOW` family into the template context — and never the run's own identity. `{{taskId}}` failed template-ref lint outright.

So a recipe that publishes a document — an audit pack, a reconciliation workbook, anything somebody signs — had **no way to name the run behind it**. The ledger knew the `taskId`; the artifact could not reach it. This surfaced in practice: a finance workbook's Sign-off tab had a blank run id, with the note that closing it "needs a runner change rather than a recipe one".

## The rule

`taskId`, **never `seq`** — same as the gate ledger's `correlationId` and the boundary receipt's. `seq` is a per-instance counter over a file several construction sites write, so it collides across concurrent bridges. An artifact naming a colliding id is worse than one naming none.

## Two decisions worth reviewing

**Lifted, not recomputed.** `runTaskId` was declared ~140 lines *below* the context construction, so exposing it to templates meant lifting it or computing it twice. Its own doc comment already called it "minted ONCE" precisely because two identical-looking expressions drift on the first edit to either. It now has four readers rather than three.

**Injected AFTER the env/seed spreads** — deliberately unlike `date` and the `YYYY` family, which a recipe variable may legitimately override. This one is an attribution, not a convenience: a recipe that shadowed it would publish a document naming a run that did not produce it. An absent id is recoverable; a confidently wrong one is not.

## Blast radius: none

`{{taskId}}` previously failed lint, so nothing could depend on it. No installed recipe declares or references that name (checked across all 82).

## Verification

**End to end, not just unit tests.** A real run wrote `run=yaml:rid-smoke:<n>` into its artifact while the run-log row carried the *identical* `taskId` — the join actually resolves against real files.

Both halves mutation-checked independently:
- removing the context injection fails 2 of 3 tests (the lint test correctly still passes, since it reads `validation.ts`, not the runner);
- removing the `builtinKeys` entry fails the third.

Worth recording: the **first mutation attempt silently did nothing** — the literal `taskId: runTaskId,` appears three times, so a `count == 1` assertion aborted and the resulting "3 passed" proved nothing. Re-done by line number with the mutation confirmed applied before trusting the result.

`typecheck`, `typecheck:tests:core`, `schema:check` (0 breaking), business-content and lsp-tools gates green. **2517 tests** across `src/recipes`, `src/privacy`, `src/workers` and `src/butler` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)