### PR TITLE
fix(identity): the session-secret file was never tightened

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,13 +50,25 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-26 `fix/session-secret-file-permissions` — `~/.patchwork/.env` holds
-  `DASHBOARD_SESSION_SECRET` (the whole ADR-0020 attribution scheme rests on it) and
-  `DASHBOARD_PASSWORD`. `credentialStore` tightens its file on read when group/world
-  readable; nothing does that for `.env`, and `writeFileSync(…, {mode})` in
-  `patchworkInit` is a no-op on an EXISTING file. Found at 644 on the reference machine.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-26 `fix/session-secret-file-permissions` — `$PATCHWORK_HOME/.env` holds
+  `DASHBOARD_SESSION_SECRET`, so forging one mints a cookie naming any member: the whole
+  ADR-0020 scheme. `credentialStore` tightens its own file on read for exactly that
+  reason; nothing did for `.env`, found at mode 644 on the reference machine. The trap
+  that hid it: `patchworkInit` DOES pass `{ mode: 0o600 }`, but `writeFileSync` applies
+  `mode` only when CREATING a file — on an existing one Node ignores it silently, so a
+  file that ever became loose stayed loose however many times init ran, with the line that
+  appears to set the mode sitting there reading as correct. Fixed at both ends (init
+  chmods after writing; the reader tightens AND reports, because silently repairing leaves
+  the operator unaware and the message has to say to rotate — tightening does not
+  un-disclose what was already readable). Reported via an optional `onWarn` rather than a
+  changed return shape: a second exported reader for one path is how two readers come to
+  disagree. Skipped on win32 in both places, since NTFS reports 0o666 regardless and a
+  warning that always fires is how a real one gets ignored. Still returns the secret when
+  loose — refusing would turn a permissions problem into an attribution outage. (#1533)
 
 - 2026-08-26 `feat/template-completion-contracts` — #1528's `contract_failed` category
   could never fire: 82 installed recipes, 10 with a step-level `expect`, ZERO with a

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- 2026-08-26 `fix/session-secret-file-permissions` — `~/.patchwork/.env` holds
+  `DASHBOARD_SESSION_SECRET` (the whole ADR-0020 attribution scheme rests on it) and
+  `DASHBOARD_PASSWORD`. `credentialStore` tightens its file on read when group/world
+  readable; nothing does that for `.env`, and `writeFileSync(…, {mode})` in
+  `patchworkInit` is a no-op on an EXISTING file. Found at 644 on the reference machine.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1296,7 +1296,12 @@ export class Bridge {
     // rather than re-read per approval, matching the load-once contract the
     // roster and credential store both document.
     if ((process.env.DASHBOARD_SESSION_SECRET ?? "") === "") {
-      __setSessionSecretFallback(readSessionSecretFromHome());
+      __setSessionSecretFallback(
+        // The warning is routed to the bridge log rather than swallowed: this
+        // file holds the session secret, and an operator running it
+        // world-readable has been doing so for however long.
+        readSessionSecretFromHome(undefined, (msg) => this.logger.warn(msg)),
+      );
     }
     if (hasSessionSecret()) {
       const roster = this.server.roster;

--- a/src/commands/patchworkInit.ts
+++ b/src/commands/patchworkInit.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import {
+  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -109,6 +110,17 @@ export function ensureDashboardEnv(
   writeFileSync(envPath, `${existing + sep + additions.join("\n")}\n`, {
     mode: 0o600,
   });
+  // `mode` above applies only when CREATING the file — on an existing one Node
+  // ignores it silently, so a `.env` that ever became group/world-readable
+  // stayed that way however many times init ran. This file holds the dashboard
+  // session secret; forging one mints a session naming any member.
+  if (process.platform !== "win32") {
+    try {
+      chmodSync(envPath, 0o600);
+    } catch {
+      /* best-effort: a failure here must not break `init` */
+    }
+  }
   // Also write dashboard/.env.local so Next.js picks up credentials without start-all sourcing
   const dashDir =
     dashboardDirOverride !== undefined

--- a/src/identity/__tests__/sessionSecretPermissions.test.ts
+++ b/src/identity/__tests__/sessionSecretPermissions.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `$PATCHWORK_HOME/.env` holds `DASHBOARD_SESSION_SECRET`. Forge one and you
+ * can mint a session naming any member, which is the entire ADR-0020
+ * attribution scheme — so the file's permissions are a governance property,
+ * not housekeeping.
+ *
+ * `credentialStore` already tightens its own file on read for exactly this
+ * reason. Nothing did it here, and the file was found mode 644 on the
+ * reference machine on 2026-08-26.
+ *
+ * The trap that hid it: `patchworkInit` DOES pass `{ mode: 0o600 }`, so the
+ * code looks correct. `writeFileSync` applies `mode` only when CREATING a
+ * file — on an existing one Node ignores it silently, so a `.env` that ever
+ * became loose stayed loose however many times init ran.
+ */
+
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readSessionSecretFromHome } from "../sessionSecretFile.js";
+
+const SECRET = "a".repeat(64);
+let home: string;
+let envFile: string;
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(os.tmpdir(), "pw-envperm-"));
+  envFile = path.join(home, ".env");
+  writeFileSync(envFile, `DASHBOARD_SESSION_SECRET=${SECRET}\n`, {
+    mode: 0o600,
+  });
+});
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const mode = () => statSync(envFile).mode & 0o777;
+
+// NTFS reports 0o666 whatever chmod does, so these assertions are meaningless
+// there and the production check skips win32 for the same reason.
+describe.skipIf(process.platform === "win32")(
+  "the session-secret file is tightened on read",
+  () => {
+    it("tightens a group/world-readable file to 0600", () => {
+      chmodSync(envFile, 0o644);
+      expect(mode()).toBe(0o644);
+      const warnings: string[] = [];
+      const secret = readSessionSecretFromHome(home, (m) => warnings.push(m));
+      expect(mode()).toBe(0o600);
+      // Still returns the secret: refusing to read it would turn a permissions
+      // problem into an attribution outage, which is the worse failure.
+      expect(secret).toBe(SECRET);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("Tightened to 0600");
+    });
+
+    it("REPORTS, not just fixes — silence would leave the operator unaware", () => {
+      chmodSync(envFile, 0o604);
+      const warnings: string[] = [];
+      readSessionSecretFromHome(home, (m) => warnings.push(m));
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatch(/readable by group or others/);
+      expect(warnings[0]).toMatch(/rotate the secret/);
+    });
+
+    it("says nothing when the file is already 0600", () => {
+      const warnings: string[] = [];
+      expect(readSessionSecretFromHome(home, (m) => warnings.push(m))).toBe(
+        SECRET,
+      );
+      expect(warnings).toEqual([]);
+      expect(mode()).toBe(0o600);
+    });
+
+    it("group-execute-only still counts as loose", () => {
+      chmodSync(envFile, 0o610);
+      const warnings: string[] = [];
+      readSessionSecretFromHome(home, (m) => warnings.push(m));
+      expect(mode()).toBe(0o600);
+      expect(warnings).toHaveLength(1);
+    });
+
+    it("works with no reporter passed — the existing call shape", () => {
+      chmodSync(envFile, 0o644);
+      expect(readSessionSecretFromHome(home)).toBe(SECRET);
+      expect(mode()).toBe(0o600);
+    });
+
+    it("an absent file is not a warning", () => {
+      rmSync(envFile);
+      const warnings: string[] = [];
+      expect(
+        readSessionSecretFromHome(home, (m) => warnings.push(m)),
+      ).toBeUndefined();
+      expect(warnings).toEqual([]);
+    });
+  },
+);

--- a/src/identity/sessionSecretFile.ts
+++ b/src/identity/sessionSecretFile.ts
@@ -33,7 +33,7 @@
  * lives here and is injected.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { patchworkHome } from "../patchworkHome.js";
@@ -49,10 +49,56 @@ const KEY = "DASHBOARD_SESSION_SECRET";
  * decisions recorded unattributed. That is the pre-existing behaviour and the
  * correct one, since an absent actor already means "nobody recorded this" and
  * must never be filled in with a guess.
+ *
+ * ## It also tightens the file, and reports having done so
+ *
+ * This file holds `DASHBOARD_SESSION_SECRET` — forge one and you can mint a
+ * session naming any member, which is the whole ADR-0020 attribution scheme —
+ * and in practice `DASHBOARD_PASSWORD` beside it. `credentialStore` already
+ * tightens its own file on read for exactly this reason; nothing did it here,
+ * and the file was found mode 644 on the reference machine.
+ *
+ * `patchworkInit` does pass `{ mode: 0o600 }`, which is why this is easy to
+ * miss: **`writeFileSync` applies `mode` only when CREATING a file.** On an
+ * existing one it is silently ignored, so a file that ever became loose stays
+ * loose no matter how many times init runs.
+ *
+ * `onWarn` rather than a return-shape change: the caller needs to be TOLD, not
+ * just silently fixed — an operator who has been running world-readable has
+ * been doing so for however long — but adding a second exported reader for the
+ * same path is how two readers of one file come to disagree.
  */
-export function readSessionSecretFromHome(dir?: string): string | undefined {
+export function readSessionSecretFromHome(
+  dir?: string,
+  onWarn?: (message: string) => void,
+): string | undefined {
   const file = path.join(dir ?? patchworkHome(), ".env");
   if (!existsSync(file)) return undefined;
+
+  // NTFS reports 0o666 regardless of any chmod, so this check would fire on
+  // every Windows start and tighten nothing. A warning that always fires is
+  // how a real one gets ignored.
+  if (process.platform !== "win32") {
+    try {
+      if ((statSync(file).mode & 0o077) !== 0) {
+        let tightened = false;
+        try {
+          chmodSync(file, 0o600);
+          tightened = true;
+        } catch {
+          /* reported below either way — nothing else to do */
+        }
+        onWarn?.(
+          `[patchwork] ${file} was readable by group or others; it holds the dashboard session secret. ` +
+            (tightened
+              ? "Tightened to 0600 — rotate the secret if the machine is shared."
+              : "FAILED to tighten it — fix the permissions by hand and rotate the secret."),
+        );
+      }
+    } catch {
+      /* stat failed — fall through; the read below decides */
+    }
+  }
 
   let text: string;
   try {


### PR DESCRIPTION
`$PATCHWORK_HOME/.env` holds `DASHBOARD_SESSION_SECRET`, and in practice `DASHBOARD_PASSWORD` beside it. **Forge a session secret and you can mint a cookie naming any member** — that is the entire ADR-0020 attribution scheme. This file's permissions are a governance property, not housekeeping.

`credentialStore` already tightens its own file on read, with a comment saying why: *"a world-readable password file is a live problem, and an operator who is told about it at startup has already been running that way for however long."* Nothing did the same for `.env`.

Found **mode 644** on the reference machine, 2026-08-26.

## The trap, and why this looked fine

`patchworkInit` **does** pass `{ mode: 0o600 }`. But `writeFileSync` applies `mode` **only when creating** a file — on an existing one Node ignores it silently.

So a `.env` that ever became group- or world-readable stayed that way no matter how many times `init` ran, while the line that appears to set the mode sat right there being read as correct.

## Two changes, because one alone leaves a hole

- **`patchworkInit` chmods after writing** — so init repairs an existing loose file instead of only getting new ones right.
- **`readSessionSecretFromHome` tightens on read and reports it**, mirroring `credentialStore`.

Reporting matters as much as fixing. Silently repairing leaves an operator unaware they were running exposed, and the message says to **rotate the secret**, because tightening a file does not un-disclose what was already readable.

Reported via an optional `onWarn` callback rather than a changed return shape: the caller needs to be told, but a second exported reader for the same path is how two readers of one file come to disagree. The existing call shape still works and its tests are untouched.

## Two deliberate limits

- **Skipped on win32**, both places. NTFS reports `0o666` whatever `chmod` does, so the check would fire on every Windows start and tighten nothing — and a warning that always fires is how a real one gets ignored.
- **Still returns the secret when the file is loose.** Refusing to read it would turn a permissions problem into an attribution outage, which is the worse failure.

## Verification

| mutation (each confirmed applied) | result |
|---|---|
| report without tightening | 3 failed |
| tighten without reporting | 3 failed |
| narrow the mask to world bits only (misses group-readable) | 1 failed |
| restored | 6 passed |

10,420 passed · `typecheck`, `typecheck:tests:core`, all 19 CI audit gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)