### PR TITLE
feat(halts): a run could break its promise and count as nothing

### DIFF
--- a/dashboard/src/lib/haltCategory.ts
+++ b/dashboard/src/lib/haltCategory.ts
@@ -17,12 +17,14 @@ export type HaltCategory =
   | "budget_exceeded"
   | "expect_failed"
   | "step_timeout"
+  | "judge_revisions_exhausted"
   | "auth_failure"
   | "rate_limited"
   | "network_error"
   | "missing_connector"
   | "approval_rejected"
   | "run_level"
+  | "contract_failed"
   | "unsupported_step"
   | "unknown";
 
@@ -42,12 +44,14 @@ export const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   budget_exceeded: "budget exceeded",
   expect_failed: "expect failed",
   step_timeout: "step timeout",
+  judge_revisions_exhausted: "judge revisions exhausted",
   auth_failure: "auth failure",
   rate_limited: "rate limited",
   network_error: "network error",
   missing_connector: "missing connector",
   approval_rejected: "approval rejected",
   run_level: "run-level halt",
+  contract_failed: "completion contract failed",
   unsupported_step: "unsupported step form",
   unknown: "uncategorised",
 };
@@ -72,6 +76,8 @@ export const HALT_CATEGORY_HINT: Record<HaltCategory, string> = {
     "A step's expect: assertion didn't match. Inspect the assertion + actual output.",
   step_timeout:
     "Step exceeded its timeout_ms. Bump the timeout or speed up the step.",
+  judge_revisions_exhausted:
+    "The judge→refine loop used its max_revisions budget and the judge still asked for changes. Raise max_revisions, refine the prompt, or set on_exhausted: proceed.",
   auth_failure:
     "Connector token expired or scopes insufficient. Reconnect from /connections.",
   rate_limited:
@@ -84,6 +90,8 @@ export const HALT_CATEGORY_HINT: Record<HaltCategory, string> = {
     "A step was rejected at the approval gate. Approve it from the dashboard, or set requireApproval: false on the recipe.",
   run_level:
     "Whole-recipe failure (no step ran). Check the recipe for circular deps / parse errors.",
+  contract_failed:
+    "The run finished its steps but broke its run-level expect: postcondition — it completed without delivering what it promised. Compare the assertion with the run output.",
   unsupported_step:
     "The step uses a form this recipe type can't run (parallel / each / recipe / chain / branch on a non-chained recipe). Use the fan_out tool step (it loops a tool or an agent sub-step), or set trigger.type: chained.",
   unknown: "Uncategorised halt. Open the run trace for the raw error.",

--- a/dashboard/src/lib/haltPhrasing.ts
+++ b/dashboard/src/lib/haltPhrasing.ts
@@ -128,6 +128,26 @@ export function ownerHaltPhrase(
           "One of its steps uses a feature this kind of recipe can't run, so it stopped.",
         fix: "none",
       };
+    case "judge_revisions_exhausted":
+      return {
+        sentence:
+          "It rewrote this several times and its reviewer still wasn't satisfied, so it stopped.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
+    case "contract_failed":
+      // The ONLY case in this file where the run did not stop. Every other
+      // sentence ends in "so it stopped"; this one finished and handed back
+      // work that failed its own final check. Saying "stopped" here would
+      // send the owner looking for a halt that never happened, and would
+      // hide the thing that actually matters: the output exists and should
+      // not be trusted.
+      return {
+        sentence:
+          "It finished, but the result didn't pass its own final check — don't rely on it yet.",
+        fix: "open-trace",
+        fixLabel: "See what happened",
+      };
     case "unknown":
       return {
         sentence: "It stopped for a reason we couldn't label.",

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,21 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-26 `feat/halts-see-completion-contracts` — a run that violated its run-level
+  `recipe.expect` finished `done`, and `summariseHalts` only emits a run-level entry for
+  `status === "error"`, so the operator-facing halt count could not distinguish "nothing
+  halted" from "the job finished without delivering what it promised". Adds
+  `contract_failed`, counted ONE per run rather than one per assertion (three failures are
+  one contract broken three ways; counting three inflates the number against the
+  "incomplete jobs" reading it exists for) and NOT guarded on the step count, unlike
+  `run_level` — a postcondition violation is a different fact from a step error, not the
+  same one restated. Would have shipped INERT: measured 1455 run rows with 0
+  `assertionFailures`, because no shipped template declared a run-level `expect`, so
+  `morning-brief` now promises its `brief` output. Also closed a pre-existing drift the
+  work surfaced: `judge_revisions_exhausted` was in the bridge union and absent from the
+  dashboard's entirely, which no compiler could catch — a `Record` over a SHORTER union is
+  well-typed — so the two unions are now compared as text by a test. (#1528)
+
 - 2026-08-26 `feat/durable-approver-attribution` — ADR-0020 Phase A resolved the approver
   and then put the name somewhere it could be thrown away. `approvalHttp` verifies the
   member's own signed session AFTER `queue.approve()` has landed the decision (deliberate:

--- a/src/recipes/__tests__/haltCategoryContract.test.ts
+++ b/src/recipes/__tests__/haltCategoryContract.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Two things this file guards, both learned the same way.
+ *
+ * 1. A run that violated its RUN-LEVEL completion contract must appear in the
+ *    halt count. Such a run finishes `done`, not `error`, so the run-level
+ *    branch never fired and `HaltSummaryInputRun` had no field for
+ *    `assertionFailures` at all — "nothing halted" and "the job did not do
+ *    what it promised" read identically.
+ *
+ * 2. The bridge's `HaltCategory` and the dashboard's copy must agree. They had
+ *    already drifted before this file existed: `judge_revisions_exhausted`
+ *    shipped in the bridge and was absent from the dashboard entirely, so a
+ *    run halted by an exhausted judge loop rendered with no label and no fix
+ *    hint. Nothing caught it, because a `Record<HaltCategory, string>` on a
+ *    SHORTER union is perfectly well-typed — the drift is invisible to both
+ *    compilers by construction. It has to be checked as text.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  HALT_CATEGORY_HINTS,
+  HALT_CATEGORY_LABELS,
+  type HaltSummaryInputRun,
+  summariseHalts,
+} from "../haltCategory.js";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+function unionMembers(file: string): string[] {
+  const src = readFileSync(path.join(repoRoot, file), "utf8");
+  const m = /export type HaltCategory\s*=(.*?);/s.exec(src);
+  if (!m) throw new Error(`no HaltCategory union found in ${file}`);
+  return (m[1] as string)
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith("|"))
+    .map((l) => l.replace(/^\|\s*"|"$/g, ""));
+}
+
+function run(over: Partial<HaltSummaryInputRun> = {}): HaltSummaryInputRun {
+  return { seq: 1, status: "done", ...over };
+}
+
+describe("completion-contract failures are visible to halts", () => {
+  it("counts a done run that broke its run-level expect", () => {
+    const s = summariseHalts([
+      run({ assertionFailures: [{ message: "missing SUMMARY" }] }),
+    ]);
+    expect(s.total).toBe(1);
+    expect(s.byCategory.contract_failed).toBe(1);
+    expect(s.recent[0]?.category).toBe("contract_failed");
+  });
+
+  it("counts ONE entry per run, not one per assertion", () => {
+    const s = summariseHalts([run({ assertionFailures: [{}, {}, {}] })]);
+    expect(s.byCategory.contract_failed).toBe(1);
+    expect(s.total).toBe(1);
+    expect(s.recent[0]?.reason).toContain("3 assertions");
+  });
+
+  it("says 'assertion' singular for one failure", () => {
+    const s = summariseHalts([run({ assertionFailures: [{}] })]);
+    expect(s.recent[0]?.reason).toContain("1 assertion)");
+  });
+
+  it("a clean done run still contributes nothing", () => {
+    const s = summariseHalts([run(), run({ assertionFailures: [] })]);
+    expect(s.total).toBe(0);
+    expect(s.byCategory.contract_failed).toBeUndefined();
+  });
+
+  /**
+   * Deliberately NOT guarded on the step count, unlike `run_level`: a step
+   * failing and a postcondition being violated are different facts, and a run
+   * can have either without the other.
+   */
+  it("counts alongside step halts rather than instead of them", () => {
+    const s = summariseHalts([
+      run({
+        status: "error",
+        stepResults: [{ status: "error", haltReason: "Tool x threw" }],
+        assertionFailures: [{}],
+      }),
+    ]);
+    expect(s.byCategory.contract_failed).toBe(1);
+    expect(s.byCategory.tool_threw).toBe(1);
+    expect(s.total).toBe(2);
+  });
+
+  it("does not quote the assertion text into `recent`", () => {
+    // The assertion can carry run output, and `recent` reaches the CLI, the
+    // dashboard and a metrics-adjacent surface.
+    const s = summariseHalts([
+      run({ assertionFailures: [{ message: "SECRET-PAYLOAD-MARKER" }] }),
+    ]);
+    expect(JSON.stringify(s)).not.toContain("SECRET-PAYLOAD-MARKER");
+  });
+});
+
+describe("bridge and dashboard halt categories agree", () => {
+  const bridge = unionMembers("src/recipes/haltCategory.ts");
+  const dash = unionMembers("dashboard/src/lib/haltCategory.ts");
+
+  it("the unions hold exactly the same members", () => {
+    expect([...dash].sort()).toEqual([...bridge].sort());
+  });
+
+  it("every bridge category has a label and a hint", () => {
+    for (const c of bridge) {
+      expect(
+        HALT_CATEGORY_LABELS[c as keyof typeof HALT_CATEGORY_LABELS],
+      ).toBeTruthy();
+      expect(
+        HALT_CATEGORY_HINTS[c as keyof typeof HALT_CATEGORY_HINTS],
+      ).toBeTruthy();
+    }
+  });
+
+  it("every dashboard category has a label and a hint there too", () => {
+    const src = readFileSync(
+      path.join(repoRoot, "dashboard/src/lib/haltCategory.ts"),
+      "utf8",
+    );
+    // Both maps are object literals keyed by the category name; a missing key
+    // is what drift looks like on that side.
+    // Named SINGULAR on the dashboard side and PLURAL on the bridge side.
+    // Matching the wrong one silently yields "", turning every assertion
+    // below into a confusing failure about the first category rather than
+    // about the missing map. Throw instead of defaulting.
+    const body = (re: RegExp, what: string): string => {
+      const m = re.exec(src);
+      if (!m?.[1]) throw new Error(`dashboard ${what} map not found`);
+      return m[1];
+    };
+    const labels = body(/HALT_CATEGORY_LABEL\b[^{]*\{(.*?)\n\};/s, "label");
+    const hints = body(/HALT_CATEGORY_HINT\b[^{]*\{(.*?)\n\};/s, "hint");
+    for (const c of dash) {
+      expect(labels, `label missing for ${c}`).toContain(`${c}:`);
+      expect(hints, `hint missing for ${c}`).toContain(`${c}:`);
+    }
+  });
+});

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { summariseHalts } from "../haltCategory.js";
 
 // Isolate from the developer's real ~/.patchwork/config.json — agent steps
 // now read it via a static import (was a broken `require()` under ESM that
@@ -2345,6 +2346,72 @@ describe("evaluateExpect — multiple assertions", () => {
         context: { key: "expected" },
       }),
     ).toHaveLength(0);
+  });
+});
+
+describe("runYamlRecipe — a violated contract reaches the halt count", () => {
+  /**
+   * The join, not the halves. `evaluateExpect` was already tested and
+   * `summariseHalts` is tested in `haltCategoryContract.test.ts`; what was
+   * broken is that nothing carried one to the other. The run finishes `done`,
+   * so the summariser's run-level branch (which needs `status: "error"`) never
+   * fired and its input type had no field for `assertionFailures` at all.
+   *
+   * Shaped like the `morning-brief` template's contract — an agent step that
+   * produces no output, so the promised key is missing.
+   */
+  it("a done run missing its promised output is counted as contract_failed", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "contract.txt"),
+          content: "wrote something",
+          into: "saved",
+        },
+      ],
+      expect: { outputs: ["brief"] },
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      writeFile: () => {},
+    });
+
+    // The run did NOT fail — that is the whole point.
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.assertionFailures?.length).toBe(1);
+
+    const summary = summariseHalts([
+      {
+        seq: 1,
+        status: "done",
+        ...(result.assertionFailures
+          ? { assertionFailures: result.assertionFailures }
+          : {}),
+      },
+    ]);
+    expect(summary.byCategory.contract_failed).toBe(1);
+    expect(summary.total).toBe(1);
+  });
+
+  it("a run that honours its contract is counted as nothing", async () => {
+    const recipe = makeRecipe({
+      steps: [
+        {
+          tool: "file.write",
+          path: path.join(TMP, "contract-ok.txt"),
+          content: "ok",
+          into: "saved",
+        },
+      ],
+      expect: { outputs: [path.join(TMP, "contract-ok.txt")] },
+    });
+    const result = await runYamlRecipe(recipe, {
+      ...noop(),
+      writeFile: () => {},
+    });
+    expect(result.assertionFailures ?? []).toHaveLength(0);
+    expect(summariseHalts([{ seq: 1, status: "done" }]).total).toBe(0);
   });
 });
 

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -60,6 +60,16 @@ export type HaltCategory =
   /** Whole-recipe failure (e.g. circular dependencies) — has no step row. */
   | "run_level"
   /**
+   * The run finished its steps but violated its RUN-LEVEL completion contract
+   * (`recipe.expect` → `assertionFailures`). Distinct from `expect_failed`,
+   * which is a per-STEP assertion and arrives as an error step row.
+   *
+   * Its own category because such a run finishes `done`, not `error`: the
+   * operator-facing halt count could not see it at all, so "nothing halted"
+   * and "the job did not do what it promised" were the same reading.
+   */
+  | "contract_failed"
+  /**
    * The step uses a construct this runner does not implement (a compound
    * step — `parallel`, `each`, `recipe`, `chain`, `branch` — on a non-chained
    * recipe). An AUTHORING defect, not a runtime failure: nothing was attempted
@@ -92,6 +102,7 @@ export const HALT_CATEGORY_LABELS: Record<HaltCategory, string> = {
   missing_connector: "missing connector",
   approval_rejected: "approval rejected",
   run_level: "run-level halt",
+  contract_failed: "completion contract failed",
   unsupported_step: "unsupported step form",
   unknown: "uncategorised",
 };
@@ -120,6 +131,8 @@ export const HALT_CATEGORY_HINTS: Record<HaltCategory, string> = {
   approval_rejected:
     "approve the step from the dashboard, or set requireApproval: false",
   run_level: "check recipe for circular deps / parse errors",
+  contract_failed:
+    "the run finished but broke its `expect` postcondition — compare the assertion with the run output",
   unsupported_step: "use `fan_out`, or set trigger.type: chained",
   unknown: "open run trace for raw error",
 };
@@ -191,12 +204,18 @@ export interface HaltSummary {
   recent: Array<{ reason: string; category: HaltCategory; runSeq: number }>;
 }
 
-interface HaltSummaryInputRun {
+export interface HaltSummaryInputRun {
   seq: number;
   /** Top-level run status — `run_level` halts are runs with status === "error" but no error stepResults (e.g. circular-dep failure before any step ran). */
   status?: "running" | "done" | "error" | "cancelled" | "interrupted";
   /** Top-level errorMessage — surfaced as a `run_level` halt when no per-step halts cover it. */
   errorMessage?: string;
+  /**
+   * Run-level `recipe.expect` violations. Present on the run-log row already
+   * — the runner persists them — so every caller passing a whole row gets
+   * this for free and no call site changes.
+   */
+  assertionFailures?: Array<{ message?: string } | unknown>;
   stepResults?: Array<{
     status: "ok" | "skipped" | "error";
     haltReason?: string;
@@ -213,6 +232,19 @@ interface HaltSummaryInputRun {
  * - one entry per error-status stepResult that has a `haltReason`
  * - plus one `run_level` entry if `status === "error"` and there were no
  *   per-step halts that already explained it (avoids double-counting).
+ * - plus ONE `contract_failed` entry if the run violated its run-level
+ *   `recipe.expect`, regardless of the two above.
+ *
+ * The contract entry is deliberately NOT guarded on the step count, unlike
+ * `run_level`. That guard exists because a run's `errorMessage` usually
+ * restates a step failure already counted — the same fact twice. A violated
+ * postcondition is a DIFFERENT fact: every step can succeed and the run still
+ * fail to deliver what it promised, and a step can fail for a reason
+ * unrelated to the assertion that also failed.
+ *
+ * ONE entry per run, not one per failure. A run with three assertion failures
+ * broke one contract in three ways; counting three would inflate the halt
+ * count against "incomplete jobs", which is the reading this count is for.
  */
 export function summariseHalts(runs: HaltSummaryInputRun[]): HaltSummary {
   const byCategory: Partial<Record<HaltCategory, number>> = {};
@@ -230,6 +262,23 @@ export function summariseHalts(runs: HaltSummaryInputRun[]): HaltSummary {
         recent.push({
           reason: step.haltReason,
           category: cat,
+          runSeq: run.seq,
+        });
+      }
+    }
+    const assertionCount = run.assertionFailures?.length ?? 0;
+    if (assertionCount > 0) {
+      total++;
+      byCategory.contract_failed = (byCategory.contract_failed ?? 0) + 1;
+      if (recent.length < 5) {
+        recent.push({
+          // Names the count rather than quoting an assertion: the assertion
+          // text can carry run output, and `recent` is rendered in the CLI,
+          // the dashboard and a Prometheus-adjacent surface.
+          reason: `run-level expect failed (${assertionCount} assertion${
+            assertionCount === 1 ? "" : "s"
+          })`,
+          category: "contract_failed",
           runSeq: run.seq,
         });
       }

--- a/templates/recipes/morning-brief.yaml
+++ b/templates/recipes/morning-brief.yaml
@@ -7,6 +7,20 @@ description: Daily morning brief combining unread emails, calendar, recent git a
 allowWrites:
   - file.write
 
+# Run-level completion contract. The steps can all report `ok` and the run can
+# still finish `done` having produced no brief — an agent that narrates instead
+# of answering, or a driver that returns empty, leaves `brief` unset and the
+# file step then writes a heading with nothing under it. That is the failure
+# this recipe actually has, and it is silent.
+#
+# `expect` is checked AFTER the last step and does not change the run's status:
+# a violated contract is recorded as `assertionFailures` on the run and counted
+# by `patchwork halts` under `completion contract failed`. So the run still
+# writes whatever it produced — this reports, it does not roll back.
+expect:
+  outputs:
+    - brief
+
 trigger:
   type: cron
   at: "0 8 * * 1-5"


### PR DESCRIPTION
Doc-13 §2.3's remaining tail. `recipe.expect` has run in production since it shipped, and the operator-facing halt count could not see it.

## The finding

A run that violates its run-level completion contract finishes `done`, not `error`. `summariseHalts` only emits a run-level entry when `status === "error" && errorMessage`, and `HaltSummaryInputRun` had **no field for `assertionFailures` at all** — so *"nothing halted"* and *"the job finished without delivering what it promised"* were the same reading.

## The change

A `contract_failed` category, counted **one per run**, not one per failure. A run with three assertion failures broke one contract in three ways; counting three inflates the number against "incomplete jobs", which is the reading this count exists for.

Deliberately **not** guarded on the step count, unlike `run_level`. That guard exists because a run's `errorMessage` usually restates a step failure already counted — the same fact twice. A violated postcondition is a *different* fact: every step can succeed and the run still fail to deliver, and a step can fail for a reason unrelated to the assertion that also failed.

`recent` names the assertion **count** and never quotes the assertion text — the text can carry run output, and `recent` renders in the CLI, the dashboard, and next to a Prometheus gauge.

## It would have shipped inert

Measured across the live run log and its rotation archive: **1455 rows, 0 with `assertionFailures`**. No shipped template declared a run-level `expect`, so the new counter had nothing to count.

So `morning-brief` now promises its `brief` output. That recipe's real failure mode is an agent that narrates instead of answering: every step reports ok, the run finishes `done`, and the file step writes a heading with nothing under it. `expect` is checked after the last step and does **not** change run status — it reports, it does not roll back.

## A pre-existing drift, found on the way in

`judge_revisions_exhausted` shipped in the bridge and was **absent from the dashboard's union entirely** — 0 occurrences anywhere in `dashboard/src` — so a run halted by an exhausted judge loop rendered with no label and no fix hint.

Nothing caught it, and nothing could: `Record<HaltCategory, string>` over a **shorter** union is perfectly well-typed, so the drift is invisible to both compilers by construction. Now guarded by a test that reads both files as text and compares the unions — the only way this class can be checked.

The dashboard's owner-facing phrasing gets both new categories. `contract_failed` is the only case in that file where **the run did not stop** — every other sentence ends "so it stopped". Saying it here would send the owner hunting a halt that never happened, and hide the point: the output exists and should not be trusted.

## Verification

| mutation (each confirmed applied first) | result |
|---|---|
| remove the counting branch | 4 failed |
| count per-assertion instead of per-run | 1 failed |
| re-introduce the dashboard drift | 1 failed |
| quote assertion text into `recent` | 1 failed |
| revert the runner→summariser join | 1 failed |
| restored | all pass |

An end-to-end test drives the **real** runner and feeds its result to the summariser: both halves were already tested, and what was broken was the join.

Two gates caught what vitest could not — `typecheck:tests:core` found `HaltSummaryInputRun` unexported, and the dashboard typecheck found the owner-phrasing switch no longer exhaustive.

Bridge 10,382 passed · dashboard 1,322 passed · `typecheck`, `typecheck:tests:core`, dashboard `tsc`, `audit-lsp-tools`, `audit-in-flight`, `audit-business-content`, `audit-private-identifiers` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)