### PR TITLE
feat(workers): a manifest could govern nothing and say nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,38 @@ Comply with all docs in `/documents/`. Consult before changes:
   A recipe that fails any of these is reported by `recipe doctor`, which is
   where an operator will actually look.
 
+  **Completion contracts (`expect`) — three things changed 2026-08-26.**
+  - **Run-level `expect` now runs on CHAINED recipes too.** It lints clean with
+    zero warnings and was previously dropped entirely: `dispatchRecipe` casts a
+    `YamlRecipe` straight across, so the block was on the object at runtime and
+    `ChainedRecipe` simply had no field for it. `outputs` deliberately means
+    **step ids** there and agent `into:` keys / resolved `file.write` paths on
+    the flat runner — that is what each is keyed by — so a flat-style entry
+    fails loudly rather than passing, and lint warns on a path-shaped entry
+    (never on a flat recipe, where a path is correct).
+  - **`expect.required`** (default false). A step skipped by its `when:` guard
+    never evaluated its `expect`, so an expectation on a conditional step was
+    unenforceable by construction. `required: true` makes the skip itself an
+    `expect_failed` error. Scoped to the `when:` guard ONLY — the
+    unregistered-tool skip stays silent by design, pinned by the guard test
+    named *"skip paths that must NOT change"*.
+  - **`patchwork halts` can see a violated contract** (`contract_failed`).
+    Such a run finishes `done`, not `error`, so the run-level branch never
+    fired. Counted ONE per run, not one per assertion, and NOT guarded on the
+    step count — a postcondition violation is a different fact from a step
+    error, not the same one restated.
+
+  Two traps recorded because both cost a build: the committed JSON Schemas were
+  **184 lines behind their generator**, because `schema:generate` emits JSON
+  `biome check` rejects — so regenerating turned CI red and people stopped.
+  `npm run build && npm run schema:generate && npx biome check --write schemas/
+  dashboard/public/schema/`; the biome step is not optional, and
+  `scripts/audit-generated-schemas.mjs` now gates it by comparing PARSED
+  content (a byte gate would demand exactly the state the linter refuses). And
+  the flat runner derives run-log step ids from `into`, never `step.id`, so a
+  halt on a step with an explicit `id:` is reported as `step_N` — consistent
+  everywhere, and not worth the blast radius of changing.
+
   **An unregistered tool id SKIPS the step silently, and that is DELIBERATE —
   do not "fix" it.** `executeStep` returns null for a tool nothing is
   registered under, the run loop records `skipped`, and the run finishes
@@ -289,6 +321,8 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `analytics show|configure|clear|test` — Manage the opt-in telemetry collector config (endpoint + shared secret) at `~/.claude/ide/analytics-config.json` (mode 0600). Replaces the brittle pattern of putting the secret in a launchd plist. `configure --endpoint URL --key KEY` writes both atomically; `test` sends a tiny synthetic payload and reports the HTTP status; `show` prints active values and resolution source (env / config / default). Env vars still win for headless/CI.
 - `panic` — Shortcut for `kill-switch engage --reason "manual panic"`.
 - `judgments [--window 1h|24h|overnight|7d|any] [--recipe <name>] [--json]` — Recent judge-step verdicts (from recipe steps with `agent.kind: judge`) across runs. Discovers the running bridge via lock file, queries `/runs/judge-summary`, prints per-verdict counts + 5 most-recent. Sibling of `halts`; same window/filter shape.
+- `workers list [--workers-dir <path>] [--json]` — what is installed and, the point, **what the bridge IGNORES**. `loadWorkersFromDir` is fail-soft: a manifest that does not parse is SKIPPED, and it logs only when the caller passes a logger — which the resolution path does not. Exits 1 when any manifest is ignored.
+- `workers validate [--workers-dir <path>] [--recipes-dir <path>] [--templates-dir <path>] [--json]` — every way a manifest can be present and govern NOTHING. All of them end identically: `resolveWorkerIdForRecipe` returns undefined, the caller falls back to the tier-based approval fn, and the worker ramp never runs. Since the worker gate is composed as a FLOOR over the tier fn (it can only ADD approvals), losing it means the recipe is governed **less**, and a manifest's ADR-0017 `forbids` list goes inert without a word. Checks: unparseable manifest · `recipe:` not installed · two workers claiming one recipe (**BOTH are ignored — resolution refuses to guess, so there is no winner**) · an unparseable `forbids` entry (**fails OPEN** — the banned action degrades to merely gated, which a human can then approve) · drift against `templates/workers`. Exits 1 when unhealthy. Leads with the denominator: an empty directory reports "nothing to check", never "no problems". Measured 2026-08-26 on the reference install — 8 manifests, all parsing, none dangling, none ambiguous, no drift — so the validator was built against deliberately broken fixtures, since one that has only seen healthy input is not known to be able to fail. **No `install` verb**, deliberately: a package format has to answer the third-copy problem (`templates/workers/` and `~/.patchwork/workers/` already diverge, which is why `manifestDrift` exists), and that is a design decision rather than a missing function.
 - `workers shadow [--workers-dir <path>]` — Replay run + gate logs to show per-worker × action-class trust dial and ramp-vs-gate divergences. Primary monitoring tool during the worker autonomy dogfood campaign. See [docs/runbooks/worker-autonomy-dogfood.md](docs/runbooks/worker-autonomy-dogfood.md).
 - `workers backtest [--workers-dir <path>]` — Cold-start calibration: replay historical runs as if the gate were live; measures how many shadow divergences the gate would have produced.
 - `gate explain <workerId> <classKey> [--limit N] [--diff] [--json]` — "Why did the worker allow/gate THIS action?" Plain-English rendering of the most recent decision(s) for a worker × action-class, from the local Decision Record (`~/.patchwork/worker_gate_decisions.jsonl`) — no bridge required. `--limit N` shows the N most recent (default 1, or 2 with `--diff`). `--diff` compares the 2 most recent decisions and reports only the fields that changed (e.g. `action: gate → allow`) — Tier 2 of the legibility layer. `classKey` is `domain:reversibility:blastTier`, plus a `:magnitudeBand` suffix for value-bearing domains (e.g. `issue:compensable:high`, `payments:irreversible:high:band<=50`). Also exposed over HTTP at `GET /gate/decisions?workerId=&classKey=&limit=` for the dashboard.

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,13 +50,26 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-26 `feat/workers-list-validate` — `patchwork workers` has only `shadow` and
-  `backtest`. A worker manifest that fails to parse is SKIPPED by `loadWorkersFromDir`, so
-  no worker owns the recipe, so the autonomy gate (including ADR-0017 `forbids`) is
-  silently inert for it — and manifest drift is only ever printed at bridge startup. Adds
-  read-only `list` + `validate`. NOT `install` (needs a package-format decision).
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-26 `feat/workers-list-validate` — four ways a worker manifest is installed and
+  governs NOTHING, all silent: it does not parse (`loadWorkersFromDir` is fail-soft and
+  logs only when given a logger, which the resolution path does not pass), its `recipe:`
+  is not installed, two manifests claim one recipe (resolution refuses to guess, so BOTH
+  lose — there is no winner), or a `forbids` entry does not parse (a dropped deny-rule
+  fails OPEN, degrading a banned action to merely gated). All four end at
+  `resolveWorkerIdForRecipe` returning undefined and the run falling back to the tier fn —
+  and since the worker gate is a FLOOR over that fn, losing it governs the recipe LESS.
+  `detectWorkerManifestDrift` existed but printed only in the bridge STARTUP log; now an
+  operator can ask. Read-only, exits 1 when unhealthy (including `list` — an ignored
+  manifest is a gap, not a note), and leads with the denominator so an empty directory says
+  "nothing to check" rather than "no problems". NO `install` verb: a package format must
+  answer the third-copy problem that `manifestDrift` exists because of. The reference
+  install was healthy on all four checks, so the validator was built against deliberately
+  broken fixtures — one that has only seen healthy input is not known to be able to fail.
+  (#1531)
 
 - 2026-08-26 `feat/step-expect-required` — both runners evaluate `step.expect` only on a
   step that RAN, so an expectation on a `when:`-guarded step could never fail. Opt-in

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- 2026-08-26 `feat/workers-list-validate` — `patchwork workers` has only `shadow` and
+  `backtest`. A worker manifest that fails to parse is SKIPPED by `loadWorkersFromDir`, so
+  no worker owns the recipe, so the autonomy gate (including ADR-0017 `forbids`) is
+  silently inert for it — and manifest drift is only ever printed at bridge startup. Adds
+  read-only `list` + `validate`. NOT `install` (needs a package-format decision).
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4986,12 +4986,23 @@ if (process.argv[2] === "workers") {
   const args = process.argv.slice(3);
   const sub = args[0];
   if (
-    (sub !== "shadow" && sub !== "backtest") ||
+    (sub !== "shadow" &&
+      sub !== "backtest" &&
+      sub !== "list" &&
+      sub !== "validate") ||
     args.includes("--help") ||
     args.includes("-h")
   ) {
     process.stdout.write(
-      "Usage: patchwork workers <shadow|backtest> [--workers-dir <path>]\n\n" +
+      "Usage: patchwork workers <list|validate|shadow|backtest> [--workers-dir <path>]\n\n" +
+        "  list      What is installed, and — the point — what the bridge IGNORES.\n" +
+        "            A manifest that does not parse is skipped by the loader, so no\n" +
+        "            worker owns its recipe and the autonomy gate never runs for it.\n" +
+        "  validate  Every way a manifest can be present and govern nothing:\n" +
+        "            unparseable file, `recipe:` that is not installed, two workers\n" +
+        "            claiming one recipe (BOTH are ignored, not one winner), an\n" +
+        "            unparseable forbids entry (fails OPEN), and drift against\n" +
+        "            templates/workers. Exits 1 when unhealthy.\n" +
         "  shadow    Read-only worker trust dial: replays ~/.patchwork/runs.jsonl\n" +
         "            + the gate decision log through the (worker × action-class)\n" +
         "            ramp. Computes what the ramp WOULD decide vs what the gate DID.\n" +
@@ -5007,6 +5018,58 @@ if (process.argv[2] === "workers") {
     try {
       const dirIdx = args.indexOf("--workers-dir");
       const workersDir = dirIdx !== -1 ? args[dirIdx + 1] : undefined;
+      if (sub === "list" || sub === "validate") {
+        const {
+          scanWorkers,
+          validateWorkers,
+          formatWorkersList,
+          formatWorkersValidate,
+          defaultWorkersDir,
+          defaultRecipesDir,
+        } = await import("./workers/workersCli.js");
+        const dir = workersDir ?? defaultWorkersDir();
+        const json = args.includes("--json");
+        if (sub === "list") {
+          const scan = scanWorkers(dir);
+          process.stdout.write(
+            json
+              ? `${JSON.stringify(
+                  {
+                    dir: scan.dir,
+                    loaded: scan.loaded.map((l) => ({
+                      file: l.file,
+                      id: l.worker.id,
+                      name: l.worker.name,
+                      recipe: l.worker.recipe ?? null,
+                      autonomyCeiling: l.worker.autonomyCeiling,
+                      owns: l.worker.owns,
+                    })),
+                    broken: scan.broken,
+                  },
+                  null,
+                  2,
+                )}\n`
+              : formatWorkersList(scan),
+          );
+          // A manifest the bridge ignores is a governance gap, not a note.
+          process.exit(scan.broken.length > 0 ? 1 : 0);
+        }
+        const tIdx = args.indexOf("--templates-dir");
+        const templatesDir = tIdx !== -1 ? args[tIdx + 1] : undefined;
+        const rIdx = args.indexOf("--recipes-dir");
+        const result = validateWorkers({
+          workersDir: dir,
+          recipesDir:
+            rIdx !== -1 ? (args[rIdx + 1] as string) : defaultRecipesDir(),
+          ...(templatesDir ? { templatesDir } : {}),
+        });
+        process.stdout.write(
+          json
+            ? `${JSON.stringify(result, null, 2)}\n`
+            : formatWorkersValidate(result),
+        );
+        process.exit(result.healthy ? 0 : 1);
+      }
       const { runWorkerShadowReport, runWorkerBacktest } = await import(
         "./workers/runWorkerShadow.js"
       );

--- a/src/workers/__tests__/workersCli.test.ts
+++ b/src/workers/__tests__/workersCli.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Every way a worker manifest can be present and govern NOTHING.
+ *
+ * All of these end the same way: `resolveWorkerIdForRecipe` returns undefined,
+ * the caller falls back to the tier-based approval fn, and the worker ramp
+ * never runs. Because the worker gate is composed as a FLOOR over the tier fn —
+ * it can only ADD approvals — losing it means the recipe is governed LESS. The
+ * sharpest case is a manifest's ADR-0017 `forbids` list, whose whole point is
+ * that no trust and no approval unlocks the action, going inert without a word.
+ *
+ * Verified against the real installation before this existed: all 8 manifests
+ * parsed, none dangling, none ambiguous, no drift. So these tests build the
+ * broken states deliberately — a validator that has only ever seen healthy
+ * input is not known to be able to fail.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  formatWorkersValidate,
+  scanWorkers,
+  validateWorkers,
+} from "../workersCli.js";
+
+let workersDir: string;
+let recipesDir: string;
+
+beforeEach(() => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "pw-workers-cli-"));
+  workersDir = path.join(root, "workers");
+  recipesDir = path.join(root, "recipes");
+  for (const d of [workersDir, recipesDir]) mkdirSync(d, { recursive: true });
+  writeFileSync(
+    path.join(recipesDir, "good.yaml"),
+    "name: good-recipe\ndescription: d\ntrigger: { type: manual }\nsteps: []\n",
+  );
+});
+afterEach(() => {
+  rmSync(path.dirname(workersDir), { recursive: true, force: true });
+});
+
+function worker(file: string, body: string) {
+  writeFileSync(path.join(workersDir, file), body);
+}
+
+const healthy = `id: healthy-worker
+name: Healthy
+responsibilities: [x]
+recipe: good-recipe
+owns: [issue]
+autonomyCeiling: 1
+`;
+
+function validate() {
+  return validateWorkers({ workersDir, recipesDir });
+}
+
+describe("scanWorkers keeps what the loader drops", () => {
+  it("reports an unparseable manifest instead of discarding it", () => {
+    worker("healthy.worker.yaml", healthy);
+    worker("broken.worker.yaml", "id: [not a worker\n");
+    const scan = scanWorkers(workersDir);
+    expect(scan.loaded).toHaveLength(1);
+    expect(scan.broken).toHaveLength(1);
+    expect(scan.broken[0]?.file).toBe("broken.worker.yaml");
+  });
+
+  it("a missing directory is empty, not a throw", () => {
+    const scan = scanWorkers(path.join(workersDir, "nope"));
+    expect(scan.loaded).toEqual([]);
+    expect(scan.broken).toEqual([]);
+  });
+});
+
+describe("validateWorkers", () => {
+  it("is healthy on a correct installation", () => {
+    worker("healthy.worker.yaml", healthy);
+    const r = validate();
+    expect(r.healthy).toBe(true);
+    expect(r.findings).toEqual([]);
+  });
+
+  it("errors on a manifest the bridge would silently skip", () => {
+    worker("broken.worker.yaml", "id: [not a worker\n");
+    const r = validate();
+    expect(r.healthy).toBe(false);
+    expect(r.findings.map((f) => f.code)).toContain("unparseable-manifest");
+  });
+
+  it("errors on a recipe reference that is not installed", () => {
+    worker(
+      "dangling.worker.yaml",
+      healthy.replace("recipe: good-recipe", "recipe: not-installed"),
+    );
+    const r = validate();
+    expect(r.findings.map((f) => f.code)).toContain("dangling-recipe");
+    expect(r.healthy).toBe(false);
+  });
+
+  /**
+   * BOTH are ignored, not one winner — resolution refuses to guess, because
+   * guessing would apply the wrong worker's policy. The message has to say so:
+   * an operator who believes one of them won will look for the wrong behaviour.
+   */
+  it("errors when two workers claim one recipe, and says both lose", () => {
+    worker("a.worker.yaml", healthy.replace("healthy-worker", "dup-a"));
+    worker("b.worker.yaml", healthy.replace("healthy-worker", "dup-b"));
+    const r = validate();
+    const f = r.findings.find((x) => x.code === "ambiguous-recipe");
+    expect(f).toBeDefined();
+    expect(f?.message).toContain("ALL of them are ignored");
+  });
+
+  it("errors on an unparseable forbids entry, because it fails OPEN", () => {
+    worker("bad.worker.yaml", `${healthy}forbids:\n  - 12345\n`);
+    const r = validate();
+    const f = r.findings.find((x) => x.code === "unparseable-forbid-rule");
+    expect(f).toBeDefined();
+    expect(f?.level).toBe("error");
+    expect(f?.message).toContain("fails OPEN");
+  });
+
+  it("a well-formed forbids list is not a finding", () => {
+    worker(
+      "ok.worker.yaml",
+      `${healthy}forbids:\n  - match: payments\n    reason: never\n`,
+    );
+    expect(validate().healthy).toBe(true);
+  });
+
+  it("warns — not errors — when a worker declares no recipe", () => {
+    worker(
+      "norecipe.worker.yaml",
+      healthy.replace("recipe: good-recipe\n", ""),
+    );
+    const r = validate();
+    const f = r.findings.find((x) => x.code === "no-recipe");
+    expect(f?.level).toBe("warning");
+    expect(r.healthy).toBe(true);
+  });
+
+  /**
+   * If no recipes are installed at all, EVERY worker would look dangling. That
+   * is a statement about the recipe directory, not about the workers, and
+   * emitting it per-worker would bury any real finding.
+   */
+  it("does not report every worker as dangling when no recipes are installed", () => {
+    rmSync(path.join(recipesDir, "good.yaml"));
+    worker("healthy.worker.yaml", healthy);
+    expect(validate().findings.some((f) => f.code === "dangling-recipe")).toBe(
+      false,
+    );
+  });
+});
+
+describe("the report leads with the denominator", () => {
+  it("an empty install says 'nothing to check', never 'no problems'", () => {
+    const out = formatWorkersValidate(validate());
+    expect(out).toContain("nothing to check");
+    expect(out).not.toContain("no problems");
+  });
+
+  it("a populated healthy install says no problems, with the count", () => {
+    worker("healthy.worker.yaml", healthy);
+    const out = formatWorkersValidate(validate());
+    expect(out).toContain("1 manifest(s) load, 0 ignored");
+    expect(out).toContain("no problems");
+  });
+});

--- a/src/workers/workersCli.ts
+++ b/src/workers/workersCli.ts
@@ -1,0 +1,299 @@
+/**
+ * `patchwork workers list` / `workers validate` — read-only.
+ *
+ * `workers` shipped with `shadow` and `backtest` only, so a worker reached a
+ * running bridge by hand-copying a file and there was no way to ask whether it
+ * had landed correctly. Three failure modes are silent, and all three end the
+ * same way — the autonomy gate does not govern that worker at all:
+ *
+ *  1. **A manifest that does not parse is SKIPPED.** `loadWorkersFromDir` is
+ *     fail-soft by design (one bad file must not blind the whole dial), and it
+ *     logs only when the caller passes a logger. The bridge does not pass one
+ *     on the resolution path.
+ *  2. **A `recipe:` naming something not installed** binds the worker to
+ *     nothing.
+ *  3. **Two manifests claiming the same recipe** resolve to `undefined` —
+ *     deliberately, since guessing would apply the wrong worker's policy — so
+ *     BOTH are ignored rather than one winning.
+ *
+ * In every case `resolveWorkerIdForRecipe` returns undefined, the caller falls
+ * back to the tier-based approval fn, and the worker ramp never runs. The worker
+ * gate is composed as a FLOOR over the tier fn — it can only ADD approvals — so
+ * losing it means the recipe is governed LESS, not more. Most sharply, a
+ * manifest's ADR-0017 `forbids` list, whose whole point is that no trust and no
+ * approval can unlock the action, becomes inert without a word.
+ *
+ * Manifest drift has the opposite problem: `detectWorkerManifestDrift` is wired,
+ * but only into the bridge's STARTUP report. A real signal that appears once, in
+ * a log, at the moment nobody is watching. This makes it something an operator
+ * can ask for.
+ *
+ * Read-only and deliberately no `install` verb: a package format has to answer
+ * the third-copy problem (`templates/workers/` and `~/.patchwork/workers/`
+ * already diverge, which is why `manifestDrift` exists at all), and that is a
+ * design decision, not a missing function.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { patchworkPath } from "../patchworkHome.js";
+import { parseForbidRules } from "./forbidPolicy.js";
+import {
+  detectWorkerManifestDrift,
+  formatWorkerManifestDrift,
+} from "./manifestDrift.js";
+import { parseWorker, type WorkerManifest } from "./worker.js";
+
+const MANIFEST_RE = /\.worker\.ya?ml$/i;
+
+export interface LoadedWorker {
+  file: string;
+  worker: WorkerManifest;
+}
+
+export interface BrokenWorker {
+  file: string;
+  reason: string;
+}
+
+export interface WorkersScan {
+  dir: string;
+  loaded: LoadedWorker[];
+  /** Files that exist and do NOT load. The population `loadWorkersFromDir` drops. */
+  broken: BrokenWorker[];
+}
+
+/**
+ * Like `loadWorkersFromDir`, but KEEPS what it could not parse instead of
+ * discarding it. That difference is the entire point: the loader's job is to
+ * keep the bridge running, this one's job is to tell an operator what the
+ * bridge silently ignored.
+ */
+export function scanWorkers(dir: string): WorkersScan {
+  const loaded: LoadedWorker[] = [];
+  const broken: BrokenWorker[] = [];
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return { dir, loaded, broken };
+  }
+  for (const file of entries.sort()) {
+    if (!MANIFEST_RE.test(file)) continue;
+    try {
+      loaded.push({
+        file,
+        worker: parseWorker(
+          parseYaml(readFileSync(path.join(dir, file), "utf-8")),
+        ),
+      });
+    } catch (err) {
+      broken.push({
+        file,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return { dir, loaded, broken };
+}
+
+/** Recipe names installed in `dir`, for the dangling-reference check. */
+export function installedRecipeNames(dir: string): Set<string> {
+  const names = new Set<string>();
+  if (!existsSync(dir)) return names;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return names;
+  }
+  for (const f of entries) {
+    if (!/\.ya?ml$/i.test(f)) continue;
+    try {
+      const parsed = parseYaml(readFileSync(path.join(dir, f), "utf-8")) as
+        | { name?: unknown }
+        | undefined;
+      if (typeof parsed?.name === "string") names.add(parsed.name);
+    } catch {
+      // An unreadable recipe is the recipe subsystem's problem to report, not
+      // this one's. Skipping it can only make the dangling check MORE likely to
+      // fire, never less — it cannot hide a real finding.
+    }
+  }
+  return names;
+}
+
+export interface WorkersFinding {
+  level: "error" | "warning" | "info";
+  code: string;
+  message: string;
+}
+
+export interface ValidateResult {
+  findings: WorkersFinding[];
+  healthy: boolean;
+  counts: { loaded: number; broken: number };
+}
+
+export function validateWorkers(opts: {
+  workersDir: string;
+  recipesDir: string;
+  templatesDir?: string;
+}): ValidateResult {
+  const scan = scanWorkers(opts.workersDir);
+  const findings: WorkersFinding[] = [];
+
+  for (const b of scan.broken) {
+    findings.push({
+      level: "error",
+      code: "unparseable-manifest",
+      message:
+        `${b.file} does not parse, so the bridge SKIPS it — no worker owns its ` +
+        `recipe and the autonomy gate (including any forbids) never runs for it. ${b.reason}`,
+    });
+  }
+
+  const recipes = installedRecipeNames(opts.recipesDir);
+  const claims = new Map<string, string[]>();
+  for (const { worker } of scan.loaded) {
+    if (!worker.recipe) {
+      findings.push({
+        level: "warning",
+        code: "no-recipe",
+        message: `${worker.id} declares no \`recipe:\`, so nothing binds it to a run. Its owns/forbids govern nothing.`,
+      });
+      continue;
+    }
+    if (recipes.size > 0 && !recipes.has(worker.recipe)) {
+      findings.push({
+        level: "error",
+        code: "dangling-recipe",
+        message: `${worker.id} names recipe "${worker.recipe}", which is not installed. The worker governs nothing.`,
+      });
+    }
+    claims.set(worker.recipe, [
+      ...(claims.get(worker.recipe) ?? []),
+      worker.id,
+    ]);
+  }
+
+  for (const { worker } of scan.loaded) {
+    // `forbids` is held raw on the manifest and parsed at point of use, because
+    // a deny-list that silently loses a rule fails OPEN: the banned action
+    // degrades to merely gated, and a human can then approve it. That is the
+    // one direction ADR-0017's terminal `forbid` must never degrade in, so an
+    // unparseable entry is an ERROR here rather than a warning.
+    const parsed = parseForbidRules(worker.forbids);
+    if (parsed.invalid.length > 0) {
+      findings.push({
+        level: "error",
+        code: "unparseable-forbid-rule",
+        message:
+          `${worker.id} has ${parsed.invalid.length} unparseable forbids entr${parsed.invalid.length === 1 ? "y" : "ies"} ` +
+          `(index ${parsed.invalid.join(", ")}). A dropped deny-rule fails OPEN — the action becomes merely gated, ` +
+          "which a human can approve.",
+      });
+    }
+  }
+
+  for (const [recipe, ids] of claims) {
+    if (ids.length > 1) {
+      findings.push({
+        level: "error",
+        code: "ambiguous-recipe",
+        message:
+          `recipe "${recipe}" is claimed by ${ids.length} workers (${ids.join(", ")}). ` +
+          "Resolution refuses to guess, so ALL of them are ignored — not one of them wins.",
+      });
+    }
+  }
+
+  if (opts.templatesDir) {
+    const drift = detectWorkerManifestDrift({
+      templatesDir: opts.templatesDir,
+      liveDir: opts.workersDir,
+    });
+    for (const line of formatWorkerManifestDrift(drift)) {
+      findings.push({
+        level: "warning",
+        code: "manifest-drift",
+        message: line,
+      });
+    }
+  }
+
+  return {
+    findings,
+    healthy: !findings.some((f) => f.level === "error"),
+    counts: { loaded: scan.loaded.length, broken: scan.broken.length },
+  };
+}
+
+export function formatWorkersList(scan: WorkersScan): string {
+  const out: string[] = [];
+  out.push(`Workers in ${scan.dir}`);
+  out.push("─".repeat(40));
+  if (scan.loaded.length === 0 && scan.broken.length === 0) {
+    out.push("  (none installed)");
+    out.push("");
+    return `${out.join("\n")}\n`;
+  }
+  for (const { worker } of scan.loaded) {
+    out.push(
+      `  ${worker.id}  —  ${worker.name}\n` +
+        `      recipe: ${worker.recipe ?? "(none)"}   ceiling: L${worker.autonomyCeiling}   ` +
+        `owns: ${worker.owns.length}   forbids: ${parseForbidRules(worker.forbids).rules.length}`,
+    );
+  }
+  // Broken files are listed WITH the healthy ones, not hidden behind a flag.
+  // The whole failure mode is that they are invisible.
+  for (const b of scan.broken) {
+    out.push(
+      `  ✗ ${b.file}  —  NOT LOADED (the bridge ignores it): ${b.reason}`,
+    );
+  }
+  out.push("");
+  out.push(
+    `  ${scan.loaded.length} loaded${scan.broken.length > 0 ? `, ${scan.broken.length} IGNORED` : ""}`,
+  );
+  out.push("");
+  return `${out.join("\n")}\n`;
+}
+
+export function formatWorkersValidate(result: ValidateResult): string {
+  const out: string[] = [];
+  out.push("Worker manifest validation");
+  out.push("─".repeat(40));
+  // Lead with the denominator, like `privacy receipts` and `halts`: "0 problems"
+  // over an empty directory is not the same statement as "0 problems" over eight
+  // manifests, and reporting them identically is how an empty install reads as a
+  // clean one.
+  out.push(
+    `  ${result.counts.loaded} manifest(s) load, ${result.counts.broken} ignored`,
+  );
+  if (result.findings.length === 0) {
+    out.push("");
+    out.push(
+      result.counts.loaded === 0
+        ? "  nothing to check — no worker manifests are installed"
+        : "  ✓ no problems found",
+    );
+    out.push("");
+    return `${out.join("\n")}\n`;
+  }
+  out.push("");
+  for (const f of result.findings) {
+    const mark = f.level === "error" ? "✗" : f.level === "warning" ? "⚠" : "·";
+    out.push(`  ${mark} [${f.code}] ${f.message}`);
+  }
+  out.push("");
+  return `${out.join("\n")}\n`;
+}
+
+export function defaultWorkersDir(): string {
+  return patchworkPath("workers");
+}
+export function defaultRecipesDir(): string {
+  return patchworkPath("recipes");
+}


### PR DESCRIPTION
`patchwork workers` shipped with `shadow` and `backtest` only, so a worker reached a running bridge by hand-copying a file and there was no way to ask whether it had landed. Doc-13 item 9.

Adds read-only **`workers list`** and **`workers validate`**.

## Four ways a manifest is present and governs nothing — all silent

1. **It does not parse.** `loadWorkersFromDir` is fail-soft by design (one bad file must not blind the whole dial) and logs only when the caller passes a logger — which the resolution path does not.
2. **Its `recipe:` names something not installed.**
3. **Two manifests claim the same recipe.** Resolution refuses to guess, because guessing would apply the wrong worker's policy — so **both are ignored**. There is no winner, and an operator who assumes one won will look for the wrong behaviour.
4. **A `forbids` entry does not parse.** Held raw and parsed at point of use, so a dropped deny-rule **fails OPEN**: the banned action degrades to merely gated, which a human can then approve.

In every case `resolveWorkerIdForRecipe` returns `undefined`, the caller falls back to the tier-based approval fn, and the worker ramp never runs. The worker gate is composed as a **floor** over the tier fn — it can only *add* approvals — so losing it means the recipe is governed **less**, not more. Most sharply, an ADR-0017 `forbids` list, whose whole point is that no trust and no approval unlocks the action, goes inert without a word.

Manifest drift had the opposite problem: `detectWorkerManifestDrift` was wired, but only into the bridge's **startup** report — a real signal that appears once, in a log, when nobody is watching. `validate` makes it something an operator can ask for.

## Reporting

Leads with the denominator, like `privacy receipts` and `halts`: an empty directory reports *"nothing to check"*, never *"no problems"*. Broken files are listed alongside healthy ones rather than behind a flag, since being invisible is the entire failure mode. Exits 1 when unhealthy — **including `list`**, because a manifest the bridge ignores is a governance gap, not a note.

## No `install` verb, deliberately

A package format has to answer the third-copy problem — `templates/workers/` and `~/.patchwork/workers/` already diverge, which is why `manifestDrift` exists at all. That is a design decision, not a missing function.

## Verification

Measured on the reference install **before** building: 8 manifests, all parsing, none dangling, none ambiguous, no drift. So the validator was built against deliberately broken fixtures — one that has only ever seen healthy input is not known to be able to fail.

| mutation (each confirmed applied first) | result |
|---|---|
| do not report broken files | 1 failed |
| disable the dangling-recipe check | 1 failed |
| fire dangling even when no recipes are installed | 1 failed |
| disable the ambiguity check | 1 failed |
| disable the forbid-rule check | 1 failed |
| make an empty install report "no problems" | 1 failed |
| restored | 12 passed |

Exit codes checked without a pipe swallowing them: unhealthy 1, healthy 0, `list` with a broken manifest 1, `list` healthy 0.

10,412 passed · all 19 CI audit gates, `typecheck`, `typecheck:tests:core` green.

## Also

CLAUDE.md records the new verbs and the three `expect` changes that landed today (#1528–#1530), plus two traps that each cost a build: the schema-regeneration/biome conflict, and that the flat runner derives run-log step ids from `into` and never `step.id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)