### PR TITLE
feat(templates): the halt counter had nothing to count

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,12 +50,25 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-26 `feat/template-completion-contracts` — #1528 taught `patchwork halts` to see a
-  violated run-level `expect`, and measured 0 of 82 installed recipes declaring one, so the
-  counter has nothing to count. Adds contracts to the three templates whose postcondition
-  is unambiguous (an agent step whose output IS the artifact). Templates only.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-26 `feat/template-completion-contracts` — #1528's `contract_failed` category
+  could never fire: 82 installed recipes, 10 with a step-level `expect`, ZERO with a
+  run-level one. Adds contracts to the three templates that end in an agent step whose
+  output IS the artifact (`daily-status`, `morning-brief-slack`, `release-notes`), which is
+  the failure this family actually has — every step ok, run `done`, and the final step
+  writes a heading with nothing under it. Asserts ONLY the artifact: the upstream fetch
+  steps may legitimately come back empty, and turning a quiet day into a halt is a contract
+  that cries wolf. NOT added to the other five candidates — four have no agent step and one
+  produces no single named artifact, so the postcondition would have to be arbitrary.
+  Verified both directions: `release-notes` passes and fails when the asserted key is
+  changed to one nothing produces; `daily-status`'s contract FIRES on the real template
+  because its agent step fails under `recipe test`. Recorded rather than glossed: two of
+  the three already failed `recipe test` on main (failed agent fetch; four missing
+  connector fixture libraries), and that missing `~/.patchwork/fixtures` directory is the
+  same precondition making a worker eval harness premature. (#1532)
 
 - 2026-08-26 `feat/workers-list-validate` — four ways a worker manifest is installed and
   governs NOTHING, all silent: it does not parse (`loadWorkersFromDir` is fail-soft and

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,10 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- 2026-08-26 `feat/template-completion-contracts` — #1528 taught `patchwork halts` to see a
+  violated run-level `expect`, and measured 0 of 82 installed recipes declaring one, so the
+  counter has nothing to count. Adds contracts to the three templates whose postcondition
+  is unambiguous (an agent step whose output IS the artifact). Templates only.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/templates/recipes/daily-status.yaml
+++ b/templates/recipes/daily-status.yaml
@@ -7,6 +7,24 @@ description: Every morning at 08:00, summarize yesterday's commits + today's cal
 allowWrites:
   - file.write
 
+# Run-level completion contract. Every step can report ok and the run can still
+# finish `done` having produced no `brief` — an agent that narrates instead of
+# answering, or a driver that returns empty, leaves the key unset and the step
+# after it writes a heading with nothing under it. That is this recipe's real
+# failure mode and it is silent.
+#
+# Checked AFTER the last step; it does NOT change the run's status. A violation
+# is recorded as `assertionFailures` on the run and counted by `patchwork halts`
+# under `completion contract failed`. So the run still writes whatever it
+# produced — this reports, it does not roll back.
+#
+# Asserts only the daily status it exists to write: the upstream fetch steps are
+# allowed to come back empty (no commits today, an empty calendar), and turning
+# a quiet day into a halt would be a contract that cries wolf.
+expect:
+  outputs:
+    - brief
+
 trigger:
   type: cron
   at: "0 8 * * *"

--- a/templates/recipes/morning-brief-slack.yaml
+++ b/templates/recipes/morning-brief-slack.yaml
@@ -8,6 +8,24 @@ allowWrites:
   - file.write
   - slack.post_message
 
+# Run-level completion contract. Every step can report ok and the run can still
+# finish `done` having produced no `brief` — an agent that narrates instead of
+# answering, or a driver that returns empty, leaves the key unset and the step
+# after it writes a heading with nothing under it. That is this recipe's real
+# failure mode and it is silent.
+#
+# Checked AFTER the last step; it does NOT change the run's status. A violation
+# is recorded as `assertionFailures` on the run and counted by `patchwork halts`
+# under `completion contract failed`. So the run still writes whatever it
+# produced — this reports, it does not roll back.
+#
+# Asserts only the brief it posts to Slack: the upstream fetch steps are
+# allowed to come back empty (no commits today, an empty calendar), and turning
+# a quiet day into a halt would be a contract that cries wolf.
+expect:
+  outputs:
+    - brief
+
 trigger:
   type: cron
   at: "0 8 * * 1-5"

--- a/templates/recipes/release-notes.yaml
+++ b/templates/recipes/release-notes.yaml
@@ -6,6 +6,24 @@ name: release-notes
 description: After a commit lands, draft a changelog entry from the new commits into the inbox.
 allowWrites:
   - file.write
+# Run-level completion contract. Every step can report ok and the run can still
+# finish `done` having produced no `notes` — an agent that narrates instead of
+# answering, or a driver that returns empty, leaves the key unset and the step
+# after it writes a heading with nothing under it. That is this recipe's real
+# failure mode and it is silent.
+#
+# Checked AFTER the last step; it does NOT change the run's status. A violation
+# is recorded as `assertionFailures` on the run and counted by `patchwork halts`
+# under `completion contract failed`. So the run still writes whatever it
+# produced — this reports, it does not roll back.
+#
+# Asserts only the release notes it drafts: the upstream fetch steps are
+# allowed to come back empty (no commits today, an empty calendar), and turning
+# a quiet day into a halt would be a contract that cries wolf.
+expect:
+  outputs:
+    - notes
+
 trigger:
   type: git_hook
   event: post-commit


### PR DESCRIPTION
#1528 taught `patchwork halts` to see a run that finished `done` while violating its run-level `expect`. Measured at the time: **82 installed recipes, 10 with a step-level `expect`, and zero with a run-level one** — so the new `contract_failed` category could never fire. #1528 gave `morning-brief` the first contract; this gives three more.

## Chosen by shape, not by count

| template | artifact key |
|---|---|
| `daily-status` | `brief` |
| `morning-brief-slack` | `brief` |
| `release-notes` | `notes` |

Each ends in an agent step whose output **is** the artifact, consumed by a write or post step. That is the failure this family actually has: every step reports ok, the run finishes `done`, and the final step writes a heading with nothing under it because the agent narrated instead of answering.

**Asserts only the artifact.** The upstream fetch steps are allowed to come back empty — no commits today, an empty calendar — and turning a quiet day into a halt would be a contract that cries wolf, which is how a real signal gets ignored.

**Deliberately not added to the other five candidates.** `inbox-triage`, `stale-branches`, `gmail-health-check` and `ambient-journal` have no agent step; `project-health-check` produces no single named artifact. A contract there would assert something arbitrary, and an arbitrary postcondition is worse than none.

## Verified in both directions

- `release-notes` **passes** `recipe test`; changing the asserted key to one nothing produces **fails** it:
  `✗ Expected output key "notes_not_produced" not found in [notes, …/release-notes-2026-08-26.md]`
- `daily-status`'s contract **fires on the real template** — its agent step fails under `recipe test` (no network), so `brief` is never produced and the contract reports `not found in []`. Exactly its job.

That second line also confirms the flat runner's `outputs` vocabulary documented in #1529: the agent `into:` key **and** the resolved `file.write` path.

## What I could not exercise, stated rather than glossed

`daily-status` and `morning-brief-slack` already failed `recipe test` on main **before** this change — the first on a failed agent fetch, the second on four missing connector fixture libraries. So `recipe test` cannot fully validate those two here.

The missing fixtures are the same precondition that makes a worker eval harness premature: **no `~/.patchwork/fixtures` directory exists at all**. Authoring contracts and recording fixtures is what unblocks that, not writing the aggregator.

10,414 passed · all 19 CI audit gates green · three templates lint clean with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)