### PR TITLE
fix(identity): set-password muted stdout permanently, so nobody saw "Confirm:"

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -59,6 +59,11 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   `approval_log.jsonl` holding a bare `request` — indistinguishable from still-pending, and
   self-healing only on restart. Fixing it exposed a second question: with two queues over one
   log dir, both timers fire, so expiry is now written by the OWNER only. — merged as #1537
+- 2026-08-26 `fix/set-password-muted-stdout-permanently` — readline's `output` IS
+  `process.stdout`, so muting the echo overwrote `process.stdout.write` and unmuting read
+  that no-op back, rebinding the mute forever. The `Confirm:` prompt was invisible and the
+  operator confirmed blind; the only visible line came from stderr. This is why the roster
+  still had a member with no credential. — merged as #1538
 
 - 2026-08-26 `feat/privacy-undeclared` — ADR-0021 is fail-soft, so an agent step with no
   `data_policy` is classified `internal` and passes; correct as a default, and it makes an

--- a/src/identity/__tests__/ttyEcho.test.ts
+++ b/src/identity/__tests__/ttyEcho.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The echo muter must not swallow the stream it was meant to restore.
+ *
+ * `members set-password` muted stdout to hide a typed password and restored it
+ * by reading `process.stdout.write` back — which, because readline's `output`
+ * IS `process.stdout`, read back the no-op it had just installed. stdout
+ * stayed muted for the rest of the process, so the "Confirm:" prompt was
+ * invisible and the operator confirmed blind.
+ *
+ * The alias case is the one that matters: a test using a standalone object
+ * passes against the broken version.
+ */
+
+import { describe, expect, it } from "vitest";
+import { type EchoTarget, muteEcho } from "../ttyEcho.js";
+
+function recorder(): EchoTarget & { seen: string[] } {
+  const seen: string[] = [];
+  return {
+    seen,
+    write(chunk: string) {
+      seen.push(chunk);
+      return true;
+    },
+  };
+}
+
+describe("muteEcho", () => {
+  it("suppresses writes while muted and restores them after", () => {
+    const out = recorder();
+    out.write("before");
+    const restore = muteEcho(out);
+    out.write("secret");
+    restore();
+    out.write("after");
+    expect(out.seen).toEqual(["before", "after"]);
+  });
+
+  it("restores through an ALIAS of the same stream", () => {
+    // readline holds `output === process.stdout`. Muting through one name and
+    // restoring through the other is exactly the shape that broke.
+    const out = recorder();
+    const alias = out;
+    const restore = muteEcho(alias);
+    out.write("secret");
+    restore();
+    out.write("visible");
+    expect(out.seen).toEqual(["visible"]);
+  });
+
+  it("survives a second mute/restore cycle", () => {
+    // Two prompts in a row — password, then confirm. The second cycle is the
+    // one that was already broken by the first.
+    const out = recorder();
+    const r1 = muteEcho(out);
+    out.write("password");
+    r1();
+    out.write("Confirm: ");
+    const r2 = muteEcho(out);
+    out.write("again");
+    r2();
+    out.write("done");
+    expect(out.seen).toEqual(["Confirm: ", "done"]);
+  });
+
+  it("is idempotent on repeated restore", () => {
+    const out = recorder();
+    const restore = muteEcho(out);
+    restore();
+    restore();
+    out.write("still visible");
+    expect(out.seen).toEqual(["still visible"]);
+  });
+});

--- a/src/identity/ttyEcho.ts
+++ b/src/identity/ttyEcho.ts
@@ -1,0 +1,44 @@
+/**
+ * Suppress terminal echo while a secret is typed.
+ *
+ * Node's readline cannot turn echo off portably, so the standard trick is to
+ * replace the output stream's `write` with a no-op for the duration of the
+ * prompt. The trick has a trap, and `members set-password` fell in it:
+ *
+ * `readline.createInterface({ input: process.stdin, output: process.stdout })`
+ * stores `process.stdout` AS `rl.output`. They are the same object. So muting
+ * via `rl.output.write = () => {}` overwrites `process.stdout.write` itself,
+ * and unmuting by reading `process.stdout.write` back reads the no-op that was
+ * just installed — rebinding the mute permanently. Everything written to
+ * stdout after the first prompt vanished, including the "Confirm:" prompt, so
+ * the operator typed their confirmation into a prompt they could not see and
+ * got "passwords did not match". The error was visible only because it goes to
+ * stderr, which was never muted.
+ *
+ * Capturing the original once, up front, is the whole fix. Returning a
+ * restore function rather than a `mute(boolean)` toggle makes the trap hard to
+ * reintroduce: there is no path that reads the current value back.
+ */
+
+/** The minimal shape this needs — anything with a `write`. */
+export interface EchoTarget {
+  write: (chunk: string) => boolean | void;
+}
+
+/**
+ * Silence `target.write` and return the function that restores it.
+ *
+ * The original is captured BEFORE the no-op is installed, so restoring is
+ * always correct no matter how many times this is called or how the target
+ * aliases another stream. Restoring twice is harmless.
+ */
+export function muteEcho(target: EchoTarget): () => void {
+  const original = target.write;
+  target.write = () => true;
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    target.write = original;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 
 // Silence the one-per-process `node:sqlite` ExperimentalWarning (ADR-0022).
 // FIRST, before anything can import node:sqlite — the warning fires at import
+import type { EchoTarget } from "./identity/ttyEcho.js";
+
 // time, so installing this later would suppress nothing. Entry point only:
 // it mutates global process state, which no leaf module should do on import.
 // Unrelated warnings still surface; that is the property its tests guard.
@@ -5370,29 +5372,30 @@ if (process.argv[2] === "members") {
           process.exit(2);
         }
         const { createInterface } = await import("node:readline");
+        const { muteEcho } = await import("./identity/ttyEcho.js");
         const rl = createInterface({
           input: process.stdin,
           output: process.stdout,
         });
         const ask = (q: string): Promise<string> =>
           new Promise((resolve) => rl.question(q, resolve));
-        // Node's readline cannot suppress echo portably; muting the output
-        // stream is the standard trick and is why this is written by hand.
-        const mute = (on: boolean) => {
-          (
-            rl as unknown as { output: { write: (c: string) => void } }
-          ).output.write = on
-            ? () => {}
-            : process.stdout.write.bind(process.stdout);
-        };
+        // Node's readline cannot suppress echo portably, so the output
+        // stream's `write` is replaced for the duration of each prompt.
+        // `muteEcho` captures the original BEFORE installing the no-op. This
+        // used to restore by reading `process.stdout.write` back, which read
+        // the no-op just installed, because readline's `output` IS
+        // `process.stdout`. stdout then stayed muted for the rest of the
+        // process: the "Confirm:" prompt was invisible and the operator
+        // confirmed a password they never saw prompted. See `ttyEcho.ts`.
+        const echoTarget = (rl as unknown as { output: EchoTarget }).output;
         process.stdout.write(`Password for ${memberId}: `);
-        mute(true);
+        let unmute = muteEcho(echoTarget);
         const pw = (await ask("")).trim();
-        mute(false);
+        unmute();
         process.stdout.write("\nConfirm: ");
-        mute(true);
+        unmute = muteEcho(echoTarget);
         const again = (await ask("")).trim();
-        mute(false);
+        unmute();
         process.stdout.write("\n");
         rl.close();
 


### PR DESCRIPTION
`members set-password` hid the typed password by replacing the output stream's `write` with a no-op, and restored it with `process.stdout.write.bind(process.stdout)`.

`readline.createInterface({ output: process.stdout })` stores that stream **as** `rl.output` — they are the same object. So muting through `rl.output.write` overwrote `process.stdout.write` itself, and unmuting read `process.stdout.write` back, which by then *was* the no-op just installed. It rebound the mute.

stdout stayed muted for the rest of the process. The `Confirm:` prompt was invisible, so the operator typed their confirmation into a prompt that never appeared, and `[members] password set for <id>.` was swallowed too. The only visible output was `[members] passwords did not match.` — visible purely because it goes to **stderr**, which was never muted.

This is why the reference workspace still has a member with no credential and ADR-0020 attribution has never fired: the command looked broken every time it was run.

## The fix

`muteEcho` captures the original **before** installing the no-op and returns a restore function. The `mute(boolean)` toggle shape is gone deliberately — it is what made the trap reachable, since it had to read the current value back to unmute.

## Verification

End-to-end against a real pty with a throwaway `PATCHWORK_HOME`, on both sides of the fix:

**Before** — no `Confirm:`, no success line, everything after the first mute swallowed:
```
Password for testuser:
```

**After** — both prompts render, secret never echoed, credential lands at 0600:
```
Password for testuser:
Confirm:
[members] password set for testuser.
```

Four unit tests, **all four verified failing** when `muteEcho` is mutated back to reading the value back at restore time (mutation grepped to confirm it applied). The alias case is the one that counts — a test using a standalone object passes against the broken version.

Full suite green (10,451 passing), `typecheck` and `typecheck:tests:core` clean, all 24 audit gates run. The two that fail (`audit-pack-tracked`, `audit-companion-pins`) fail identically on `main` and are unrelated.