### PR TITLE
fix(approvals): an approval that expired never reached the durable log

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,12 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-26 `fix/expiry-never-reached-the-durable-log` — ADR-0018's live TTL timer tore its
+  entry down inline and never persisted, so an approval that expired on a running bridge left
+  `approval_log.jsonl` holding a bare `request` — indistinguishable from still-pending, and
+  self-healing only on restart. Fixing it exposed a second question: with two queues over one
+  log dir, both timers fire, so expiry is now written by the OWNER only. — merged as #1537
+
 - 2026-08-26 `feat/privacy-undeclared` — ADR-0021 is fail-soft, so an agent step with no
   `data_policy` is classified `internal` and passes; correct as a default, and it makes an
   undeclared step invisible in a way a declared one is not. Measured: 132 of 214 shadow

--- a/src/__tests__/approvalExpiryDurable.test.ts
+++ b/src/__tests__/approvalExpiryDurable.test.ts
@@ -1,0 +1,114 @@
+/**
+ * ADR-0018 — an approval that EXPIRES must reach the durable log.
+ *
+ * `ApprovalQueue` has two expiry paths, and only one of them persisted.
+ *
+ * The restore-time path (`restore()`) resolves an entry whose `expiresAt`
+ * passed while the process was down, and records the decision. The LIVE path
+ * — the `setTimeout` armed in `request()` — did its own inline teardown:
+ * delete the entry, resolve `"expired"`, notify. It never called
+ * `persistence.recordDecision`, because it never went through `resolveEntry`,
+ * which is where every other resolution (`approve` / `reject` / `cancel`)
+ * writes its row.
+ *
+ * The consequence is not a missing nicety. `approval_log.jsonl` is the durable
+ * event source, and a `request` row with no `decision` row is exactly how the
+ * log spells "still pending". So an approval that timed out on a running
+ * bridge was indistinguishable, forever, from one still waiting for a human —
+ * and the control plane's measures counted it as undecided. It self-healed
+ * only on restart, which on a long-lived bridge is indefinitely.
+ *
+ * Observed live on 2026-08-26: a low-tier approval expired, `patchwork
+ * approve` correctly reported it not pending, and the log still carried the
+ * bare `request`.
+ *
+ * These tests assert on the FILE. Asserting on the resolved promise would
+ * pass against the broken version — the promise always resolved `"expired"`;
+ * it was only the durable write that was missing.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ApprovalQueue } from "../approvalQueue.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "approval-expiry-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function readEvents(): Array<Record<string, unknown>> {
+  const file = path.join(dir, "approval_log.jsonl");
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+function requestOne(queue: ApprovalQueue) {
+  return queue.request({
+    tier: "low",
+    toolName: "example.list_items",
+    params: { limit: 50 },
+    sessionId: "s1",
+  });
+}
+
+describe("approval expiry reaches the durable log", () => {
+  it("writes a decision row when the LIVE timer fires", async () => {
+    const queue = new ApprovalQueue({ ttlMs: 20, persistDir: dir });
+    const { callId, promise } = requestOne(queue);
+
+    await expect(promise).resolves.toBe("expired");
+
+    const events = readEvents();
+    const decision = events.find(
+      (e) => e.kind === "decision" && e.callId === callId,
+    );
+    expect(decision, "expiry wrote no decision row").toBeDefined();
+    expect(decision?.decision).toBe("expired");
+  });
+
+  it("leaves no callId carrying a request with no decision", async () => {
+    const queue = new ApprovalQueue({ ttlMs: 20, persistDir: dir });
+    const { promise } = requestOne(queue);
+    await promise;
+
+    const events = readEvents();
+    const requested = new Set(
+      events.filter((e) => e.kind === "request").map((e) => e.callId),
+    );
+    const decided = new Set(
+      events.filter((e) => e.kind === "decision").map((e) => e.callId),
+    );
+    const unresolved = [...requested].filter((c) => !decided.has(c));
+    expect(unresolved, "a resolved call still reads as pending").toEqual([]);
+  });
+  it("records exactly one decision when a second queue shares the log", async () => {
+    // Two bridges over one ~/.patchwork is a real deployment, not a
+    // contrivance. The owner's live timer and the non-owner's restored timer
+    // both fire; only the owner may write, or readers that join on callId
+    // see the same expiry twice.
+    const owner = new ApprovalQueue({ ttlMs: 60, persistDir: dir });
+    const { callId, promise } = requestOne(owner);
+
+    const observer = new ApprovalQueue({ persistDir: dir });
+    expect(observer.list()).toHaveLength(1);
+    expect(observer.list()[0]?.owned).toBe(false);
+
+    await promise;
+    await new Promise((r) => setTimeout(r, 40));
+
+    const decisions = readEvents().filter(
+      (e) => e.kind === "decision" && e.callId === callId,
+    );
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toBe("expired");
+  });
+});

--- a/src/approvalQueue.ts
+++ b/src/approvalQueue.ts
@@ -318,7 +318,15 @@ export class ApprovalQueue {
         req.expiresAt !== null
           ? setTimeout(
               () => {
-                this.resolveEntry(req.callId, "expired");
+                // `persist: false` — this entry is OWNED by another process,
+                // which arms its own timer and records the expiry itself.
+                // Both writing would put two `expired` rows on one callId,
+                // and readers join on callId (the control plane's approval
+                // measures count decision events). If that owner is in fact
+                // gone, nothing is written here — the next restore sees an
+                // `expiresAt` already passed and records it via the branch
+                // above. Late, but exactly once.
+                this.resolveEntry(req.callId, "expired", { persist: false });
               },
               Math.max(0, req.expiresAt - now),
             )
@@ -447,13 +455,14 @@ export class ApprovalQueue {
     const timer =
       ttl > 0
         ? setTimeout(() => {
-            const entry = this.entries.get(callId);
-            if (!entry) return;
-            this.entries.delete(callId);
-            this.inflight.delete(entry.inflightKey);
-            entry.resolve("expired");
-            for (const r of entry.pendingPromises) r("expired");
-            this.notify();
+            // Goes through resolveEntry rather than tearing the entry down
+            // inline. The inline version did everything resolveEntry does
+            // EXCEPT `persistence.recordDecision`, so an approval that timed
+            // out on a running bridge left `approval_log.jsonl` holding a
+            // bare `request` — which is how that log spells "still pending".
+            // Only the restore-time expiry path was durable. See
+            // `approvalExpiryDurable.test.ts`.
+            this.resolveEntry(callId, "expired");
           }, ttl)
         : null;
     if (timer && typeof timer === "object" && "unref" in timer) timer.unref();
@@ -654,7 +663,11 @@ export class ApprovalQueue {
     this.recentlyDecided.clear();
   }
 
-  private resolveEntry(callId: string, decision: ApprovalDecision): boolean {
+  private resolveEntry(
+    callId: string,
+    decision: ApprovalDecision,
+    opts: { persist?: boolean } = {},
+  ): boolean {
     const entry = this.entries.get(callId);
     if (!entry) return false;
     if (entry.timer) clearTimeout(entry.timer);
@@ -667,7 +680,9 @@ export class ApprovalQueue {
     const decidedAt = Date.now();
     this.recentlyDecided.set(callId, { decision, at: decidedAt });
     this.pruneRecentlyDecided();
-    this.persistence?.recordDecision(callId, decision, decidedAt);
+    if (opts.persist !== false) {
+      this.persistence?.recordDecision(callId, decision, decidedAt);
+    }
     entry.resolve(decision);
     // Wake up any duplicate callers who joined this entry via dedup.
     for (const r of entry.pendingPromises) r(decision);


### PR DESCRIPTION
`ApprovalQueue` has two expiry paths and only one of them persisted.

The restore-time path records the decision. The **live** path — the timer armed in `request()` — tore the entry down inline (delete, resolve `"expired"`, notify) and never called `persistence.recordDecision`, because it never went through `resolveEntry`, which is where `approve` / `reject` / `cancel` write theirs.

`approval_log.jsonl` is the durable event source (ADR-0018), and a `request` row with no `decision` row is precisely how that log spells *still pending*. An approval that timed out on a running bridge was therefore indistinguishable, permanently, from one still waiting for a human — and a reader counting decisions saw it as undecided. It self-healed only on restart, which on a long-lived bridge is indefinitely.

Observed live: a low-tier approval expired, the CLI correctly reported it not pending, and the log still carried the bare `request`.

## The second question this exposed

Routing the live timer through `resolveEntry` surfaced something the inline version had been masking. With two queues over one log directory — two bridges sharing a home is a real deployment — the owner's timer and the restored non-owner's timer both fire. Previously the owner wrote nothing and the non-owner wrote: backwards, but it netted one row. Persisting from both would put two `expired` rows on one `callId`, and readers join on `callId`.

Expiry is now recorded by the **owner** only; the restored entry's timer resolves with `persist: false`. If that owner is genuinely gone, nothing is written at expiry and the next restore records it via the already-passed branch — late, but exactly once. `approve` / `reject` / `cancel` on a restored entry still persist, since a decision made there would otherwise be lost.

## Verification

Three tests, each verified failing against the version before it:

- the live timer writes a decision row
- no `callId` is left carrying a request with no decision
- a second queue sharing the log yields exactly one decision

The third was mutation-checked — restoring the unguarded call makes it fail, and the mutation was grepped to confirm it applied.

Full suite green (10,450 passing), `typecheck` and `typecheck:tests:core` clean, all 24 audit gates run. Two gates fail identically on `main` and are unrelated: `audit-pack-tracked` (local untracked files — a clean clone cannot fail it) and `audit-companion-pins` (upstream dep drift).