### PR TITLE
feat(recipes): a chained recipe's completion contract was never checked

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- 2026-08-26 `feat/chained-run-level-expect` — a chained recipe's run-level `expect:` lints
+  clean with zero warnings and is then dropped entirely: `ChainedRecipe` has no `expect`
+  field and `runChainedRecipe` never calls `evaluateExpect`. Reproduced against a real run
+  — two impossible assertions, `status: done`, `assertionFailures: None`. Touches
+  `recipes/chainedRunner.ts` + recipe lint.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,11 +50,7 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-26 `feat/chained-run-level-expect` — a chained recipe's run-level `expect:` lints
-  clean with zero warnings and is then dropped entirely: `ChainedRecipe` has no `expect`
-  field and `runChainedRecipe` never calls `evaluateExpect`. Reproduced against a real run
-  — two impossible assertions, `status: done`, `assertionFailures: None`. Touches
-  `recipes/chainedRunner.ts` + recipe lint.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
@@ -72,6 +68,20 @@ verified (which is how this line came to be written).
   work surfaced: `judge_revisions_exhausted` was in the bridge union and absent from the
   dashboard's entirely, which no compiler could catch — a `Record` over a SHORTER union is
   well-typed — so the two unions are now compared as text by a test. (#1528)
+- 2026-08-26 `feat/chained-run-level-expect` — `recipe lint` accepted a run-level `expect:`
+  on a chained recipe with ZERO warnings and the runner dropped it; `dispatchRecipe` casts
+  a `YamlRecipe` straight across, so the block was on the object at runtime and
+  `ChainedRecipe` simply had no field for it. Reproduced against a real run first: two
+  impossible assertions, `status: done`, `assertionFailures: None`. `outputs` deliberately
+  means STEP IDS here and `into:` keys / resolved paths on the flat runner — a flat-style
+  entry fails loudly instead of passing, and lint now warns on a path-shaped entry
+  (never on a flat recipe, where a path is correct). A THIRD implementation turned up on
+  the way in: `recipe test` evaluated the chained contract itself with `outputs: []` and
+  `summary.total`, so every `outputs` assertion failed there regardless of the recipe and
+  skipped steps were counted — on the very surface an author uses to check their contract.
+  Collapsed to the runner's result. NOT fixed and called out rather than left to be
+  rediscovered: `recipe run --local` passes no `runLog`/`runLogDir`, so a chained CLI run
+  writes no runner row at all. (#1529)
 
 - 2026-08-26 `feat/durable-approver-attribution` — ADR-0020 Phase A resolved the approver
   and then put the name somewhere it could be thrown away. `approvalHttp` verifies the

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -2702,7 +2702,6 @@ export async function runTest(
         const { runChainedRecipe } = await import(
           "../recipes/chainedRunner.js"
         );
-        const { evaluateExpect } = await import("../recipes/yamlRunner.js");
         const chainedRecipe =
           recipe as unknown as import("../recipes/chainedRunner.js").ChainedRecipe;
         const recipeRecord = recipe as unknown as Record<string, unknown>;
@@ -2726,22 +2725,19 @@ export async function runTest(
           issues.push({ level: "error", message: run.errorMessage });
         }
 
-        // Evaluate expect: block against chained run results
-        const expectBlock = recipeRecord.expect as
-          | import("../recipes/yamlRunner.js").YamlRecipeExpect
-          | undefined;
-        if (expectBlock) {
-          const failures = evaluateExpect(
-            {
-              stepsRun: run.summary.total,
-              outputs: [],
-              context: run.context,
-              errorMessage: run.errorMessage,
-            },
-            expectBlock,
-          );
-          assertionFailures = failures;
-          for (const failure of failures) {
+        // Read the contract the RUNNER evaluated — do not re-evaluate it here.
+        //
+        // This branch used to run `evaluateExpect` itself, and disagreed with a
+        // real run in two ways: it passed `outputs: []`, so every `outputs`
+        // assertion failed under `recipe test` no matter what the recipe did,
+        // and it passed `summary.total`, which counts SKIPPED steps that a real
+        // run does not. `recipe test` is the surface an author uses to find out
+        // whether their contract holds, so a private second implementation of
+        // it is the worst possible place for drift. Mirrors the flat branch
+        // below, which has always read the runner's own result.
+        if (run.assertionFailures && run.assertionFailures.length > 0) {
+          assertionFailures = run.assertionFailures;
+          for (const failure of run.assertionFailures) {
             issues.push({ level: "error", message: failure.message });
           }
         }

--- a/src/recipes/__tests__/chainedRunLevelExpect.test.ts
+++ b/src/recipes/__tests__/chainedRunLevelExpect.test.ts
@@ -1,0 +1,152 @@
+/**
+ * A chained recipe's run-level `expect:` used to be dropped in silence.
+ *
+ * `dispatchRecipe` casts a `YamlRecipe` straight to a `ChainedRecipe`, so the
+ * block was present on the object at runtime — but `ChainedRecipe` had no
+ * `expect` field and `runChainedRecipe` never evaluated one. Reproduced
+ * against a real run before the fix: two impossible assertions
+ * (`stepsRun: 99`, an output key nothing produces), `status: done`, and no
+ * `assertionFailures` anywhere. `recipe lint` reported zero warnings.
+ *
+ * That is the "lints clean, never fires" family, and it is why these tests
+ * assert on the run-log row and not only on the returned object: the value
+ * being right while nothing persists it is the same defect one layer along.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ChainedRecipe,
+  ExecutionDeps,
+  RunOptions,
+} from "../chainedRunner.js";
+import { runChainedRecipe } from "../chainedRunner.js";
+
+const deps: ExecutionDeps = {
+  executeTool: vi.fn().mockResolvedValue({ ok: true }),
+  executeAgent: vi.fn().mockResolvedValue("agent output"),
+  loadNestedRecipe: vi.fn().mockResolvedValue(null),
+};
+
+const baseOptions: RunOptions = {
+  env: {},
+  maxConcurrency: 4,
+  maxDepth: 3,
+  dryRun: false,
+};
+
+function recipe(over: Partial<ChainedRecipe> = {}): ChainedRecipe {
+  return {
+    name: "chained-contract",
+    steps: [{ id: "fetch", tool: "http.get" }],
+    ...over,
+  };
+}
+
+/** Minimal run-log double — records what `completeRun` was handed. */
+function fakeRunLog() {
+  const completed: Array<Record<string, unknown>> = [];
+  return {
+    completed,
+    log: {
+      startRun: () => 1,
+      completeRun: (_seq: number, patch: Record<string, unknown>) => {
+        completed.push(patch);
+      },
+    } as unknown as NonNullable<RunOptions["runLog"]>,
+  };
+}
+
+describe("chained run-level expect", () => {
+  it("evaluates a contract that the run cannot satisfy", async () => {
+    const result = await runChainedRecipe(
+      recipe({ expect: { stepsRun: 99, outputs: ["never-produced"] } }),
+      baseOptions,
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.assertionFailures).toHaveLength(2);
+  });
+
+  it("reports, it does not roll back — success stays true", async () => {
+    const result = await runChainedRecipe(
+      recipe({ expect: { outputs: ["never-produced"] } }),
+      baseOptions,
+      deps,
+    );
+    // Same posture as the flat runner: a violated postcondition is recorded,
+    // the run still completed and its side effects still happened.
+    expect(result.success).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.assertionFailures).toHaveLength(1);
+  });
+
+  it("a satisfied contract records NOTHING, not an empty array", async () => {
+    // "No contract" and "the contract passed" must stay distinguishable.
+    const result = await runChainedRecipe(
+      recipe({ expect: { stepsRun: 1, outputs: ["fetch"] } }),
+      baseOptions,
+      deps,
+    );
+    expect(result.assertionFailures).toBeUndefined();
+  });
+
+  it("a recipe with no contract records nothing", async () => {
+    const result = await runChainedRecipe(recipe(), baseOptions, deps);
+    expect(result.assertionFailures).toBeUndefined();
+  });
+
+  /**
+   * `outputs` is keyed by STEP ID here, and by agent `into:` keys / resolved
+   * file paths on the flat runner. Deliberate, and asserted so nobody
+   * "harmonises" one side without noticing the other.
+   */
+  it("outputs are step ids, and a flat-style entry fails loudly", async () => {
+    const ok = await runChainedRecipe(
+      recipe({ expect: { outputs: ["fetch"] } }),
+      baseOptions,
+      deps,
+    );
+    expect(ok.assertionFailures).toBeUndefined();
+
+    const flatStyle = await runChainedRecipe(
+      recipe({ expect: { outputs: ["/abs/path/out.md"] } }),
+      baseOptions,
+      deps,
+    );
+    expect(flatStyle.assertionFailures).toHaveLength(1);
+  });
+
+  it("persists the failures onto the run-log row", async () => {
+    const { completed, log } = fakeRunLog();
+    await runChainedRecipe(
+      recipe({ expect: { outputs: ["never-produced"] } }),
+      { ...baseOptions, runLog: log },
+      deps,
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0]?.assertionFailures).toHaveLength(1);
+    // The run is still `done` on the row too — the halt count is what surfaces
+    // the violation, not the status.
+    expect(completed[0]?.status).toBe("done");
+  });
+
+  it("omits the field on the row when the contract held", async () => {
+    const { completed, log } = fakeRunLog();
+    await runChainedRecipe(
+      recipe({ expect: { outputs: ["fetch"] } }),
+      { ...baseOptions, runLog: log },
+      deps,
+    );
+    expect(completed[0]).not.toHaveProperty("assertionFailures");
+  });
+
+  it("a throwing contract cannot strand the run", async () => {
+    const result = await runChainedRecipe(
+      // A non-object expect is the shape most likely to blow up the helper.
+      recipe({ expect: null as unknown as ChainedRecipe["expect"] }),
+      baseOptions,
+      deps,
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/recipes/__tests__/validationParity.test.ts
+++ b/src/recipes/__tests__/validationParity.test.ts
@@ -175,3 +175,68 @@ describe("branch otherwise does not skip co-located step validation (audit 2026-
     expect(errors.length).toBeGreaterThan(0);
   });
 });
+
+/**
+ * `expect.outputs` names step ids on a chained recipe and agent `into:` keys /
+ * resolved file paths on a flat one — deliberate, since that is what each
+ * runner is keyed by. The failure mode is quiet and expensive: a path-shaped
+ * entry on a chained recipe can never match, and only says so at the END of a
+ * run that already did all its work.
+ */
+describe("chained expect.outputs written in the flat runner's vocabulary", () => {
+  const chained = {
+    name: "chained-outputs",
+    description: "test recipe",
+    trigger: { type: "chained" as const },
+    steps: [{ id: "fetch", tool: "http.get", url: "https://example.test/x" }],
+  };
+
+  it("warns on a path-shaped entry", () => {
+    const result = validateRecipeDefinition({
+      ...chained,
+      expect: { outputs: ["~/.patchwork/inbox/out.md"] },
+    });
+    const issue = result.issues.find(
+      (i) => i.code === "chained-expect-outputs-path",
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.level).toBe("warning");
+  });
+
+  it("does not warn on a plain step id", () => {
+    const result = validateRecipeDefinition({
+      ...chained,
+      expect: { outputs: ["fetch"] },
+    });
+    expect(
+      result.issues.some((i) => i.code === "chained-expect-outputs-path"),
+    ).toBe(false);
+  });
+
+  it("warns once per offending entry and leaves valid ones alone", () => {
+    const result = validateRecipeDefinition({
+      ...chained,
+      expect: { outputs: ["fetch", "/abs/a.md", "~/b.md"] },
+    });
+    expect(
+      result.issues.filter((i) => i.code === "chained-expect-outputs-path"),
+    ).toHaveLength(2);
+  });
+
+  /**
+   * The flat runner is where a path IS the right vocabulary, so the rule must
+   * not fire there — otherwise it would train authors to ignore it.
+   */
+  it("never fires on a flat recipe, where a path is correct", () => {
+    const result = validateRecipeDefinition({
+      name: "flat-outputs",
+      description: "test recipe",
+      trigger: { type: "manual" as const },
+      steps: [{ id: "s1", agent: { prompt: "hi" }, into: "brief" }],
+      expect: { outputs: ["~/.patchwork/inbox/out.md"] },
+    });
+    expect(
+      result.issues.some((i) => i.code === "chained-expect-outputs-path"),
+    ).toBe(false);
+  });
+});

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -43,7 +43,15 @@ import {
 import type { TemplateContext, TemplateError } from "./templateEngine.js";
 import { compileTemplate } from "./templateEngine.js";
 import { evaluateWhen } from "./whenGuard.js";
-import type { StepExpect } from "./yamlRunner.js";
+// TYPE-ONLY on purpose. `yamlRunner` imports this module dynamically to break
+// the cycle (see `loadRecipeServers` below); a value import here would close
+// it. `evaluateExpect` is pulled in with `await import()` at its call site for
+// the same reason.
+import type {
+  AssertionFailure,
+  StepExpect,
+  YamlRecipeExpect,
+} from "./yamlRunner.js";
 import {
   computeAgentCallUsage,
   declaredRecipeEnv,
@@ -111,6 +119,22 @@ export interface ChainedRecipe {
    * recipe ran UNBOUNDED API calls (S1 finding).
    */
   budget?: BudgetPolicy;
+  /**
+   * Run-level completion contract, evaluated after the last step.
+   *
+   * Present at RUNTIME long before it was present here: `dispatchRecipe` casts
+   * a `YamlRecipe` straight across, so an author could write `expect:` on a
+   * chained recipe, have lint pass with zero warnings, and have it silently
+   * dropped — the recipe promised a postcondition nothing ever checked.
+   *
+   * ONE KEY MEANS SOMETHING DIFFERENT HERE, deliberately. `outputs` on the
+   * flat runner lists agent `into:` keys and resolved `file.write` paths; on
+   * this runner it lists the STEP IDS that produced data, because that is what
+   * a chained run is keyed by. A flat-style entry therefore never matches and
+   * fails loudly rather than passing by accident, and `recipe lint` warns when
+   * a chained `outputs` entry looks like a path.
+   */
+  expect?: YamlRecipeExpect;
 }
 
 export interface RunOptions {
@@ -1083,6 +1107,12 @@ export interface ChainedRunResult {
   errorMessage?: string;
   /** Step output data keyed by step id, stringified for expect: assertions. */
   context: Record<string, string>;
+  /**
+   * Run-level `expect` violations. Absent when the recipe declared no contract
+   * or the contract held — never an empty array, so "no contract" and "the
+   * contract passed" stay distinguishable from a reader's point of view.
+   */
+  assertionFailures?: AssertionFailure[];
 }
 
 /**
@@ -1629,12 +1659,45 @@ export async function runChainedRecipe(
     }
   }
 
+  const chainedSummary = registry.summary();
+
+  // Run-level completion contract. Evaluated AFTER every step, and it does not
+  // change `success`: a violated postcondition is reported, not rolled back —
+  // identical to the flat runner, where the run still finishes `done`.
+  //
+  // Guarded so a throw here cannot strand the run: an assertion helper that
+  // blows up must not turn a completed run into a crashed one.
+  let assertionFailures: AssertionFailure[] = [];
+  if (recipe.expect) {
+    try {
+      const { evaluateExpect } = await import("./yamlRunner.js");
+      assertionFailures = evaluateExpect(
+        {
+          // `stepsRun` is "steps that actually executed", matching the flat
+          // runner's counter — a skipped step did not run.
+          stepsRun: chainedSummary.total - chainedSummary.skipped,
+          // Step ids that produced data. See the `expect` field's note on
+          // ChainedRecipe: this vocabulary differs from the flat runner's and
+          // that is deliberate, not an oversight.
+          outputs: Object.keys(context),
+          context,
+          ...(failed > 0 ? { errorMessage: `${failed} step(s) failed` } : {}),
+        },
+        recipe.expect,
+      );
+    } catch {
+      // Same posture as the flat path: never let contract evaluation break a
+      // run that already finished.
+    }
+  }
+
   const result: ChainedRunResult = {
     success: failed === 0,
     stepResults: enrichedResults,
-    summary: registry.summary(),
+    summary: chainedSummary,
     errorMessage: failed > 0 ? `${failed} step(s) failed` : undefined,
     context,
+    ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
   };
 
   // Write to RecipeRunLog so the dashboard Runs page shows chained executions.
@@ -1758,6 +1821,7 @@ export async function runChainedRecipe(
           ...(result.errorMessage !== undefined && {
             errorMessage: result.errorMessage,
           }),
+          ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
           ...(tokenTotals ? { tokenTotals } : {}),
           ...(budgetTotals ? { budgetTotals } : {}),
         });
@@ -1796,6 +1860,7 @@ export async function runChainedRecipe(
           errorMessage: result.errorMessage,
           stepResults: stepResultsList,
           ...(budgetWarnings.length > 0 && { budgetWarnings }),
+          ...(assertionFailures.length > 0 ? { assertionFailures } : {}),
           ...(tokenTotals ? { tokenTotals } : {}),
           ...(budgetTotals ? { budgetTotals } : {}),
         });

--- a/src/recipes/validation.ts
+++ b/src/recipes/validation.ts
@@ -143,6 +143,43 @@ export function validateRecipeDefinition(recipe: unknown): LintResult {
       });
     }
 
+    // `expect.outputs` means DIFFERENT things in the two runners, deliberately:
+    // step ids on a chained recipe, agent `into:` keys and resolved file paths
+    // on a flat one. A path-shaped entry on a chained recipe is therefore a
+    // contract that can never be satisfied — and it fails at the END of a run
+    // that already did its work, which is the expensive place to find out.
+    //
+    // A warning rather than an error: `outputs` is author-supplied and a step
+    // id containing a slash is legal, if odd. The point is to name the mistake
+    // at lint time, where the previous behaviour was to say nothing at all.
+    {
+      const rTrigger =
+        r.trigger && typeof r.trigger === "object"
+          ? (r.trigger as Record<string, unknown>)
+          : undefined;
+      const rExpect =
+        r.expect && typeof r.expect === "object"
+          ? (r.expect as Record<string, unknown>)
+          : undefined;
+      const rOutputs = rExpect?.outputs;
+      if (rTrigger?.type === "chained" && Array.isArray(rOutputs)) {
+        for (const entry of rOutputs) {
+          if (typeof entry !== "string") continue;
+          if (!entry.includes("/") && !entry.startsWith("~")) continue;
+          issues.push({
+            level: "warning",
+            message:
+              `expect.outputs entry "${entry}" looks like a file path, but on a ` +
+              "chained recipe 'outputs' lists STEP IDS (the flat runner is the one " +
+              "that lists agent into: keys and written paths). This assertion can " +
+              "never match — use the step's id, or assert on 'context' instead.",
+            code: "chained-expect-outputs-path",
+            path: "expect.outputs",
+          });
+        }
+      }
+    }
+
     if (!r.name || typeof r.name !== "string") {
       issues.push({
         level: "error",


### PR DESCRIPTION
`recipe lint` accepted a run-level `expect:` on a chained recipe with **zero warnings**, and the runner then dropped it.

## Reproduced before fixing

A chained recipe declaring two assertions that cannot hold — `stepsRun: 99` and an output key nothing produces:

```
✓ write (2ms)
status: done | assertionFailures: None
```

`dispatchRecipe` casts a `YamlRecipe` straight across, so the block was on the object at runtime the whole time. `ChainedRecipe` simply had no `expect` field and `runChainedRecipe` never evaluated one. Lints clean, never fires.

## `outputs` means something different on each runner — deliberately

| runner | `outputs` lists |
|---|---|
| flat | agent `into:` keys, resolved `file.write` paths |
| chained | **step ids** |

That is what each runner is keyed by. A flat-style entry therefore never matches and **fails loudly rather than passing by accident**, and `recipe lint` now warns when a chained `outputs` entry looks like a path — a contract that can never hold, reported at lint time instead of at the end of a run that already did all its work.

The rule never fires on a flat recipe, where a path *is* the correct vocabulary. A rule that cried wolf there would train authors to ignore it.

## Reports, does not roll back

`success` is unchanged and the run still finishes `done`, matching the flat runner. Persisted on **both** run-log paths — writing only one is the divergence this whole change is about. Absent rather than empty when the contract held, so "no contract" and "the contract passed" stay distinguishable.

## A third implementation, found on the way in

`recipe test` had its own copy of the chained evaluation, and it disagreed with a real run **twice**:

- it passed `outputs: []`, so every `outputs` assertion failed under `recipe test` no matter what the recipe did;
- it passed `summary.total`, which counts skipped steps a real run does not.

That is the surface an author uses to find out whether their contract holds, so a private second implementation is the worst possible place for drift. It now reads the runner's result, exactly as the flat branch always has.

Verified through the CLI: a satisfiable chained contract now **passes** `recipe test` (it could not before), an unsatisfiable one still fails, and the message names the real step ids (`not found in [fetch]`) instead of an empty list.

## Known, and NOT fixed here

`recipe run --local` passes no `runLog` / `runLogDir` in its `chainedOptions`, so a chained CLI run writes **no runner row at all** and its `assertionFailures` cannot be persisted on that path. Pre-existing and separate — the bridge path does pass `runLog` and is covered. Called out rather than left to be rediscovered.

## Verification

| mutation (each confirmed applied first) | result |
|---|---|
| never evaluate (the pre-fix state) | 4 failed |
| drop the run-log persistence | 1 failed |
| emit an empty array instead of omitting | 3 failed |
| count skipped steps into `stepsRun` | 1 failed |
| disable the lint rule | 2 failed |
| fire the lint rule on flat recipes too | 1 failed |
| restored | all pass |

10,383 passed · `typecheck`, `typecheck:tests:core`, `audit-in-flight`, `audit-business-content`, `audit-private-identifiers` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)