### PR TITLE
fix(recipe): a failed `recipe run` told the shell it had succeeded

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -60,6 +60,11 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   the tool-bearing `cliOpts` reaches only `claudeCliFn`. It was the only driver that could
   receive `personal` data, so a worker recipe could be honestly labelled or could run, never
   both. Pinned by an arity guard test. — merged as #1541
+- 2026-08-26 `fix/recipe-run-exits-0-on-a-failed-run` — the local-run branch ended in an
+  unconditional `process.exit(0)`, in the same block that computes `summary.ok` and records
+  `status: "error"`, so `patchwork recipe run X && echo ok` printed `ok` after a failure and
+  silently greened every cron caller. Same family as the `doctor --expect-running` gap.
+  — merged as #1540
 
 - 2026-08-26 `fix/expiry-never-reached-the-durable-log` — ADR-0018's live TTL timer tore its
   entry down inline and never persisted, so an approval that expired on a running bridge left

--- a/src/__tests__/recipe-cli.integration.test.ts
+++ b/src/__tests__/recipe-cli.integration.test.ts
@@ -152,6 +152,38 @@ describe.skipIf(process.platform === "win32")("recipe CLI integration", () => {
     expect(fs.readFileSync(outputPath, "utf-8")).toBe("run cli");
   });
 
+  it("recipe run exits NON-ZERO when the run itself fails", () => {
+    // The local-run branch computed `summary.ok`, printed "✗", wrote the
+    // error to stderr, recorded `status: "error"` in the run log — and then
+    // called `process.exit(0)` unconditionally. So the CLI knew the run had
+    // failed and told the shell it had succeeded, which makes
+    // `patchwork recipe run X && echo ok` print `ok` after a failure and
+    // silently greens every cron and CI caller.
+    //
+    // Asserting on stdout is what the sibling test above does, and it passes
+    // against the broken version — the ✗ was always printed. The exit code is
+    // the part nothing checked.
+    const homeDir = makeTmpDir();
+    const recipeDir = makeTmpDir();
+    const recipePath = path.join(recipeDir, "run-fails.yaml");
+
+    // `file.write` to a path outside the recipe jail is rejected at dispatch,
+    // so the step fails without needing a network, a model or a connector.
+    fs.writeFileSync(
+      recipePath,
+      `name: run-fails\ndescription: Run that fails\ntrigger:\n  type: manual\nsteps:\n  - tool: file.write\n    path: "/proc/nonexistent/denied.txt"\n    content: "nope"\n`,
+    );
+
+    const result = spawnSync(tsxBin, [srcIndex, "recipe", "run", recipePath], {
+      cwd: workspaceRoot,
+      encoding: "utf-8",
+      env: { ...process.env, HOME: homeDir },
+    });
+
+    expect(result.stdout).toMatch(/✗ run-fails/);
+    expect(result.status).not.toBe(0);
+  });
+
   it("recipe run aborts and exits non-zero when the bridge is wedged on HTTP", async () => {
     // A bridge whose PID is alive (findBridgeLock accepts it) but whose
     // HTTP server never responds. Before the AbortController fix the CLI

--- a/src/index.ts
+++ b/src/index.ts
@@ -1715,7 +1715,15 @@ if (process.argv[2] === "recipe" && process.argv[3] === "run") {
         // Non-fatal — run log write failure must not abort the CLI
       }
 
-      process.exit(0);
+      // Exit on the RUN's outcome, not merely on having reached the end.
+      // This was `process.exit(0)` unconditionally, in the same block that
+      // computes `summary.ok` and records `status: "error"` in the run log —
+      // so the CLI knew the run had failed and told the shell it had passed.
+      // `patchwork recipe run X && echo ok` printed `ok` after a failure,
+      // greening every cron and CI caller silently. Same family as the
+      // `doctor --expect-running` gap: a check whose denominator was "did I
+      // get here", not "did it work".
+      process.exit(summary.ok ? 0 : 1);
     } catch (err) {
       process.stderr.write(
         `Error: ${err instanceof Error ? err.message : String(err)}\n`,


### PR DESCRIPTION
The local-run branch ended in `process.exit(0)` **unconditionally** — in the same block that computes `summary.ok`, prints `✗`, writes the error to stderr, and records `status: "error"` in the run log.

So the CLI knew the run had failed and reported success to its caller. `patchwork recipe run X && echo ok` printed `ok` after a failure, silently greening every cron, CI step and wrapper script that chains on it. A recipe can fail every night and the shell running it never notices.

Same family as the `doctor --expect-running` gap already recorded in CLAUDE.md: a check whose denominator was *did I reach the end*, not *did the thing work*.

Found while verifying an unrelated change — the probe run printed `✗` and two errors and still came back `0`.

## Verification

Both directions, against the built CLI:

```
failed run now exits: 1
passing run still exits: 0
```

The second half matters: a fix that simply always exited 1 would pass a one-sided test.

The new integration test asserts the **exit code**. Its sibling asserts on stdout, and that assertion passes against the broken version — the `✗` was always printed. The exit code was the part nothing checked, which is why this survived.

## This is a deliberate behaviour change

A caller that today ignores a failed run will begin to see it. That is the point, and it matches every other verb here — `doctor`, `recipe doctor` and `workers validate` all exit 1 when unhealthy.

Full suite green (10,451 passing), `typecheck` and `typecheck:tests:core` clean, all 24 audit gates run. The two that fail (`audit-pack-tracked`, `audit-companion-pins`) fail identically on `main` and are unrelated.