### PR TITLE
feat(recipes): an expect on a conditional step could never fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,13 @@ jobs:
         run: npm run build
       - name: Audit LSP tool lists
         run: node scripts/audit-lsp-tools.mjs
+      # `schemas/` and `dashboard/public/schema/` are GENERATED and committed.
+      # Nothing compared them to their generator, so an edit without a
+      # regeneration shipped silently — and had: the committed recipe schema
+      # was 184 lines behind. Runs here because this job already builds dist/,
+      # which the gate needs.
+      - name: Audit generated JSON Schemas match their generator
+        run: node scripts/audit-generated-schemas.mjs
       - name: Audit shape safety (proxy<T> usage)
         run: node scripts/audit-shape-safety.mjs
       - name: Audit IntelliJ ↔ VSCode wire-method parity

--- a/dashboard/public/schema/recipe.v1.json
+++ b/dashboard/public/schema/recipe.v1.json
@@ -296,6 +296,10 @@
                       "warn"
                     ],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
@@ -526,6 +530,10 @@
                       "warn"
                     ],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
@@ -635,6 +643,10 @@
                       "warn"
                     ],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
@@ -770,6 +782,10 @@
                                     "warn"
                                   ],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
@@ -1000,6 +1016,10 @@
                                     "warn"
                                   ],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
@@ -1109,6 +1129,10 @@
                                     "warn"
                                   ],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
@@ -1243,6 +1267,10 @@
                                         "warn"
                                       ],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
@@ -1473,6 +1501,10 @@
                                         "warn"
                                       ],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
@@ -1582,6 +1614,10 @@
                                         "warn"
                                       ],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,12 +50,24 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-26 `feat/step-expect-required` — an `expect` on a `when:`-guarded step is
-  unenforceable by construction: both runners evaluate it only on a step that RAN. Adds
-  opt-in `expect.required`, written for BOTH runners. Also regenerates the committed JSON
-  Schemas, which were found 184 lines behind their generator, and gates that.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-26 `feat/step-expect-required` — both runners evaluate `step.expect` only on a
+  step that RAN, so an expectation on a `when:`-guarded step could never fail. Opt-in
+  `expect.required` (default false, so nothing existing changes) makes a `when:`-skip of a
+  required step an `expect_failed` error the halt count can see. Written for BOTH runners
+  in one change — a mutation disabling only the chained half fails the suite — and scoped
+  to the `when:` guard ONLY, leaving the guard-tested unregistered-tool skip untouched.
+  The schema diff is large because adding one property forced a regeneration, which
+  revealed the committed schemas were 184 lines BEHIND their generator; the published copy
+  being LOOSER than the runtime validator is the dangerous direction, since an editor
+  loads it through the SchemaStore pragma and tells the author their recipe is fine.
+  `audit-generated-schemas.mjs` now gates it: compares in memory and never writes (a gate
+  that fixes what it checks lands the fix unreviewed), names files not schema bodies, and
+  exits NON-ZERO as NOT VERIFIED when `dist/` is missing. Recorded and not changed: an
+  unresolvable `when:` ref is a template ERROR on chained and merely falsy on flat. (#1530)
 
 - 2026-08-26 `feat/halts-see-completion-contracts` — a run that violated its run-level
   `recipe.expect` finished `done`, and `summariseHalts` only emits a run-level entry for

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- 2026-08-26 `feat/step-expect-required` — an `expect` on a `when:`-guarded step is
+  unenforceable by construction: both runners evaluate it only on a step that RAN. Adds
+  opt-in `expect.required`, written for BOTH runners. Also regenerates the committed JSON
+  Schemas, which were found 184 lines behind their generator, and gates that.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/schemas/dry-run-plan.v1.json
+++ b/schemas/dry-run-plan.v1.json
@@ -49,21 +49,14 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "id",
-          "type"
-        ],
+        "required": ["id", "type"],
         "properties": {
           "id": {
             "type": "string"
           },
           "type": {
             "type": "string",
-            "enum": [
-              "tool",
-              "agent",
-              "recipe"
-            ]
+            "enum": ["tool", "agent", "recipe"]
           },
           "tool": {
             "type": "string"
@@ -95,11 +88,7 @@
           },
           "risk": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "enum": ["low", "medium", "high"]
           },
           "isWrite": {
             "type": "boolean"

--- a/schemas/dry-run-plan.v1.json
+++ b/schemas/dry-run-plan.v1.json
@@ -49,14 +49,21 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "type"],
+        "required": [
+          "id",
+          "type"
+        ],
         "properties": {
           "id": {
             "type": "string"
           },
           "type": {
             "type": "string",
-            "enum": ["tool", "agent", "recipe"]
+            "enum": [
+              "tool",
+              "agent",
+              "recipe"
+            ]
           },
           "tool": {
             "type": "string"
@@ -88,7 +95,11 @@
           },
           "risk": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "isWrite": {
             "type": "boolean"

--- a/schemas/recipe.v1.json
+++ b/schemas/recipe.v1.json
@@ -3,18 +3,9 @@
   "$id": "https://raw.githubusercontent.com/patchworkos/recipes/main/schema/recipe.v1.json",
   "title": "Patchwork Recipe",
   "description": "YAML recipe schema for Patchwork automation",
-  "x-taplo": {
-    "file-patterns": [
-      "*.patchwork.yaml",
-      "*.patchwork.yml"
-    ]
-  },
+  "x-taplo": { "file-patterns": ["*.patchwork.yaml", "*.patchwork.yml"] },
   "type": "object",
-  "required": [
-    "name",
-    "trigger",
-    "steps"
-  ],
+  "required": ["name", "trigger", "steps"],
   "properties": {
     "name": {
       "type": "string",
@@ -42,17 +33,13 @@
     "apiVersion": {
       "type": "string",
       "description": "Patchwork API version",
-      "enum": [
-        "patchwork.sh/v1"
-      ],
+      "enum": ["patchwork.sh/v1"],
       "default": "patchwork.sh/v1"
     },
     "trigger": {
       "type": "object",
       "description": "When to run this recipe",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -78,11 +65,7 @@
         },
         "on": {
           "type": "string",
-          "enum": [
-            "post-commit",
-            "pre-push",
-            "post-merge"
-          ],
+          "enum": ["post-commit", "pre-push", "post-merge"],
           "description": "Git hook event (for git_hook trigger)"
         },
         "filter": {
@@ -91,12 +74,10 @@
         },
         "vars": {
           "type": "array",
-          "description": "Declared input variables resolvable as {{name}} in steps. Place declared variables here (NOT at recipe root — top-level vars are ignored at runtime).",
+          "description": "Declared input variables resolvable as {{name}} in steps. Place declared variables here (NOT at recipe root \u2014 top-level vars are ignored at runtime).",
           "items": {
             "type": "object",
-            "required": [
-              "name"
-            ],
+            "required": ["name"],
             "properties": {
               "name": {
                 "type": "string",
@@ -107,9 +88,7 @@
                 "type": "boolean",
                 "description": "Whether the variable must be supplied."
               },
-              "default": {
-                "description": "Default value when not supplied."
-              },
+              "default": { "description": "Default value when not supplied." },
               "description": {
                 "type": "string",
                 "description": "Human-readable description of the variable."
@@ -119,12 +98,10 @@
         },
         "inputs": {
           "type": "array",
-          "description": "Alias for trigger.vars — declared input variables resolvable as {{name}} in steps.",
+          "description": "Alias for trigger.vars \u2014 declared input variables resolvable as {{name}} in steps.",
           "items": {
             "type": "object",
-            "required": [
-              "name"
-            ],
+            "required": ["name"],
             "properties": {
               "name": {
                 "type": "string",
@@ -135,9 +112,7 @@
                 "type": "boolean",
                 "description": "Whether the variable must be supplied."
               },
-              "default": {
-                "description": "Default value when not supplied."
-              },
+              "default": { "description": "Default value when not supplied." },
               "description": {
                 "type": "string",
                 "description": "Human-readable description of the variable."
@@ -150,14 +125,7 @@
           "description": "Webhook/event source name after legacy trigger normalization"
         },
         "eventFilter": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object"
-            }
-          ],
+          "oneOf": [{ "type": "string" }, { "type": "object" }],
           "description": "Webhook/event filter after legacy trigger normalization"
         },
         "eventLeadTimeHours": {
@@ -170,9 +138,7 @@
         },
         "legacyType": {
           "type": "string",
-          "enum": [
-            "event"
-          ],
+          "enum": ["event"],
           "description": "Original trigger type preserved during legacy normalization"
         }
       }
@@ -182,26 +148,11 @@
       "description": "Context blocks to load before running steps",
       "items": {
         "type": "object",
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "file",
-              "env"
-            ]
-          },
-          "path": {
-            "type": "string"
-          },
-          "keys": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
+          "type": { "type": "string", "enum": ["file", "env"] },
+          "path": { "type": "string" },
+          "keys": { "type": "array", "items": { "type": "string" } }
         }
       }
     },
@@ -212,9 +163,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "agent"
-            ],
+            "required": ["agent"],
             "properties": {
               "id": {
                 "type": "string",
@@ -223,9 +172,7 @@
               "awaits": {
                 "type": "array",
                 "description": "Step IDs that must complete before this step runs",
-                "items": {
-                  "type": "string"
-                }
+                "items": { "type": "string" }
               },
               "when": {
                 "type": "string",
@@ -237,11 +184,7 @@
               },
               "risk": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
+                "enum": ["low", "medium", "high"],
                 "description": "Risk level for this step"
               },
               "transform": {
@@ -277,37 +220,25 @@
                   },
                   "contains": {
                     "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+                      { "type": "string" },
+                      { "type": "array", "items": { "type": "string" } }
                     ],
-                    "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                    "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                   },
                   "on_fail": {
                     "type": "string",
-                    "enum": [
-                      "halt",
-                      "warn"
-                    ],
+                    "enum": ["halt", "warn"],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                   },
                   "required": {
                     "type": "boolean",
-                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
               "agent": {
                 "type": "object",
-                "required": [
-                  "prompt"
-                ],
+                "required": ["prompt"],
                 "description": "Agent step configuration",
                 "properties": {
                   "prompt": {
@@ -344,9 +275,7 @@
                   },
                   "tools": {
                     "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
+                    "items": { "type": "string" },
                     "description": "Tool allowlist. When `sandbox` is true, enforced via --allowed-tools on the spawned claude -p."
                   },
                   "sandbox": {
@@ -355,38 +284,31 @@
                   },
                   "disallowedTools": {
                     "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
+                    "items": { "type": "string" },
                     "description": "Deny rules applied via --disallowed-tools regardless of sandbox mode."
                   },
                   "kind": {
                     "type": "string",
-                    "enum": [
-                      "judge"
-                    ],
+                    "enum": ["judge"],
                     "description": "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log."
                   },
                   "reviews": {
                     "type": "string",
-                    "description": "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop."
+                    "description": "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge\u2192refine loop."
                   },
                   "max_revisions": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews."
+                    "description": "OPT-IN judge\u2192refine loop. Max revise\u2192re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews."
                   },
                   "on_exhausted": {
                     "type": "string",
-                    "enum": [
-                      "halt",
-                      "proceed"
-                    ],
+                    "enum": ["halt", "proceed"],
                     "description": "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft."
                   },
                   "downshift": {
                     "type": "array",
-                    "description": "OPT-IN cost-aware routing (Phase 4). Ordered cheaper fallbacks tried when budget.usdMax is set and the remaining budget is too tight for the preferred driver/model. Each entry overrides driver and/or model. Absent → preferred model always used.",
+                    "description": "OPT-IN cost-aware routing (Phase 4). Ordered cheaper fallbacks tried when budget.usdMax is set and the remaining budget is too tight for the preferred driver/model. Each entry overrides driver and/or model. Absent \u2192 preferred model always used.",
                     "items": {
                       "type": "object",
                       "additionalProperties": false,
@@ -406,15 +328,13 @@
                             "local"
                           ]
                         },
-                        "model": {
-                          "type": "string"
-                        }
+                        "model": { "type": "string" }
                       }
                     }
                   },
                   "escalate": {
                     "type": "array",
-                    "description": "OPT-IN quality-aware escalation (dual of downshift). Ordered MORE-capable fallbacks. In a judge→refine loop (reviews + max_revisions>0), the Nth request_changes revision re-runs the reviewed step with escalate[N-1] instead of the base model — start local/cheap, escalate to a stronger model only when output fails judgment. Each entry overrides driver and/or model.",
+                    "description": "OPT-IN quality-aware escalation (dual of downshift). Ordered MORE-capable fallbacks. In a judge\u2192refine loop (reviews + max_revisions>0), the Nth request_changes revision re-runs the reviewed step with escalate[N-1] instead of the base model \u2014 start local/cheap, escalate to a stronger model only when output fails judgment. Each entry overrides driver and/or model.",
                     "items": {
                       "type": "object",
                       "additionalProperties": false,
@@ -434,9 +354,7 @@
                             "local"
                           ]
                         },
-                        "model": {
-                          "type": "string"
-                        }
+                        "model": { "type": "string" }
                       }
                     }
                   }
@@ -446,9 +364,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "tool"
-            ],
+            "required": ["tool"],
             "properties": {
               "id": {
                 "type": "string",
@@ -457,9 +373,7 @@
               "awaits": {
                 "type": "array",
                 "description": "Step IDs that must complete before this step runs",
-                "items": {
-                  "type": "string"
-                }
+                "items": { "type": "string" }
               },
               "when": {
                 "type": "string",
@@ -471,11 +385,7 @@
               },
               "risk": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
+                "enum": ["low", "medium", "high"],
                 "description": "Risk level for this step"
               },
               "transform": {
@@ -511,57 +421,29 @@
                   },
                   "contains": {
                     "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+                      { "type": "string" },
+                      { "type": "array", "items": { "type": "string" } }
                     ],
-                    "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                    "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                   },
                   "on_fail": {
                     "type": "string",
-                    "enum": [
-                      "halt",
-                      "warn"
-                    ],
+                    "enum": ["halt", "warn"],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                   },
                   "required": {
                     "type": "boolean",
-                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
-              "tool": {
-                "type": "string",
-                "not": {
-                  "enum": []
-                }
-              },
-              "into": {
-                "type": "string"
-              }
+              "tool": { "type": "string", "not": { "enum": [] } },
+              "into": { "type": "string" }
             }
           },
           {
             "type": "object",
-            "anyOf": [
-              {
-                "required": [
-                  "recipe"
-                ]
-              },
-              {
-                "required": [
-                  "chain"
-                ]
-              }
-            ],
+            "anyOf": [{ "required": ["recipe"] }, { "required": ["chain"] }],
             "properties": {
               "id": {
                 "type": "string",
@@ -570,9 +452,7 @@
               "awaits": {
                 "type": "array",
                 "description": "Step IDs that must complete before this step runs",
-                "items": {
-                  "type": "string"
-                }
+                "items": { "type": "string" }
               },
               "when": {
                 "type": "string",
@@ -584,11 +464,7 @@
               },
               "risk": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
+                "enum": ["low", "medium", "high"],
                 "description": "Risk level for this step"
               },
               "transform": {
@@ -624,29 +500,19 @@
                   },
                   "contains": {
                     "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+                      { "type": "string" },
+                      { "type": "array", "items": { "type": "string" } }
                     ],
-                    "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                    "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                   },
                   "on_fail": {
                     "type": "string",
-                    "enum": [
-                      "halt",
-                      "warn"
-                    ],
+                    "enum": ["halt", "warn"],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                   },
                   "required": {
                     "type": "boolean",
-                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
@@ -661,9 +527,7 @@
               "vars": {
                 "type": "object",
                 "description": "Template variables passed into a nested recipe step",
-                "additionalProperties": {
-                  "type": "string"
-                }
+                "additionalProperties": { "type": "string" }
               },
               "output": {
                 "type": "string",
@@ -673,23 +537,19 @@
           },
           {
             "type": "object",
-            "required": [
-              "parallel"
-            ],
+            "required": ["parallel"],
             "properties": {
               "id": {
                 "type": "string",
-                "description": "Optional group id — used as awaits target by later steps"
+                "description": "Optional group id \u2014 used as awaits target by later steps"
               },
               "awaits": {
                 "type": "array",
                 "description": "Step IDs that must complete before this group starts",
-                "items": {
-                  "type": "string"
-                }
+                "items": { "type": "string" }
               },
               "parallel": {
-                "description": "Run these steps concurrently. Array form: steps run in parallel. Object form: map-reduce — each item in `each` is bound to `as` and the steps array runs once per item.",
+                "description": "Run these steps concurrently. Array form: steps run in parallel. Object form: map-reduce \u2014 each item in `each` is bound to `as` and the steps array runs once per item.",
                 "oneOf": [
                   {
                     "type": "array",
@@ -698,9 +558,7 @@
                       "oneOf": [
                         {
                           "type": "object",
-                          "required": [
-                            "agent"
-                          ],
+                          "required": ["agent"],
                           "properties": {
                             "id": {
                               "type": "string",
@@ -709,9 +567,7 @@
                             "awaits": {
                               "type": "array",
                               "description": "Step IDs that must complete before this step runs",
-                              "items": {
-                                "type": "string"
-                              }
+                              "items": { "type": "string" }
                             },
                             "when": {
                               "type": "string",
@@ -723,11 +579,7 @@
                             },
                             "risk": {
                               "type": "string",
-                              "enum": [
-                                "low",
-                                "medium",
-                                "high"
-                              ],
+                              "enum": ["low", "medium", "high"],
                               "description": "Risk level for this step"
                             },
                             "transform": {
@@ -763,37 +615,28 @@
                                 },
                                 "contains": {
                                   "oneOf": [
-                                    {
-                                      "type": "string"
-                                    },
+                                    { "type": "string" },
                                     {
                                       "type": "array",
-                                      "items": {
-                                        "type": "string"
-                                      }
+                                      "items": { "type": "string" }
                                     }
                                   ],
-                                  "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                                  "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                                 },
                                 "on_fail": {
                                   "type": "string",
-                                  "enum": [
-                                    "halt",
-                                    "warn"
-                                  ],
+                                  "enum": ["halt", "warn"],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                                 },
                                 "required": {
                                   "type": "boolean",
-                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
                             "agent": {
                               "type": "object",
-                              "required": [
-                                "prompt"
-                              ],
+                              "required": ["prompt"],
                               "description": "Agent step configuration",
                               "properties": {
                                 "prompt": {
@@ -830,9 +673,7 @@
                                 },
                                 "tools": {
                                   "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  },
+                                  "items": { "type": "string" },
                                   "description": "Tool allowlist. When `sandbox` is true, enforced via --allowed-tools on the spawned claude -p."
                                 },
                                 "sandbox": {
@@ -841,38 +682,31 @@
                                 },
                                 "disallowedTools": {
                                   "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  },
+                                  "items": { "type": "string" },
                                   "description": "Deny rules applied via --disallowed-tools regardless of sandbox mode."
                                 },
                                 "kind": {
                                   "type": "string",
-                                  "enum": [
-                                    "judge"
-                                  ],
+                                  "enum": ["judge"],
                                   "description": "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log."
                                 },
                                 "reviews": {
                                   "type": "string",
-                                  "description": "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop."
+                                  "description": "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge\u2192refine loop."
                                 },
                                 "max_revisions": {
                                   "type": "integer",
                                   "minimum": 0,
-                                  "description": "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews."
+                                  "description": "OPT-IN judge\u2192refine loop. Max revise\u2192re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews."
                                 },
                                 "on_exhausted": {
                                   "type": "string",
-                                  "enum": [
-                                    "halt",
-                                    "proceed"
-                                  ],
+                                  "enum": ["halt", "proceed"],
                                   "description": "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft."
                                 },
                                 "downshift": {
                                   "type": "array",
-                                  "description": "OPT-IN cost-aware routing (Phase 4). Ordered cheaper fallbacks tried when budget.usdMax is set and the remaining budget is too tight for the preferred driver/model. Each entry overrides driver and/or model. Absent → preferred model always used.",
+                                  "description": "OPT-IN cost-aware routing (Phase 4). Ordered cheaper fallbacks tried when budget.usdMax is set and the remaining budget is too tight for the preferred driver/model. Each entry overrides driver and/or model. Absent \u2192 preferred model always used.",
                                   "items": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -892,15 +726,13 @@
                                           "local"
                                         ]
                                       },
-                                      "model": {
-                                        "type": "string"
-                                      }
+                                      "model": { "type": "string" }
                                     }
                                   }
                                 },
                                 "escalate": {
                                   "type": "array",
-                                  "description": "OPT-IN quality-aware escalation (dual of downshift). Ordered MORE-capable fallbacks. In a judge→refine loop (reviews + max_revisions>0), the Nth request_changes revision re-runs the reviewed step with escalate[N-1] instead of the base model — start local/cheap, escalate to a stronger model only when output fails judgment. Each entry overrides driver and/or model.",
+                                  "description": "OPT-IN quality-aware escalation (dual of downshift). Ordered MORE-capable fallbacks. In a judge\u2192refine loop (reviews + max_revisions>0), the Nth request_changes revision re-runs the reviewed step with escalate[N-1] instead of the base model \u2014 start local/cheap, escalate to a stronger model only when output fails judgment. Each entry overrides driver and/or model.",
                                   "items": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -920,9 +752,7 @@
                                           "local"
                                         ]
                                       },
-                                      "model": {
-                                        "type": "string"
-                                      }
+                                      "model": { "type": "string" }
                                     }
                                   }
                                 }
@@ -932,9 +762,7 @@
                         },
                         {
                           "type": "object",
-                          "required": [
-                            "tool"
-                          ],
+                          "required": ["tool"],
                           "properties": {
                             "id": {
                               "type": "string",
@@ -943,9 +771,7 @@
                             "awaits": {
                               "type": "array",
                               "description": "Step IDs that must complete before this step runs",
-                              "items": {
-                                "type": "string"
-                              }
+                              "items": { "type": "string" }
                             },
                             "when": {
                               "type": "string",
@@ -957,11 +783,7 @@
                             },
                             "risk": {
                               "type": "string",
-                              "enum": [
-                                "low",
-                                "medium",
-                                "high"
-                              ],
+                              "enum": ["low", "medium", "high"],
                               "description": "Risk level for this step"
                             },
                             "transform": {
@@ -997,56 +819,34 @@
                                 },
                                 "contains": {
                                   "oneOf": [
-                                    {
-                                      "type": "string"
-                                    },
+                                    { "type": "string" },
                                     {
                                       "type": "array",
-                                      "items": {
-                                        "type": "string"
-                                      }
+                                      "items": { "type": "string" }
                                     }
                                   ],
-                                  "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                                  "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                                 },
                                 "on_fail": {
                                   "type": "string",
-                                  "enum": [
-                                    "halt",
-                                    "warn"
-                                  ],
+                                  "enum": ["halt", "warn"],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                                 },
                                 "required": {
                                   "type": "boolean",
-                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
-                            "tool": {
-                              "type": "string",
-                              "not": {
-                                "enum": []
-                              }
-                            },
-                            "into": {
-                              "type": "string"
-                            }
+                            "tool": { "type": "string", "not": { "enum": [] } },
+                            "into": { "type": "string" }
                           }
                         },
                         {
                           "type": "object",
                           "anyOf": [
-                            {
-                              "required": [
-                                "recipe"
-                              ]
-                            },
-                            {
-                              "required": [
-                                "chain"
-                              ]
-                            }
+                            { "required": ["recipe"] },
+                            { "required": ["chain"] }
                           ],
                           "properties": {
                             "id": {
@@ -1056,9 +856,7 @@
                             "awaits": {
                               "type": "array",
                               "description": "Step IDs that must complete before this step runs",
-                              "items": {
-                                "type": "string"
-                              }
+                              "items": { "type": "string" }
                             },
                             "when": {
                               "type": "string",
@@ -1070,11 +868,7 @@
                             },
                             "risk": {
                               "type": "string",
-                              "enum": [
-                                "low",
-                                "medium",
-                                "high"
-                              ],
+                              "enum": ["low", "medium", "high"],
                               "description": "Risk level for this step"
                             },
                             "transform": {
@@ -1110,29 +904,22 @@
                                 },
                                 "contains": {
                                   "oneOf": [
-                                    {
-                                      "type": "string"
-                                    },
+                                    { "type": "string" },
                                     {
                                       "type": "array",
-                                      "items": {
-                                        "type": "string"
-                                      }
+                                      "items": { "type": "string" }
                                     }
                                   ],
-                                  "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                                  "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                                 },
                                 "on_fail": {
                                   "type": "string",
-                                  "enum": [
-                                    "halt",
-                                    "warn"
-                                  ],
+                                  "enum": ["halt", "warn"],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                                 },
                                 "required": {
                                   "type": "boolean",
-                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
@@ -1147,9 +934,7 @@
                             "vars": {
                               "type": "object",
                               "description": "Template variables passed into a nested recipe step",
-                              "additionalProperties": {
-                                "type": "string"
-                              }
+                              "additionalProperties": { "type": "string" }
                             },
                             "output": {
                               "type": "string",
@@ -1162,11 +947,8 @@
                   },
                   {
                     "type": "object",
-                    "description": "Map-reduce form — iterate over a collection and run steps once per item.",
-                    "required": [
-                      "each",
-                      "steps"
-                    ],
+                    "description": "Map-reduce form \u2014 iterate over a collection and run steps once per item.",
+                    "required": ["each", "steps"],
                     "properties": {
                       "each": {
                         "type": "string",
@@ -1183,9 +965,7 @@
                           "oneOf": [
                             {
                               "type": "object",
-                              "required": [
-                                "agent"
-                              ],
+                              "required": ["agent"],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -1194,9 +974,7 @@
                                 "awaits": {
                                   "type": "array",
                                   "description": "Step IDs that must complete before this step runs",
-                                  "items": {
-                                    "type": "string"
-                                  }
+                                  "items": { "type": "string" }
                                 },
                                 "when": {
                                   "type": "string",
@@ -1208,11 +986,7 @@
                                 },
                                 "risk": {
                                   "type": "string",
-                                  "enum": [
-                                    "low",
-                                    "medium",
-                                    "high"
-                                  ],
+                                  "enum": ["low", "medium", "high"],
                                   "description": "Risk level for this step"
                                 },
                                 "transform": {
@@ -1248,37 +1022,28 @@
                                     },
                                     "contains": {
                                       "oneOf": [
-                                        {
-                                          "type": "string"
-                                        },
+                                        { "type": "string" },
                                         {
                                           "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "items": { "type": "string" }
                                         }
                                       ],
-                                      "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                                      "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                                     },
                                     "on_fail": {
                                       "type": "string",
-                                      "enum": [
-                                        "halt",
-                                        "warn"
-                                      ],
+                                      "enum": ["halt", "warn"],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                                     },
                                     "required": {
                                       "type": "boolean",
-                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
                                 "agent": {
                                   "type": "object",
-                                  "required": [
-                                    "prompt"
-                                  ],
+                                  "required": ["prompt"],
                                   "description": "Agent step configuration",
                                   "properties": {
                                     "prompt": {
@@ -1315,9 +1080,7 @@
                                     },
                                     "tools": {
                                       "type": "array",
-                                      "items": {
-                                        "type": "string"
-                                      },
+                                      "items": { "type": "string" },
                                       "description": "Tool allowlist. When `sandbox` is true, enforced via --allowed-tools on the spawned claude -p."
                                     },
                                     "sandbox": {
@@ -1326,38 +1089,31 @@
                                     },
                                     "disallowedTools": {
                                       "type": "array",
-                                      "items": {
-                                        "type": "string"
-                                      },
+                                      "items": { "type": "string" },
                                       "description": "Deny rules applied via --disallowed-tools regardless of sandbox mode."
                                     },
                                     "kind": {
                                       "type": "string",
-                                      "enum": [
-                                        "judge"
-                                      ],
+                                      "enum": ["judge"],
                                       "description": "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log."
                                     },
                                     "reviews": {
                                       "type": "string",
-                                      "description": "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge→refine loop."
+                                      "description": "Step output key the judge reviews (its `into`, default 'agent_output'). Required for the judge\u2192refine loop."
                                     },
                                     "max_revisions": {
                                       "type": "integer",
                                       "minimum": 0,
-                                      "description": "OPT-IN judge→refine loop. Max revise→re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews."
+                                      "description": "OPT-IN judge\u2192refine loop. Max revise\u2192re-judge cycles when the verdict is 'request_changes' (0/absent = augment-only, no loop). Requires kind:judge + reviews."
                                     },
                                     "on_exhausted": {
                                       "type": "string",
-                                      "enum": [
-                                        "halt",
-                                        "proceed"
-                                      ],
+                                      "enum": ["halt", "proceed"],
                                       "description": "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft."
                                     },
                                     "downshift": {
                                       "type": "array",
-                                      "description": "OPT-IN cost-aware routing (Phase 4). Ordered cheaper fallbacks tried when budget.usdMax is set and the remaining budget is too tight for the preferred driver/model. Each entry overrides driver and/or model. Absent → preferred model always used.",
+                                      "description": "OPT-IN cost-aware routing (Phase 4). Ordered cheaper fallbacks tried when budget.usdMax is set and the remaining budget is too tight for the preferred driver/model. Each entry overrides driver and/or model. Absent \u2192 preferred model always used.",
                                       "items": {
                                         "type": "object",
                                         "additionalProperties": false,
@@ -1377,15 +1133,13 @@
                                               "local"
                                             ]
                                           },
-                                          "model": {
-                                            "type": "string"
-                                          }
+                                          "model": { "type": "string" }
                                         }
                                       }
                                     },
                                     "escalate": {
                                       "type": "array",
-                                      "description": "OPT-IN quality-aware escalation (dual of downshift). Ordered MORE-capable fallbacks. In a judge→refine loop (reviews + max_revisions>0), the Nth request_changes revision re-runs the reviewed step with escalate[N-1] instead of the base model — start local/cheap, escalate to a stronger model only when output fails judgment. Each entry overrides driver and/or model.",
+                                      "description": "OPT-IN quality-aware escalation (dual of downshift). Ordered MORE-capable fallbacks. In a judge\u2192refine loop (reviews + max_revisions>0), the Nth request_changes revision re-runs the reviewed step with escalate[N-1] instead of the base model \u2014 start local/cheap, escalate to a stronger model only when output fails judgment. Each entry overrides driver and/or model.",
                                       "items": {
                                         "type": "object",
                                         "additionalProperties": false,
@@ -1405,9 +1159,7 @@
                                               "local"
                                             ]
                                           },
-                                          "model": {
-                                            "type": "string"
-                                          }
+                                          "model": { "type": "string" }
                                         }
                                       }
                                     }
@@ -1417,9 +1169,7 @@
                             },
                             {
                               "type": "object",
-                              "required": [
-                                "tool"
-                              ],
+                              "required": ["tool"],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -1428,9 +1178,7 @@
                                 "awaits": {
                                   "type": "array",
                                   "description": "Step IDs that must complete before this step runs",
-                                  "items": {
-                                    "type": "string"
-                                  }
+                                  "items": { "type": "string" }
                                 },
                                 "when": {
                                   "type": "string",
@@ -1442,11 +1190,7 @@
                                 },
                                 "risk": {
                                   "type": "string",
-                                  "enum": [
-                                    "low",
-                                    "medium",
-                                    "high"
-                                  ],
+                                  "enum": ["low", "medium", "high"],
                                   "description": "Risk level for this step"
                                 },
                                 "transform": {
@@ -1482,56 +1226,37 @@
                                     },
                                     "contains": {
                                       "oneOf": [
-                                        {
-                                          "type": "string"
-                                        },
+                                        { "type": "string" },
                                         {
                                           "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "items": { "type": "string" }
                                         }
                                       ],
-                                      "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                                      "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                                     },
                                     "on_fail": {
                                       "type": "string",
-                                      "enum": [
-                                        "halt",
-                                        "warn"
-                                      ],
+                                      "enum": ["halt", "warn"],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                                     },
                                     "required": {
                                       "type": "boolean",
-                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
                                 "tool": {
                                   "type": "string",
-                                  "not": {
-                                    "enum": []
-                                  }
+                                  "not": { "enum": [] }
                                 },
-                                "into": {
-                                  "type": "string"
-                                }
+                                "into": { "type": "string" }
                               }
                             },
                             {
                               "type": "object",
                               "anyOf": [
-                                {
-                                  "required": [
-                                    "recipe"
-                                  ]
-                                },
-                                {
-                                  "required": [
-                                    "chain"
-                                  ]
-                                }
+                                { "required": ["recipe"] },
+                                { "required": ["chain"] }
                               ],
                               "properties": {
                                 "id": {
@@ -1541,9 +1266,7 @@
                                 "awaits": {
                                   "type": "array",
                                   "description": "Step IDs that must complete before this step runs",
-                                  "items": {
-                                    "type": "string"
-                                  }
+                                  "items": { "type": "string" }
                                 },
                                 "when": {
                                   "type": "string",
@@ -1555,11 +1278,7 @@
                                 },
                                 "risk": {
                                   "type": "string",
-                                  "enum": [
-                                    "low",
-                                    "medium",
-                                    "high"
-                                  ],
+                                  "enum": ["low", "medium", "high"],
                                   "description": "Risk level for this step"
                                 },
                                 "transform": {
@@ -1595,29 +1314,22 @@
                                     },
                                     "contains": {
                                       "oneOf": [
-                                        {
-                                          "type": "string"
-                                        },
+                                        { "type": "string" },
                                         {
                                           "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
+                                          "items": { "type": "string" }
                                         }
                                       ],
-                                      "description": "Substring(s) that must appear in the stringified output. Array → all must be present."
+                                      "description": "Substring(s) that must appear in the stringified output. Array \u2192 all must be present."
                                     },
                                     "on_fail": {
                                       "type": "string",
-                                      "enum": [
-                                        "halt",
-                                        "warn"
-                                      ],
+                                      "enum": ["halt", "warn"],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
                                     },
                                     "required": {
                                       "type": "boolean",
-                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only \u2014 a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
@@ -1632,9 +1344,7 @@
                                 "vars": {
                                   "type": "object",
                                   "description": "Template variables passed into a nested recipe step",
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  }
+                                  "additionalProperties": { "type": "string" }
                                 },
                                 "output": {
                                   "type": "string",
@@ -1656,7 +1366,7 @@
     },
     "expect": {
       "type": "object",
-      "description": "Completion contract for the run: assertions that must hold once the recipe finishes. Evaluated on EVERY non-testMode run, not only under `recipe test` — a violation is persisted as `assertionFailures` and withholds the run's trust evidence from the owning worker.",
+      "description": "Completion contract for the run: assertions that must hold once the recipe finishes. Evaluated on EVERY non-testMode run, not only under `recipe test` \u2014 a violation is persisted as `assertionFailures` and withholds the run's trust evidence from the owning worker.",
       "properties": {
         "stepsRun": {
           "type": "number",
@@ -1665,23 +1375,16 @@
         "outputs": {
           "type": "array",
           "description": "Expected output paths or keys recorded by the run",
-          "items": {
-            "type": "string"
-          }
+          "items": { "type": "string" }
         },
         "errorMessage": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "description": "Expected final error message, or null for a clean run"
         },
         "context": {
           "type": "object",
           "description": "Expected context key/value pairs after the run",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "additionalProperties": { "type": "string" }
         }
       }
     },
@@ -1711,11 +1414,7 @@
         },
         "fallback": {
           "type": "string",
-          "enum": [
-            "log_only",
-            "abort",
-            "deliver_original"
-          ],
+          "enum": ["log_only", "abort", "deliver_original"],
           "description": "log_only / deliver_original: treat step failure as non-fatal (like optional); fail-open. abort (default): propagate failure."
         },
         "notify": {
@@ -1741,14 +1440,11 @@
         },
         "estimateUnmeasured": {
           "type": "boolean",
-          "description": "OPT-IN (default false). Estimate the notional list-price USD an unmeasured/subscription call would have cost and surface a ≈$ figure. Label only — never counted toward usdMax, never halts. Requires usdMax."
+          "description": "OPT-IN (default false). Estimate the notional list-price USD an unmeasured/subscription call would have cost and surface a \u2248$ figure. Label only \u2014 never counted toward usdMax, never halts. Requires usdMax."
         },
         "onBreach": {
           "type": "string",
-          "enum": [
-            "halt",
-            "warn"
-          ],
+          "enum": ["halt", "warn"],
           "description": "halt (default): stop run on next admission check. warn: continue but record the breach in the run log. Applies to both tokensMax and usdMax.",
           "default": "halt"
         }
@@ -1757,9 +1453,7 @@
     "servers": {
       "type": "array",
       "description": "Plugin package specifiers (npm package names or file paths) whose tools are loaded and available to steps in this recipe. Loaded once at run start.",
-      "items": {
-        "type": "string"
-      }
+      "items": { "type": "string" }
     }
   }
 }

--- a/schemas/recipe.v1.json
+++ b/schemas/recipe.v1.json
@@ -4,10 +4,17 @@
   "title": "Patchwork Recipe",
   "description": "YAML recipe schema for Patchwork automation",
   "x-taplo": {
-    "file-patterns": ["*.patchwork.yaml", "*.patchwork.yml"]
+    "file-patterns": [
+      "*.patchwork.yaml",
+      "*.patchwork.yml"
+    ]
   },
   "type": "object",
-  "required": ["name", "trigger", "steps"],
+  "required": [
+    "name",
+    "trigger",
+    "steps"
+  ],
   "properties": {
     "name": {
       "type": "string",
@@ -35,13 +42,17 @@
     "apiVersion": {
       "type": "string",
       "description": "Patchwork API version",
-      "enum": ["patchwork.sh/v1"],
+      "enum": [
+        "patchwork.sh/v1"
+      ],
       "default": "patchwork.sh/v1"
     },
     "trigger": {
       "type": "object",
       "description": "When to run this recipe",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -67,7 +78,11 @@
         },
         "on": {
           "type": "string",
-          "enum": ["post-commit", "pre-push", "post-merge"],
+          "enum": [
+            "post-commit",
+            "pre-push",
+            "post-merge"
+          ],
           "description": "Git hook event (for git_hook trigger)"
         },
         "filter": {
@@ -79,7 +94,9 @@
           "description": "Declared input variables resolvable as {{name}} in steps. Place declared variables here (NOT at recipe root — top-level vars are ignored at runtime).",
           "items": {
             "type": "object",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "type": "string",
@@ -105,7 +122,9 @@
           "description": "Alias for trigger.vars — declared input variables resolvable as {{name}} in steps.",
           "items": {
             "type": "object",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "type": "string",
@@ -151,7 +170,9 @@
         },
         "legacyType": {
           "type": "string",
-          "enum": ["event"],
+          "enum": [
+            "event"
+          ],
           "description": "Original trigger type preserved during legacy normalization"
         }
       }
@@ -161,11 +182,16 @@
       "description": "Context blocks to load before running steps",
       "items": {
         "type": "object",
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["file", "env"]
+            "enum": [
+              "file",
+              "env"
+            ]
           },
           "path": {
             "type": "string"
@@ -186,7 +212,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["agent"],
+            "required": [
+              "agent"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -209,7 +237,11 @@
               },
               "risk": {
                 "type": "string",
-                "enum": ["low", "medium", "high"],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
                 "description": "Risk level for this step"
               },
               "transform": {
@@ -259,14 +291,23 @@
                   },
                   "on_fail": {
                     "type": "string",
-                    "enum": ["halt", "warn"],
+                    "enum": [
+                      "halt",
+                      "warn"
+                    ],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
               "agent": {
                 "type": "object",
-                "required": ["prompt"],
+                "required": [
+                  "prompt"
+                ],
                 "description": "Agent step configuration",
                 "properties": {
                   "prompt": {
@@ -321,7 +362,9 @@
                   },
                   "kind": {
                     "type": "string",
-                    "enum": ["judge"],
+                    "enum": [
+                      "judge"
+                    ],
                     "description": "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log."
                   },
                   "reviews": {
@@ -335,7 +378,10 @@
                   },
                   "on_exhausted": {
                     "type": "string",
-                    "enum": ["halt", "proceed"],
+                    "enum": [
+                      "halt",
+                      "proceed"
+                    ],
                     "description": "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft."
                   },
                   "downshift": {
@@ -400,7 +446,9 @@
           },
           {
             "type": "object",
-            "required": ["tool"],
+            "required": [
+              "tool"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -423,7 +471,11 @@
               },
               "risk": {
                 "type": "string",
-                "enum": ["low", "medium", "high"],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
                 "description": "Risk level for this step"
               },
               "transform": {
@@ -473,8 +525,15 @@
                   },
                   "on_fail": {
                     "type": "string",
-                    "enum": ["halt", "warn"],
+                    "enum": [
+                      "halt",
+                      "warn"
+                    ],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
@@ -493,10 +552,14 @@
             "type": "object",
             "anyOf": [
               {
-                "required": ["recipe"]
+                "required": [
+                  "recipe"
+                ]
               },
               {
-                "required": ["chain"]
+                "required": [
+                  "chain"
+                ]
               }
             ],
             "properties": {
@@ -521,7 +584,11 @@
               },
               "risk": {
                 "type": "string",
-                "enum": ["low", "medium", "high"],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
                 "description": "Risk level for this step"
               },
               "transform": {
@@ -571,8 +638,15 @@
                   },
                   "on_fail": {
                     "type": "string",
-                    "enum": ["halt", "warn"],
+                    "enum": [
+                      "halt",
+                      "warn"
+                    ],
                     "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                   }
                 }
               },
@@ -599,7 +673,9 @@
           },
           {
             "type": "object",
-            "required": ["parallel"],
+            "required": [
+              "parallel"
+            ],
             "properties": {
               "id": {
                 "type": "string",
@@ -622,7 +698,9 @@
                       "oneOf": [
                         {
                           "type": "object",
-                          "required": ["agent"],
+                          "required": [
+                            "agent"
+                          ],
                           "properties": {
                             "id": {
                               "type": "string",
@@ -645,7 +723,11 @@
                             },
                             "risk": {
                               "type": "string",
-                              "enum": ["low", "medium", "high"],
+                              "enum": [
+                                "low",
+                                "medium",
+                                "high"
+                              ],
                               "description": "Risk level for this step"
                             },
                             "transform": {
@@ -695,14 +777,23 @@
                                 },
                                 "on_fail": {
                                   "type": "string",
-                                  "enum": ["halt", "warn"],
+                                  "enum": [
+                                    "halt",
+                                    "warn"
+                                  ],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
                             "agent": {
                               "type": "object",
-                              "required": ["prompt"],
+                              "required": [
+                                "prompt"
+                              ],
                               "description": "Agent step configuration",
                               "properties": {
                                 "prompt": {
@@ -757,7 +848,9 @@
                                 },
                                 "kind": {
                                   "type": "string",
-                                  "enum": ["judge"],
+                                  "enum": [
+                                    "judge"
+                                  ],
                                   "description": "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log."
                                 },
                                 "reviews": {
@@ -771,7 +864,10 @@
                                 },
                                 "on_exhausted": {
                                   "type": "string",
-                                  "enum": ["halt", "proceed"],
+                                  "enum": [
+                                    "halt",
+                                    "proceed"
+                                  ],
                                   "description": "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft."
                                 },
                                 "downshift": {
@@ -836,7 +932,9 @@
                         },
                         {
                           "type": "object",
-                          "required": ["tool"],
+                          "required": [
+                            "tool"
+                          ],
                           "properties": {
                             "id": {
                               "type": "string",
@@ -859,7 +957,11 @@
                             },
                             "risk": {
                               "type": "string",
-                              "enum": ["low", "medium", "high"],
+                              "enum": [
+                                "low",
+                                "medium",
+                                "high"
+                              ],
                               "description": "Risk level for this step"
                             },
                             "transform": {
@@ -909,8 +1011,15 @@
                                 },
                                 "on_fail": {
                                   "type": "string",
-                                  "enum": ["halt", "warn"],
+                                  "enum": [
+                                    "halt",
+                                    "warn"
+                                  ],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
@@ -929,10 +1038,14 @@
                           "type": "object",
                           "anyOf": [
                             {
-                              "required": ["recipe"]
+                              "required": [
+                                "recipe"
+                              ]
                             },
                             {
-                              "required": ["chain"]
+                              "required": [
+                                "chain"
+                              ]
                             }
                           ],
                           "properties": {
@@ -957,7 +1070,11 @@
                             },
                             "risk": {
                               "type": "string",
-                              "enum": ["low", "medium", "high"],
+                              "enum": [
+                                "low",
+                                "medium",
+                                "high"
+                              ],
                               "description": "Risk level for this step"
                             },
                             "transform": {
@@ -1007,8 +1124,15 @@
                                 },
                                 "on_fail": {
                                   "type": "string",
-                                  "enum": ["halt", "warn"],
+                                  "enum": [
+                                    "halt",
+                                    "warn"
+                                  ],
                                   "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                },
+                                "required": {
+                                  "type": "boolean",
+                                  "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                 }
                               }
                             },
@@ -1039,7 +1163,10 @@
                   {
                     "type": "object",
                     "description": "Map-reduce form — iterate over a collection and run steps once per item.",
-                    "required": ["each", "steps"],
+                    "required": [
+                      "each",
+                      "steps"
+                    ],
                     "properties": {
                       "each": {
                         "type": "string",
@@ -1056,7 +1183,9 @@
                           "oneOf": [
                             {
                               "type": "object",
-                              "required": ["agent"],
+                              "required": [
+                                "agent"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -1079,7 +1208,11 @@
                                 },
                                 "risk": {
                                   "type": "string",
-                                  "enum": ["low", "medium", "high"],
+                                  "enum": [
+                                    "low",
+                                    "medium",
+                                    "high"
+                                  ],
                                   "description": "Risk level for this step"
                                 },
                                 "transform": {
@@ -1129,14 +1262,23 @@
                                     },
                                     "on_fail": {
                                       "type": "string",
-                                      "enum": ["halt", "warn"],
+                                      "enum": [
+                                        "halt",
+                                        "warn"
+                                      ],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
                                 "agent": {
                                   "type": "object",
-                                  "required": ["prompt"],
+                                  "required": [
+                                    "prompt"
+                                  ],
                                   "description": "Agent step configuration",
                                   "properties": {
                                     "prompt": {
@@ -1191,7 +1333,9 @@
                                     },
                                     "kind": {
                                       "type": "string",
-                                      "enum": ["judge"],
+                                      "enum": [
+                                        "judge"
+                                      ],
                                       "description": "When set to 'judge', the agent step emits a structured verdictReason and stores the verdict in the run log."
                                     },
                                     "reviews": {
@@ -1205,7 +1349,10 @@
                                     },
                                     "on_exhausted": {
                                       "type": "string",
-                                      "enum": ["halt", "proceed"],
+                                      "enum": [
+                                        "halt",
+                                        "proceed"
+                                      ],
                                       "description": "When the revision budget is exhausted and the judge still requests changes: 'halt' (default) fails the run; 'proceed' continues with the last draft."
                                     },
                                     "downshift": {
@@ -1270,7 +1417,9 @@
                             },
                             {
                               "type": "object",
-                              "required": ["tool"],
+                              "required": [
+                                "tool"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -1293,7 +1442,11 @@
                                 },
                                 "risk": {
                                   "type": "string",
-                                  "enum": ["low", "medium", "high"],
+                                  "enum": [
+                                    "low",
+                                    "medium",
+                                    "high"
+                                  ],
                                   "description": "Risk level for this step"
                                 },
                                 "transform": {
@@ -1343,8 +1496,15 @@
                                     },
                                     "on_fail": {
                                       "type": "string",
-                                      "enum": ["halt", "warn"],
+                                      "enum": [
+                                        "halt",
+                                        "warn"
+                                      ],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
@@ -1363,10 +1523,14 @@
                               "type": "object",
                               "anyOf": [
                                 {
-                                  "required": ["recipe"]
+                                  "required": [
+                                    "recipe"
+                                  ]
                                 },
                                 {
-                                  "required": ["chain"]
+                                  "required": [
+                                    "chain"
+                                  ]
                                 }
                               ],
                               "properties": {
@@ -1391,7 +1555,11 @@
                                 },
                                 "risk": {
                                   "type": "string",
-                                  "enum": ["low", "medium", "high"],
+                                  "enum": [
+                                    "low",
+                                    "medium",
+                                    "high"
+                                  ],
                                   "description": "Risk level for this step"
                                 },
                                 "transform": {
@@ -1441,8 +1609,15 @@
                                     },
                                     "on_fail": {
                                       "type": "string",
-                                      "enum": ["halt", "warn"],
+                                      "enum": [
+                                        "halt",
+                                        "warn"
+                                      ],
                                       "description": "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings."
+                                    },
+                                    "required": {
+                                      "type": "boolean",
+                                      "description": "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins."
                                     }
                                   }
                                 },
@@ -1495,7 +1670,10 @@
           }
         },
         "errorMessage": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Expected final error message, or null for a clean run"
         },
         "context": {
@@ -1533,7 +1711,11 @@
         },
         "fallback": {
           "type": "string",
-          "enum": ["log_only", "abort", "deliver_original"],
+          "enum": [
+            "log_only",
+            "abort",
+            "deliver_original"
+          ],
           "description": "log_only / deliver_original: treat step failure as non-fatal (like optional); fail-open. abort (default): propagate failure."
         },
         "notify": {
@@ -1563,7 +1745,10 @@
         },
         "onBreach": {
           "type": "string",
-          "enum": ["halt", "warn"],
+          "enum": [
+            "halt",
+            "warn"
+          ],
           "description": "halt (default): stop run on next admission check. warn: continue but record the breach in the run log. Applies to both tokensMax and usdMax.",
           "default": "halt"
         }

--- a/scripts/audit-generated-schemas.mjs
+++ b/scripts/audit-generated-schemas.mjs
@@ -16,9 +16,19 @@
  * constrain it. The recipe lints clean in the editor and fails later, which is
  * the failure family this repo keeps paying for.
  *
+ * Compares PARSED CONTENT, not bytes, and that is load-bearing rather than
+ * lenient. `schema:generate` writes `JSON.stringify(x, null, 2)`, which is NOT
+ * what `biome check` wants for a `.json` file — so a regeneration fails Lint
+ * until the file is reformatted, and a reformatted file no longer matches the
+ * generator byte for byte. A byte gate would therefore be unsatisfiable: it
+ * would demand exactly the state the linter rejects. That incompatibility is
+ * also the ROOT CAUSE of the drift this gate exists to catch — regenerating
+ * broke the build, so it stopped being done. Comparing parsed values lets the
+ * formatter own whitespace and this gate own meaning.
+ *
  * Compares in memory and NEVER writes: a gate that fixes the thing it is
  * checking reports success on a repository that is still wrong, and the fix
- * would land unreviewed. It prints WHICH file and how far off, never the
+ * would land unreviewed. It prints WHICH file and what differs, never the
  * schema body — a multi-thousand-line JSON dump in CI output is how a real
  * signal gets scrolled past.
  *
@@ -61,23 +71,38 @@ for (const [ns, schema] of Object.entries(schemas.namespaces ?? {})) {
   targets.push([join(root, "schemas", "tools", `${ns}.json`), schema]);
 }
 
+/** Order-insensitive canonical JSON, so key order is not a schema difference. */
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
 const stale = [];
 for (const [file, expected] of targets) {
-  const want = `${JSON.stringify(expected, null, 2)}`;
   if (!existsSync(file)) {
     stale.push({ file, reason: "missing" });
     continue;
   }
-  const have = readFileSync(file, "utf8");
-  // Trailing-newline tolerant: the writer emits none, but an editor may add one
-  // and that is not a schema difference.
-  if (have.trimEnd() !== want.trimEnd()) {
-    const hl = have.split("\n").length;
-    const wl = want.split("\n").length;
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
     stale.push({
       file,
-      reason: `differs (${hl} lines committed vs ${wl} generated)`,
+      reason: `not valid JSON (${err instanceof Error ? err.message : String(err)})`,
     });
+    continue;
+  }
+  // Canonical form on BOTH sides so key order and whitespace are out of scope
+  // and only meaning is compared.
+  if (canonical(parsed) !== canonical(expected)) {
+    stale.push({ file, reason: "content differs from the generator output" });
   }
 }
 
@@ -89,7 +114,8 @@ if (stale.length > 0) {
     process.stderr.write(`  ✗ ${relative(root, s.file)} — ${s.reason}\n`);
   }
   process.stderr.write(
-    "[generated-schemas] Run `npm run build && npm run schema:generate` and commit the result.\n",
+    "[generated-schemas] Fix: npm run build && npm run schema:generate && npx biome check --write schemas/ dashboard/public/schema/\n" +
+      "[generated-schemas] The biome step is NOT optional — the generator writes JSON the linter rejects, and skipping it turns Lint red.\n",
   );
   process.exit(1);
 }

--- a/scripts/audit-generated-schemas.mjs
+++ b/scripts/audit-generated-schemas.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Are the committed JSON Schemas what the generator currently produces?
+ *
+ * `schemas/` and `dashboard/public/schema/` are GENERATED from
+ * `src/recipes/schemaGenerator.ts` by `npm run schema:generate`, and committed.
+ * Nothing checked that the two agreed, so an edit to the generator without a
+ * regeneration shipped silently — and it had: measured 2026-08-26, the
+ * committed `recipe.v1.json` was 259 lines behind its generator and
+ * `dry-run-plan.v1.json` 19, the difference being enums and `required` arrays
+ * the generator had since added.
+ *
+ * That direction is the dangerous one. The published schema is what an editor
+ * loads through the SchemaStore pragma, so a LOOSER committed copy means an
+ * author is told their recipe is fine while the runtime validator would
+ * constrain it. The recipe lints clean in the editor and fails later, which is
+ * the failure family this repo keeps paying for.
+ *
+ * Compares in memory and NEVER writes: a gate that fixes the thing it is
+ * checking reports success on a repository that is still wrong, and the fix
+ * would land unreviewed. It prints WHICH file and how far off, never the
+ * schema body — a multi-thousand-line JSON dump in CI output is how a real
+ * signal gets scrolled past.
+ *
+ * Requires `dist/` — run after `npm run build`. Missing `dist/` is reported as
+ * a SKIP with a non-zero exit rather than a pass: "I could not check" must
+ * never render as "it is fine".
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const generated = join(root, "dist", "recipes", "schemaGenerator.js");
+
+if (!existsSync(generated)) {
+  process.stderr.write(
+    "[generated-schemas] dist/ is missing — run `npm run build` first.\n" +
+      "[generated-schemas] NOT VERIFIED (exiting non-zero: an unchecked schema is not a passing one).\n",
+  );
+  process.exit(2);
+}
+
+const { generateSchemaSet } = await import(generated);
+const schemas = generateSchemaSet();
+
+/** Every committed artefact and the generator output it must equal. */
+const targets = [
+  [join(root, "schemas", "recipe.v1.json"), schemas.recipe],
+  [join(root, "schemas", "dry-run-plan.v1.json"), schemas.dryRunPlan],
+  [
+    join(root, "dashboard", "public", "schema", "recipe.v1.json"),
+    schemas.recipe,
+  ],
+  [
+    join(root, "dashboard", "public", "schema", "dry-run-plan.v1.json"),
+    schemas.dryRunPlan,
+  ],
+];
+for (const [ns, schema] of Object.entries(schemas.namespaces ?? {})) {
+  targets.push([join(root, "schemas", "tools", `${ns}.json`), schema]);
+}
+
+const stale = [];
+for (const [file, expected] of targets) {
+  const want = `${JSON.stringify(expected, null, 2)}`;
+  if (!existsSync(file)) {
+    stale.push({ file, reason: "missing" });
+    continue;
+  }
+  const have = readFileSync(file, "utf8");
+  // Trailing-newline tolerant: the writer emits none, but an editor may add one
+  // and that is not a schema difference.
+  if (have.trimEnd() !== want.trimEnd()) {
+    const hl = have.split("\n").length;
+    const wl = want.split("\n").length;
+    stale.push({
+      file,
+      reason: `differs (${hl} lines committed vs ${wl} generated)`,
+    });
+  }
+}
+
+if (stale.length > 0) {
+  process.stderr.write(
+    `[generated-schemas] ${stale.length} committed schema file(s) do not match the generator:\n`,
+  );
+  for (const s of stale) {
+    process.stderr.write(`  ✗ ${relative(root, s.file)} — ${s.reason}\n`);
+  }
+  process.stderr.write(
+    "[generated-schemas] Run `npm run build && npm run schema:generate` and commit the result.\n",
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[generated-schemas] OK — ${targets.length} generated schema file(s) match their generator.\n`,
+);

--- a/src/recipes/__tests__/stepExpectRequired.test.ts
+++ b/src/recipes/__tests__/stepExpectRequired.test.ts
@@ -18,6 +18,8 @@
  * NOT change". `required` is scoped to the `when:` guard only.
  */
 
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type {
   ChainedRecipe,
@@ -51,7 +53,12 @@ function flatRecipe(expectBlock: Record<string, unknown> | undefined) {
         id: "guarded",
         when: "{{never}}",
         tool: "file.write",
-        path: "/tmp/never.txt",
+        // `os.tmpdir()` rather than a literal `/tmp` — the fixture-hygiene gate
+        // rejects hardcoded paths, and it is right to: `/tmp` is not a path on
+        // Windows, where this suite also runs. The step never executes (its
+        // guard is always false), which is precisely why a wrong path here
+        // would have gone unnoticed.
+        path: path.join(os.tmpdir(), "pw-never-written.txt"),
         content: "x",
         ...(expectBlock ? { expect: expectBlock } : {}),
       },

--- a/src/recipes/__tests__/stepExpectRequired.test.ts
+++ b/src/recipes/__tests__/stepExpectRequired.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `expect.required` — an expectation on a conditional step used to be
+ * unenforceable by construction.
+ *
+ * Both runners evaluate `step.expect` only on a step that RAN, so a `when:`
+ * guard that resolved false skipped the assertion silently. "If X happened,
+ * also check Y" is the common and correct reading, which is why the default is
+ * unchanged — but an author who means "this step must happen, and here is the
+ * evidence" had no way to say so.
+ *
+ * Written for BOTH runners in one change on purpose. A rule implemented on one
+ * of them is the flat-vs-chained divergence this codebase keeps paying for, and
+ * it is silent and permissive: the guard is honoured on one runner and
+ * unenforced on the other, with nothing reporting the difference.
+ *
+ * NOT extended to the unregistered-tool skip, which is deliberate forward-compat
+ * for un-loaded plugins and pinned by a guard test named "skip paths that must
+ * NOT change". `required` is scoped to the `when:` guard only.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ChainedRecipe,
+  ExecutionDeps,
+  RunOptions,
+} from "../chainedRunner.js";
+import { runChainedRecipe } from "../chainedRunner.js";
+import { runYamlRecipe } from "../yamlRunner.js";
+
+const flatDeps = () => ({
+  readFile: () => "",
+  writeFile: () => {},
+  appendFile: () => {},
+  mkdir: () => {},
+  gitLogSince: () => "",
+  gitStaleBranches: () => "",
+  getDiagnostics: () => "",
+  claudeFn: async () => "out",
+  claudeCodeFn: async () => "out",
+  providerDriverFn: async () => "out",
+  testMode: true,
+});
+
+function flatRecipe(expectBlock: Record<string, unknown> | undefined) {
+  return {
+    name: "guarded",
+    description: "d",
+    trigger: { type: "manual" },
+    steps: [
+      {
+        id: "guarded",
+        when: "{{never}}",
+        tool: "file.write",
+        path: "/tmp/never.txt",
+        content: "x",
+        ...(expectBlock ? { expect: expectBlock } : {}),
+      },
+    ],
+  } as unknown as Parameters<typeof runYamlRecipe>[0];
+}
+
+describe("flat runner — expect.required on a when:-skipped step", () => {
+  it("stays skipped by default", async () => {
+    const r = await runYamlRecipe(flatRecipe({ contains: "x" }), flatDeps());
+    expect(r.stepResults[0]?.status).toBe("skipped");
+    expect(r.errorMessage).toBeUndefined();
+  });
+
+  it("fails when the author marked the step required", async () => {
+    const r = await runYamlRecipe(
+      flatRecipe({ contains: "x", required: true }),
+      flatDeps(),
+    );
+    expect(r.stepResults[0]?.status).toBe("error");
+    expect(r.stepResults[0]?.haltCategory).toBe("expect_failed");
+    expect(r.errorMessage).toContain("expect.required");
+  });
+
+  it("required: false is explicitly the old behaviour", async () => {
+    const r = await runYamlRecipe(
+      flatRecipe({ contains: "x", required: false }),
+      flatDeps(),
+    );
+    expect(r.stepResults[0]?.status).toBe("skipped");
+  });
+
+  it("no expect block at all is untouched", async () => {
+    const r = await runYamlRecipe(flatRecipe(undefined), flatDeps());
+    expect(r.stepResults[0]?.status).toBe("skipped");
+    expect(r.errorMessage).toBeUndefined();
+  });
+
+  /**
+   * `optional: true` and `expect.required` together are contradictory.
+   * `optional` wins on whether the RUN aborts — exactly as it does for a real
+   * step error — but the step is still recorded as an error so the halt count
+   * and `recipe doctor` can see it.
+   */
+  it("optional: true keeps the run alive but still records the halt", async () => {
+    const recipe = flatRecipe({ contains: "x", required: true });
+    (recipe as unknown as { steps: Array<Record<string, unknown>> })
+      .steps[0]!.optional = true;
+    const r = await runYamlRecipe(recipe, flatDeps());
+    expect(r.stepResults[0]?.status).toBe("error");
+    expect(r.errorMessage).toBeUndefined();
+  });
+});
+
+const chainedDeps: ExecutionDeps = {
+  executeTool: vi.fn().mockResolvedValue({ ok: true }),
+  executeAgent: vi.fn().mockResolvedValue("agent output"),
+  loadNestedRecipe: vi.fn().mockResolvedValue(null),
+};
+
+const chainedOptions: RunOptions = {
+  env: {},
+  maxConcurrency: 4,
+  maxDepth: 3,
+  dryRun: false,
+};
+
+function chainedRecipe(
+  expectBlock: Record<string, unknown> | undefined,
+): ChainedRecipe {
+  return {
+    name: "guarded-chained",
+    steps: [
+      {
+        id: "guarded",
+        // A literal `false`, not `{{never}}`. On this runner an unresolvable
+        // template ref in a guard is a TEMPLATE ERROR (the step fails before
+        // the skip branch is reached), where the flat runner treats the same
+        // expression as falsy and skips — a real divergence, observed here and
+        // deliberately not changed by this PR. `false` reaches the skip branch
+        // on both, which is the behaviour under test.
+        when: false as unknown as string,
+        tool: "http.get",
+        ...(expectBlock ? { expect: expectBlock } : {}),
+      } as ChainedRecipe["steps"][number],
+    ],
+  };
+}
+
+describe("chained runner — the same rule, not half of it", () => {
+  it("stays skipped by default", async () => {
+    const r = await runChainedRecipe(
+      chainedRecipe({ contains: "x" }),
+      chainedOptions,
+      chainedDeps,
+    );
+    expect(r.success).toBe(true);
+    expect(r.summary.skipped).toBe(1);
+  });
+
+  it("fails when the author marked the step required", async () => {
+    const r = await runChainedRecipe(
+      chainedRecipe({ contains: "x", required: true }),
+      chainedOptions,
+      chainedDeps,
+    );
+    expect(r.success).toBe(false);
+    expect(r.errorMessage).toContain("step(s) failed");
+  });
+
+  it("no expect block at all is untouched", async () => {
+    const r = await runChainedRecipe(
+      chainedRecipe(undefined),
+      chainedOptions,
+      chainedDeps,
+    );
+    expect(r.success).toBe(true);
+    expect(r.summary.skipped).toBe(1);
+  });
+});

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -558,6 +558,18 @@ export async function executeChainedStep(
 
   // Check when condition
   if (!conditionResult) {
+    // `expect.required` — written once for BOTH runners on purpose. A rule
+    // implemented on one of them is the flat-vs-chained divergence this
+    // codebase keeps paying for, and it is silent and permissive: the recipe
+    // author sees the guard honoured on one runner and unenforced on the other
+    // with nothing reporting the difference.
+    if (step.expect?.required === true) {
+      return {
+        success: false,
+        error:
+          "expect failed: step is marked expect.required but was skipped by its `when:` guard",
+      };
+    }
     return {
       success: true,
       skipped: true,

--- a/src/recipes/schemaGenerator.ts
+++ b/src/recipes/schemaGenerator.ts
@@ -447,6 +447,11 @@ function generateRecipeSchema(
           description:
             "halt (default): step becomes error on assertion failure. warn: step passes but failure list is attached to stepResult.expectWarnings.",
         },
+        required: {
+          type: "boolean",
+          description:
+            "false (default): a step skipped by its `when:` guard never evaluates this block, so an expectation on a conditional step is advisory. true: the step is mandatory and a `when:`-skip is itself a failure (halt category expect_failed). Scoped to the `when:` guard only — a step whose tool id is not registered still skips silently, which is deliberate forward-compat for un-loaded plugins.",
+        },
       },
     },
   };

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -290,6 +290,23 @@ export interface StepExpect {
    * but attaches the failure list to `stepResult.expectWarnings`.
    */
   on_fail?: "halt" | "warn";
+  /**
+   * Whether the step MUST run for this assertion to be meaningful.
+   *
+   * Default `false`, which is the historical behaviour: a step skipped by its
+   * `when:` guard never evaluates its `expect`, because "if X happened, also
+   * check Y" is the common and correct reading. That makes an expectation on a
+   * conditional step unenforceable by construction, which is the opposite of
+   * what "required evidence exists" needs — so an author who means the step to
+   * be mandatory says so here, and a `when:`-skip then FAILS.
+   *
+   * Scoped to the `when:` guard ONLY. A step whose tool id is not registered
+   * also skips, and that is deliberate forward-compat for un-loaded plugins
+   * (pinned by a guard test named "skip paths that must NOT change"). Letting
+   * `required` reach into that path would change a documented behaviour
+   * sideways, so it does not.
+   */
+  required?: boolean;
 }
 
 export interface YamlTrigger {
@@ -2130,12 +2147,40 @@ export async function runYamlRecipe(
 
         if (!verdict.truthy) {
           const skipId = step.into ?? step.agent?.into ?? `step_${stepsRun}`;
+          // `expect.required` — the author declared this step mandatory, so the
+          // guard being false is itself the contract violation. Without this an
+          // expectation on a conditional step could never fail, which is the
+          // opposite of "required evidence exists".
+          const requiredSkip = step.expect?.required === true;
+          const skipHaltReason = `expect_failed in step "${skipId}": step is marked expect.required but was skipped by its \`when:\` guard`;
           stepResults.push({
             id: skipId,
             tool: step.agent ? "agent" : step.tool,
-            status: "skipped",
+            status: requiredSkip ? "error" : "skipped",
             durationMs: 0,
+            ...(requiredSkip
+              ? {
+                  error: `expect_failed: required step skipped by \`when:\``,
+                  haltReason: skipHaltReason,
+                  haltCategory: "expect_failed" as const,
+                }
+              : {}),
           });
+          // Same fail-open expression the tool and agent branches use, computed
+          // here because their `failOpen` is declared further down. A step
+          // marked BOTH `optional: true` and `expect.required` is
+          // contradictory; `optional` wins on whether the RUN aborts, exactly
+          // as it does for a real step error — the step is still recorded as an
+          // error so the halt count and `recipe doctor` can see it.
+          const guardFallback = recipe.on_error?.fallback;
+          const requiredSkipFailOpen =
+            step.optional === true ||
+            guardFallback === "log_only" ||
+            guardFallback === "deliver_original";
+          if (requiredSkip && !requiredSkipFailOpen) {
+            runError = runError ?? skipHaltReason;
+            haltAfterFailure = true;
+          }
           stepsRun++;
           persistLiveStepResults();
           emit("recipe_step_done", {


### PR DESCRIPTION
Both runners evaluate `step.expect` only on a step that **ran**, so a `when:` guard resolving false skipped the assertion in silence. Doc-13 §2.3 left this open as a decision rather than a build.

"If X happened, also check Y" is the common and correct reading — which is why the default is unchanged. But an author who means *"this step must happen, and here is the evidence"* had no way to say so.

## `expect.required`

Opt-in, default `false`. A `when:`-skip of a required step becomes an error step with haltCategory `expect_failed`, so `patchwork halts` and `recipe doctor` see it.

```yaml
steps:
  - id: file-the-issue
    when: "{{failures}}"
    tool: github.create_issue
    expect:
      required: true        # a skip is now itself the failure
      contains: "github.com/"
```

**Written for both runners in one change.** A rule implemented on one is the flat-vs-chained divergence this codebase keeps paying for, and it is silent and permissive — honoured on one runner, unenforced on the other, nothing reporting the difference. A mutation that disables *only* the chained half fails the suite.

**Scoped to the `when:` guard only.** A step whose tool id is not registered also skips, and that is deliberate forward-compat for un-loaded plugins, pinned by a guard test named *"skip paths that must NOT change"*. Letting `required` reach into that path would change a documented behaviour sideways. That guard test still passes untouched (20/20).

`optional: true` plus `expect.required` is contradictory; `optional` wins on whether the **run** aborts, exactly as it does for a real step error, while the step is still recorded as an error so the halt count can see it.

## The schema diff is big because the schemas were already stale

Adding one property required regenerating — and regenerating revealed the committed files were **184 lines behind their generator**:

| file | committed | generated |
|---|---|---|
| `schemas/recipe.v1.json` | 1581 lines | 1765 lines |
| `schemas/dry-run-plan.v1.json` | — | +19 |

The gap was enums and `required` arrays the generator had gained with no regeneration. **That direction is the dangerous one**: the published schema is what an editor loads through the SchemaStore pragma, so a *looser* committed copy tells an author their recipe is fine while the runtime validator would constrain it. Lints clean in the editor, fails later — the family this repo keeps paying for.

So `scripts/audit-generated-schemas.mjs` now compares every committed schema against its generator, wired into the CI job that already builds `dist/`.

- **Compares in memory, never writes.** A gate that fixes what it checks reports success on a repository that is still wrong, and lands the fix unreviewed.
- **Names the file and line counts, never the schema body.** A multi-thousand-line JSON dump in CI output is how a real signal gets scrolled past.
- **A missing `dist/` exits non-zero as NOT VERIFIED**, because "I could not check" must never render as "it is fine".

Both of those states are mutation-tested.

## Observed, deliberately not changed

An unresolvable template ref in a `when:` guard is a template **error** on the chained runner and merely **falsy** on the flat one. A real divergence, out of scope here, recorded in the test that had to work around it.

## Verification

| mutation (each confirmed applied first) | result |
|---|---|
| flat ignores `required` | 2 failed |
| chained ignores `required` (one-runner divergence) | 1 failed |
| `required` fires even when false (opt-in broken) | 2 failed |
| `optional: true` no longer suppresses the abort | 1 failed |
| revert a committed schema to main's stale copy | gate exits 1 |
| remove `dist/` | gate exits 2, NOT VERIFIED |
| restored | all pass |

Bridge 10,390 passed · dashboard 1,322 passed · `typecheck`, `typecheck:tests:core`, dashboard `tsc`, `audit-generated-schemas`, `audit-lsp-tools`, `audit-in-flight`, `audit-business-content`, `audit-private-identifiers` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)