### PR TITLE
feat(evidence): the spine's own denominators had no verb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,7 @@ Comply with all docs in `/documents/`. Consult before changes:
 - `dashboard` — Launch the local dashboard. Guards first run: without `patchwork init` it prints a pointer instead of an empty panel.
 - `members [list|set-password <id>]` — Workspace roster plus which members hold credentials. Bare `members` lists. A member with no password is reported as `NO password — cannot authenticate`, and an absent `members.json` reports the single implicit owner rather than pretending a roster exists.
 - `runstore <backfill|compare> [--json]` — Durable run-store maintenance. `compare` prints ledger contents, so its output is **operator data, not a diagnostic blob** — never paste it into an issue, a PR body or a fixture.
+- `evidence [--dir <path>] [--json]` — **how much of the evidence spine can actually be joined?** Per ledger: how many rows carry a `correlationId` out of how many rows exist, plus how many runs appear in more than one ledger. Reports DENOMINATORS; it is deliberately not the cross-ledger reader, which the spine's own rule defers until there is evidence to read. An absent ledger is reported ABSENT, never `0 rows` — `butler/permission_exercises.jsonl` is absent because no standing permission has ever been granted, and rendering that as a zero invites someone to "fix" it. Prints **counts only, never a row, an id or any value**, because a `correlationId` IS a run's `taskId`; unlike `runstore compare` and `privacy receipts`, its output is therefore safe to quote. Always exits 0 — zero joinable rows is a true and expected state, and failing on it would make a correct answer look like an error.
 - `shadow-scan [--since <duration|ISO>] [--limit <n>] [--runs-file <path>] [--json]` — Reclassification scan over the run log.
 - `privacy suggest [--json]` — Derive a STARTER `privacy.shadow` block from the drivers your installed recipes actually declare. The destinations are MEASURED; the classifications are a conservative placeholder you are told to review. Reports agent steps that declare no driver separately rather than folding them in — they dispatch somewhere too. Emits `privacy.shadow` only, never the enforcing `privacy.destinations` key.
 - `privacy shadow [--since-days N] [--json]` — What a candidate policy WOULD have stopped, without enforcing it (ADR-0021). Leads with the DENOMINATOR and refuses to print a bare crossing count; an empty ledger reports "nothing observed", never "0 crossings". Reads `privacy_shadow.jsonl`.
@@ -650,6 +651,22 @@ is a hole to plumb, the second is a dial that has not moved.
 Two corrections' worth of warning: this section was written from a survey, and
 both of its load-bearing claims went stale or were wrong within two days. Re-run
 the check before scoping against it.
+
+**`patchwork evidence` is that check.** It reports, per ledger, how many rows
+carry a `correlationId` out of how many rows exist, and how many runs appear in
+more than one — the denominators, not a reader. Measured 2026-08-26 on the
+reference machine: gate decisions **1 of 273**, boundary receipts **14 of 170**,
+and `privacy_shadow` / `outcome-log` / `approval_log` **0**. Runs reachable in
+BOTH joined ledgers: **zero**. The two populations barely overlap by
+construction — gate rows are written for worker recipes under the autonomy flag,
+receipts for agent steps with a registered destination — so the join is sparse
+rather than merely young.
+
+That zero is what keeps the evidence graph unbuilt, and it is why item 7 is not
+"unblocked by the sentinel shipping": the sentinel settled HOW to stamp, and
+there is still almost nothing stamped. The verb prints COUNTS ONLY — never a
+row, an id or any value, because a `correlationId` is a run's `taskId` — so its
+output is safe to quote where `runstore compare` and `privacy receipts` are not.
 
 `ctxQueryTraces` reads four stores and none of those.
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- 2026-08-26 `feat/evidence-join-coverage` — CLAUDE.md's Evidence Spine section tells the
+  next session to re-measure join coverage before scoping items 7/8, and warns its own
+  figures went stale within two days. Doing that takes a bespoke script every time. Adds a
+  read-only `patchwork evidence` reporting rows / joinable / distinct ids per ledger and
+  the pairwise intersections. Reports denominators; does NOT build a reader.
 
 ## Recently closed (informal log, prune periodically)
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,13 +50,26 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-26 `feat/evidence-join-coverage` — CLAUDE.md's Evidence Spine section tells the
-  next session to re-measure join coverage before scoping items 7/8, and warns its own
-  figures went stale within two days. Doing that takes a bespoke script every time. Adds a
-  read-only `patchwork evidence` reporting rows / joinable / distinct ids per ledger and
-  the pairwise intersections. Reports denominators; does NOT build a reader.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-26 `feat/evidence-join-coverage` — the Evidence Spine section tells the next
+  session to re-measure join coverage before scoping a cross-ledger reader, and records
+  that its own figures went stale within two days; doing so took a bespoke throwaway
+  script every time, which is how a check that must be re-run stops being re-run.
+  `patchwork evidence` reports the denominators: gate decisions 1 of 273, boundary
+  receipts 14 of 170, the other three 0, and ZERO runs reachable in both joined ledgers.
+  That zero is the finding — item 7 is NOT unblocked by the sentinel shipping, because the
+  sentinel settled HOW to stamp and almost nothing is stamped; the two populations barely
+  overlap by construction (gate rows come from worker recipes under the autonomy flag,
+  receipts from agent steps with a registered destination), so the join is sparse rather
+  than young. Denominators, NOT the reader. ABSENT is reported distinctly from 0 rows
+  (permission_exercises is absent because no grant has ever happened — correct, not a
+  gap). COUNTS ONLY, never a row or an id, since a correlationId IS a taskId — so unlike
+  `runstore compare` its output is safe to quote. Always exits 0: zero joinable rows is a
+  true state, not a failure. Note for whoever mutation-tests next: the first attempt at
+  the leak mutation was a NO-OP that passed and proved nothing. (#1535)
 
 - 2026-08-26 `fix/doctor-two-handlers` — two top-level `argv[2] === "doctor"` blocks; the
   deployment-freshness one won every time (stable over five runs, zero health-check

--- a/src/__tests__/evidenceCoverage.test.ts
+++ b/src/__tests__/evidenceCoverage.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `patchwork evidence` reports the DENOMINATORS of the evidence spine.
+ *
+ * CLAUDE.md tells the next session to re-measure join coverage before scoping a
+ * cross-ledger reader, and records that its own figures went stale within two
+ * days. That measurement was a bespoke throwaway script every time.
+ *
+ * The two properties that matter here are not the arithmetic:
+ *
+ *  1. **Absent is not zero.** A ledger that does not exist is a different fact
+ *     from one with no rows — `butler/permission_exercises.jsonl` is absent
+ *     because no standing permission has ever been granted, and that absence is
+ *     CORRECT rather than a gap to plumb. Rendering it as `0 rows` invites
+ *     someone to go and "fix" it.
+ *  2. **Counts only, never contents.** A `correlationId` IS a run's `taskId`,
+ *     and these ledgers hold real task titles, captured output and third-party
+ *     record ids. A measurement may leave the machine; the rows may not.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  evidenceCoverage,
+  formatEvidenceCoverage,
+} from "../evidenceCoverage.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "pw-evidence-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function write(file: string, rows: Array<Record<string, unknown>>) {
+  const full = path.join(dir, file);
+  mkdirSync(path.dirname(full), { recursive: true });
+  writeFileSync(full, `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`);
+}
+
+const cov = () => evidenceCoverage(dir);
+const led = (key: string) =>
+  cov().ledgers.find((l) => l.key === key) as NonNullable<
+    ReturnType<typeof cov>["ledgers"][number]
+  >;
+
+describe("absent is not zero", () => {
+  it("marks a missing ledger absent rather than empty", () => {
+    const l = led("gate decisions");
+    expect(l.absent).toBe(true);
+    expect(l.rows).toBe(0);
+    expect(formatEvidenceCoverage(cov())).toContain("ABSENT");
+  });
+
+  it("an EMPTY-but-present ledger is not absent", () => {
+    writeFileSync(path.join(dir, "worker_gate_decisions.jsonl"), "");
+    const l = led("gate decisions");
+    expect(l.absent).toBe(false);
+    expect(l.rows).toBe(0);
+  });
+});
+
+describe("counting", () => {
+  it("counts joinable rows against the full denominator", () => {
+    write("worker_gate_decisions.jsonl", [
+      { rv: 1, correlationId: "run-a" },
+      { rv: 1, correlationId: "run-a" },
+      {}, // pre-sentinel row, legitimately has none
+      {},
+    ]);
+    const l = led("gate decisions");
+    expect(l.rows).toBe(4);
+    expect(l.joinable).toBe(2);
+    expect(l.distinctRuns).toBe(1);
+  });
+
+  it("reports unparseable lines instead of silently skipping them", () => {
+    writeFileSync(
+      path.join(dir, "outcome-log.jsonl"),
+      '{"correlationId":"r1"}\nnot json at all\n',
+    );
+    const l = led("outcomes");
+    expect(l.rows).toBe(1);
+    expect(l.corrupt).toBe(1);
+  });
+
+  it("ignores an empty-string correlationId — present but useless", () => {
+    write("boundary_receipts.jsonl", [
+      { correlationId: "" },
+      { correlationId: "r" },
+    ]);
+    expect(led("boundary receipts").joinable).toBe(1);
+  });
+});
+
+describe("the join is the point", () => {
+  it("reports 0 shared runs when two ledgers describe different runs", () => {
+    write("worker_gate_decisions.jsonl", [{ correlationId: "run-a" }]);
+    write("boundary_receipts.jsonl", [{ correlationId: "run-b" }]);
+    const c = cov();
+    expect(c.runsInMoreThanOneLedger).toBe(0);
+    expect(c.pairs).toContainEqual({
+      a: "gate decisions",
+      b: "boundary receipts",
+      shared: 0,
+    });
+  });
+
+  it("counts a run reachable in two ledgers", () => {
+    write("worker_gate_decisions.jsonl", [{ correlationId: "run-a" }]);
+    write("boundary_receipts.jsonl", [
+      { correlationId: "run-a" },
+      { correlationId: "run-b" },
+    ]);
+    const c = cov();
+    expect(c.runsInMoreThanOneLedger).toBe(1);
+    expect(c.pairs[0]?.shared).toBe(1);
+  });
+
+  it("says nothing can be joined when only one ledger carries ids", () => {
+    write("worker_gate_decisions.jsonl", [{ correlationId: "run-a" }]);
+    const out = formatEvidenceCoverage(cov());
+    expect(out).toContain("No two ledgers both carry run ids");
+  });
+});
+
+describe("it prints counts, never contents", () => {
+  /**
+   * The guard that matters. A correlationId is a taskId, and these rows carry
+   * real task titles and third-party record ids — so the renderer must not be
+   * able to leak one even by accident.
+   */
+  it("never renders an id or any row value", () => {
+    write("worker_gate_decisions.jsonl", [
+      {
+        correlationId: "SECRET-RUN-ID",
+        taskTitle: "SECRET-TASK-TITLE",
+        issueUrl: "https://example.test/SECRET-URL",
+      },
+    ]);
+    const out = formatEvidenceCoverage(cov());
+    expect(out).not.toContain("SECRET-RUN-ID");
+    expect(out).not.toContain("SECRET-TASK-TITLE");
+    expect(out).not.toContain("SECRET-URL");
+    // ...while still reporting the measurement.
+    expect(out).toContain("1 of 1");
+  });
+
+  it("leads with the denominator rather than a bare joinable count", () => {
+    write("boundary_receipts.jsonl", [{ correlationId: "r" }, {}, {}]);
+    expect(formatEvidenceCoverage(cov())).toMatch(
+      /1 of 3\s+rows carry a run id/,
+    );
+  });
+});

--- a/src/evidenceCoverage.ts
+++ b/src/evidenceCoverage.ts
@@ -1,0 +1,227 @@
+/**
+ * `patchwork evidence` — how much of the evidence spine can actually be joined?
+ *
+ * CLAUDE.md's Evidence Spine section tells the next session to re-measure this
+ * before scoping a cross-ledger reader, and says why in its own words: two of
+ * its load-bearing claims "went stale or were wrong within two days". Doing that
+ * measurement took a bespoke throwaway script every time. This makes it a verb.
+ *
+ * ## It reports denominators. It is NOT the reader.
+ *
+ * The spine's rule is "do NOT build the readers ahead of the evidence" — a
+ * cross-ledger graph built now would be a view over data that does not exist,
+ * and the shape of the view would then dictate the shape of the evidence,
+ * backwards. So this answers the question that comes FIRST: how many rows carry
+ * a correlation id at all, and how many runs appear in more than one ledger.
+ * Measured 2026-08-26 on the reference machine, the answer was ZERO runs in
+ * both — which is the fact that keeps the reader unbuilt.
+ *
+ * ## Absent is not zero
+ *
+ * A ledger that does not exist is reported ABSENT, never as `0 rows`. They are
+ * different facts: `butler/permission_exercises.jsonl` is absent because no
+ * standing permission has ever been granted, and that absence is CORRECT rather
+ * than a gap to plumb. Rendering it as a zero row would invite someone to go and
+ * "fix" it.
+ *
+ * ## Counts only, never contents
+ *
+ * These ledgers hold real task titles, captured output tails and third-party
+ * record ids, and a correlation id IS a run's `taskId`. So nothing here prints a
+ * row, an id, or any value — only counts and the file name. The house rule is
+ * that a measurement may leave the machine and the rows may not.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { patchworkHome } from "./patchworkHome.js";
+
+/** Ledgers on the spine, with where each lives relative to `$PATCHWORK_HOME`. */
+export const SPINE_LEDGERS: ReadonlyArray<{ key: string; file: string }> = [
+  { key: "gate decisions", file: "worker_gate_decisions.jsonl" },
+  { key: "boundary receipts", file: "boundary_receipts.jsonl" },
+  { key: "privacy shadow", file: "privacy_shadow.jsonl" },
+  { key: "outcomes", file: "outcome-log.jsonl" },
+  { key: "approvals", file: "approval_log.jsonl" },
+  { key: "permission exercises", file: "butler/permission_exercises.jsonl" },
+];
+
+export interface LedgerCoverage {
+  key: string;
+  file: string;
+  /** True when the file does not exist. Distinct from `rows === 0`. */
+  absent: boolean;
+  rows: number;
+  /** Rows carrying a `correlationId` — the joinable population. */
+  joinable: number;
+  /** Distinct correlation ids, i.e. how many runs this ledger can speak about. */
+  distinctRuns: number;
+  /** Lines that would not parse. Reported, never silently skipped. */
+  corrupt: number;
+}
+
+export interface PairCoverage {
+  a: string;
+  b: string;
+  shared: number;
+}
+
+export interface EvidenceCoverage {
+  dir: string;
+  ledgers: LedgerCoverage[];
+  /** Only pairs where BOTH sides have at least one joinable row. */
+  pairs: PairCoverage[];
+  /** Runs reachable in more than one ledger — what a reader could traverse. */
+  runsInMoreThanOneLedger: number;
+}
+
+function scan(dir: string, key: string, file: string) {
+  const full = path.join(dir, file);
+  if (!existsSync(full)) {
+    return {
+      cov: {
+        key,
+        file,
+        absent: true,
+        rows: 0,
+        joinable: 0,
+        distinctRuns: 0,
+        corrupt: 0,
+      } satisfies LedgerCoverage,
+      ids: new Set<string>(),
+    };
+  }
+  let text = "";
+  try {
+    text = readFileSync(full, "utf-8");
+  } catch {
+    // Unreadable is not absent — say so by reporting it as present with a
+    // corrupt count rather than pretending the file is not there.
+    return {
+      cov: {
+        key,
+        file,
+        absent: false,
+        rows: 0,
+        joinable: 0,
+        distinctRuns: 0,
+        corrupt: 1,
+      } satisfies LedgerCoverage,
+      ids: new Set<string>(),
+    };
+  }
+  const ids = new Set<string>();
+  let rows = 0;
+  let joinable = 0;
+  let corrupt = 0;
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(t);
+    } catch {
+      corrupt++;
+      continue;
+    }
+    rows++;
+    const c = (parsed as { correlationId?: unknown }).correlationId;
+    if (typeof c === "string" && c !== "") {
+      joinable++;
+      ids.add(c);
+    }
+  }
+  return {
+    cov: {
+      key,
+      file,
+      absent: false,
+      rows,
+      joinable,
+      distinctRuns: ids.size,
+      corrupt,
+    } satisfies LedgerCoverage,
+    ids,
+  };
+}
+
+export function evidenceCoverage(dir = patchworkHome()): EvidenceCoverage {
+  const ledgers: LedgerCoverage[] = [];
+  const idsByKey = new Map<string, Set<string>>();
+  for (const { key, file } of SPINE_LEDGERS) {
+    const { cov, ids } = scan(dir, key, file);
+    ledgers.push(cov);
+    idsByKey.set(key, ids);
+  }
+
+  const pairs: PairCoverage[] = [];
+  const withIds = [...idsByKey.entries()].filter(([, s]) => s.size > 0);
+  for (let i = 0; i < withIds.length; i++) {
+    for (let j = i + 1; j < withIds.length; j++) {
+      const [a, sa] = withIds[i] as [string, Set<string>];
+      const [b, sb] = withIds[j] as [string, Set<string>];
+      let shared = 0;
+      for (const id of sa) if (sb.has(id)) shared++;
+      pairs.push({ a, b, shared });
+    }
+  }
+
+  const seen = new Map<string, number>();
+  for (const [, s] of idsByKey) {
+    for (const id of s) seen.set(id, (seen.get(id) ?? 0) + 1);
+  }
+  let runsInMoreThanOneLedger = 0;
+  for (const [, n] of seen) if (n > 1) runsInMoreThanOneLedger++;
+
+  return { dir, ledgers, pairs, runsInMoreThanOneLedger };
+}
+
+export function formatEvidenceCoverage(c: EvidenceCoverage): string {
+  const L: string[] = [];
+  L.push("[evidence] how much of the spine can be joined?");
+  L.push(`  ${c.dir}`);
+  L.push("");
+  for (const l of c.ledgers) {
+    if (l.absent) {
+      // Absence can be the CORRECT state — no standing permission has ever been
+      // granted, so its ledger not existing is not a gap to plumb.
+      L.push(`  ABSENT   ${l.file}`);
+      continue;
+    }
+    // Always the denominator first: "14 joinable" reads as coverage,
+    // "14 of 170" is the fact.
+    L.push(
+      `  ${String(l.joinable).padStart(5)} of ${String(l.rows).padEnd(6)} rows carry a run id` +
+        `  (${l.distinctRuns} distinct run${l.distinctRuns === 1 ? "" : "s"})  ${l.file}` +
+        (l.corrupt > 0 ? `  [${l.corrupt} unparseable]` : ""),
+    );
+  }
+  L.push("");
+  if (c.pairs.length === 0) {
+    L.push(
+      "  No two ledgers both carry run ids yet, so nothing can be joined.",
+    );
+  } else {
+    L.push("  Runs shared between ledgers:");
+    for (const p of c.pairs) {
+      L.push(`    ${p.shared}  ${p.a} ↔ ${p.b}`);
+    }
+  }
+  L.push("");
+  L.push(
+    `  A cross-ledger reader could traverse ${c.runsInMoreThanOneLedger} run(s) today.`,
+  );
+  if (c.runsInMoreThanOneLedger === 0) {
+    L.push(
+      "  That is the number that keeps the evidence graph unbuilt — a reader now",
+    );
+    L.push(
+      "  would be a view over data that does not exist, and its shape would then",
+    );
+    L.push(
+      "  dictate the shape of the evidence rather than the other way round.",
+    );
+  }
+  L.push("");
+  return `${L.join("\n")}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,6 +240,7 @@ async function downloadVsixFromOpenVsx(): Promise<string> {
 // same list is also used by the unknown-command suggester at L2570.
 const KNOWN_SUBCOMMANDS = [
   "init",
+  "evidence",
   "patchwork-init",
   "start-all",
   "install-extension",
@@ -4990,6 +4991,56 @@ if (process.argv[2] === "shadow-scan") {
         json: jsonFlag,
       });
       // runShadowScanCli sets process.exitCode = 1 on reclassified > 0; no explicit exit needed.
+    } catch (err) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  })();
+}
+
+// `patchwork evidence` — how much of the evidence spine can be joined?
+//
+// CLAUDE.md tells the next session to re-measure this before scoping a
+// cross-ledger reader, and records that its own figures went stale within two
+// days. That measurement was a bespoke throwaway script every time.
+//
+// Reports DENOMINATORS. It is not the reader, and building the reader is
+// exactly what the spine's own rule defers until there is evidence to read.
+if (process.argv[2] === "evidence") {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "Usage: patchwork evidence [--dir <path>] [--json]\n\n" +
+        "How much of the evidence spine can actually be joined: per ledger, how many\n" +
+        "rows carry a run id (correlationId) out of how many rows, and how many runs\n" +
+        "appear in more than one ledger.\n\n" +
+        "Read-only. Prints COUNTS ONLY — never a row, an id or any value, because a\n" +
+        "correlationId is a run's taskId and these ledgers hold real task titles and\n" +
+        "third-party record ids. A measurement may leave the machine; the rows may not.\n\n" +
+        "  --dir <path>  ledger directory (default: $PATCHWORK_HOME)\n" +
+        "  --json        emit the raw report\n",
+    );
+    process.exit(0);
+  }
+  (async () => {
+    try {
+      const dirIdx = args.indexOf("--dir");
+      const dir = dirIdx !== -1 ? args[dirIdx + 1] : undefined;
+      const { evidenceCoverage, formatEvidenceCoverage } = await import(
+        "./evidenceCoverage.js"
+      );
+      const report = dir ? evidenceCoverage(dir) : evidenceCoverage();
+      process.stdout.write(
+        args.includes("--json")
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : formatEvidenceCoverage(report),
+      );
+      // Always 0: this is a REPORT, not a gate. Zero joinable rows is a true
+      // and expected state early on, and exiting non-zero for it would make a
+      // correct answer look like a failure.
+      process.exit(0);
     } catch (err) {
       process.stderr.write(
         `Error: ${err instanceof Error ? err.message : String(err)}\n`,


### PR DESCRIPTION
CLAUDE.md's Evidence Spine section tells the next session to re-measure join coverage before scoping a cross-ledger reader, and says why in its own words: two of its load-bearing claims *"went stale or were wrong within two days"*. Doing that took a bespoke throwaway script every time — which is how a check that must be re-run stops being re-run.

## The measurement, now a verb

```
      1 of 273    rows carry a run id  (1 distinct run)    worker_gate_decisions.jsonl
     14 of 170    rows carry a run id  (13 distinct runs)  boundary_receipts.jsonl
      0 of 213    rows carry a run id  (0 distinct runs)   privacy_shadow.jsonl
      0 of 99     rows carry a run id  (0 distinct runs)   outcome-log.jsonl
      0 of 146    rows carry a run id  (0 distinct runs)   approval_log.jsonl
  ABSENT   butler/permission_exercises.jsonl

  Runs shared between ledgers:
    0  gate decisions ↔ boundary receipts

  A cross-ledger reader could traverse 0 run(s) today.
```

**That zero is the finding.** Item 7 is *not* "unblocked by the sentinel shipping" — the sentinel settled **how** to stamp, and there is still almost nothing stamped. The two populations barely overlap by construction: gate rows are written for worker recipes under the autonomy flag, receipts for agent steps with a registered destination. The join is **sparse, not merely young**.

## Denominators, not a reader

Building the reader now is exactly what the spine's rule defers: a view over data that does not exist, whose shape would then dictate the shape of the evidence rather than the other way round.

## Three properties that are not the arithmetic

- **ABSENT is not zero.** A ledger that does not exist is a different fact from one with no rows. `butler/permission_exercises.jsonl` is absent because no standing permission has ever been granted — *correct*, not a gap — and rendering it as `0 rows` invites someone to go and fix it.
- **Counts only, never contents.** A `correlationId` **is** a run's `taskId`, and these ledgers hold real task titles, captured output tails and third-party record ids. Unlike `runstore compare` and `privacy receipts`, this output is safe to quote.
- **Always exits 0.** A report, not a gate: zero joinable rows is a true and expected state, and failing on it would make a correct answer look like an error.

Unparseable lines are counted and reported rather than silently skipped — a clean read of a damaged ledger is the failure that hides itself.

## Verification

| mutation (each confirmed applied) | result |
|---|---|
| render absent as present | 1 failed |
| count corrupt lines as rows | 1 failed |
| treat empty-string id as joinable | 1 failed |
| **actually leak the ids into the report** | 1 failed |
| restored | 10 passed |

The leak mutation is worth calling out: my **first attempt at it was a no-op that proved nothing** and passed. I rewrote it until it genuinely leaked, and only then did the guard catch it. A mutation that does not mutate is a green result that means nothing.

`KNOWN_SUBCOMMANDS` gained the verb — and its guard test is what caught the omission, exactly as designed.

10,435 passed · all 19 CI audit gates, `typecheck`, `typecheck:tests:core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)