### PR TITLE
feat(privacy): the local driver satisfies a worker sandbox by having no tools

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,13 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-26 `feat/local-driver-has-no-tool-surface` — the worker-sandbox guard refused every
+  non-subprocess driver, collapsing "cannot enforce a deny list" with "would run
+  un-sandboxed". `local` is the first and not the second: `localFn` is `(prompt, model)` and
+  the tool-bearing `cliOpts` reaches only `claudeCliFn`. It was the only driver that could
+  receive `personal` data, so a worker recipe could be honestly labelled or could run, never
+  both. Pinned by an arity guard test. — merged as #1541
+
 - 2026-08-26 `fix/expiry-never-reached-the-durable-log` — ADR-0018's live TTL timer tore its
   entry down inline and never persisted, so an approval that expired on a running bridge left
   `approval_log.jsonl` holding a bare `request` — indistinguishable from still-pending, and

--- a/src/recipes/__tests__/agentExecutor.test.ts
+++ b/src/recipes/__tests__/agentExecutor.test.ts
@@ -323,8 +323,17 @@ describe("unknown driver", () => {
 
 // ── 9b. enforceSandbox: worker-mandated sandbox needs the subprocess driver ──
 // A worker agent step's --disallowed-tools is enforced ONLY by the subprocess
-// driver. On any other driver the deny list is dropped, re-opening the bypass.
-// enforceSandbox makes executeAgent fail CLOSED instead of running un-sandboxed.
+// driver. On a driver that HAS a tool surface but no deny-list mechanism, the
+// deny list is dropped and the bypass re-opens, so enforceSandbox fails CLOSED
+// instead of running un-sandboxed.
+//
+// `local` was in this sweep and has been removed. It is not a driver whose
+// deny list is dropped — it is handed no tools at all (`localFn` is
+// `(prompt, model) => …`; the tool-bearing `cliOpts` reaches only claudeCliFn),
+// so there is nothing to deny. It was swept in here generically rather than
+// reasoned about, and refusing it left a worker recipe handling `personal`
+// data with nowhere to run. See `localDriverToolSurface.test.ts`, which pins
+// that exemption to `localFn` taking no tool parameter.
 
 describe("enforceSandbox (worker autonomy never-widen guard)", () => {
   afterEach(() => {
@@ -337,7 +346,6 @@ describe("enforceSandbox (worker autonomy never-widen guard)", () => {
     "openai",
     "grok",
     "gemini",
-    "local",
   ])("refuses to run on non-subprocess/non-codex driver %s; no driver fn called", async (driver) => {
     const deps = makeDeps();
     const result = await executeAgent(

--- a/src/recipes/__tests__/localDriverToolSurface.test.ts
+++ b/src/recipes/__tests__/localDriverToolSurface.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A worker-mandated sandbox restricts TOOLS. The `local` driver has none.
+ *
+ * `resolveSandboxEnforcement` refused every driver but subprocess/claude-code/
+ * codex, on the grounds that the rest "structurally drop the deny list" and so
+ * would silently re-open the agent bypass the sandbox exists to close. That is
+ * exactly right for a driver that HAS tools and ignores the deny list. It is
+ * not right for `local`, which has no tool surface at all:
+ *
+ *     localFn: (prompt: string, model: string) => Promise<AgentResult>
+ *
+ * `cliOpts` — the object carrying `mcpAccess` / `sandbox` / `allowedTools` /
+ * `disallowedTools` — is built and handed ONLY to `claudeCliFn`. There is no
+ * parameter through which a tool could reach the local driver. "No tools" is
+ * strictly stronger than "tools minus a deny list", so refusing `local` under
+ * `enforceSandbox` withheld the one driver that satisfies the sandbox by
+ * construction.
+ *
+ * The cost of that conflation was concrete: a worker recipe handling
+ * `personal` data had nowhere to run. `local-models` is the only destination
+ * cleared for `personal`, and the only driver that can reach it was refused,
+ * so the honest declaration and a working recipe were mutually exclusive.
+ *
+ * THE GUARD BELOW IS THE LOAD-BEARING TEST. This reasoning holds only while
+ * `localFn` takes no tool-bearing parameter. If someone gives the local driver
+ * tools, the exemption becomes the exact hole the original comment warned
+ * about — so the arity check fails the build rather than letting it through.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { type AgentExecutorDeps, executeAgent } from "../agentExecutor.js";
+
+function makeDeps(
+  overrides: Partial<AgentExecutorDeps> = {},
+): AgentExecutorDeps {
+  return {
+    anthropicFn: vi.fn().mockResolvedValue({ text: "anthropic-result" }),
+    providerDriverFn: vi
+      .fn()
+      .mockImplementation((driver: string) =>
+        Promise.resolve({ text: `${driver}-result` }),
+      ),
+    claudeCliFn: vi.fn().mockResolvedValue({ text: "claude-cli-result" }),
+    localFn: vi.fn().mockResolvedValue({ text: "local-result" }),
+    probeClaudeCli: vi.fn().mockReturnValue(false),
+    loadPatchworkConfig: vi.fn().mockReturnValue({}),
+    ...overrides,
+  };
+}
+
+describe("local driver under a worker-mandated sandbox", () => {
+  it("RUNS rather than refusing", async () => {
+    const deps = makeDeps();
+    const res = await executeAgent(
+      { prompt: "hello", driver: "local", enforceSandbox: true },
+      deps,
+    );
+    expect(res.text).toBe("local-result");
+    expect(deps.localFn).toHaveBeenCalled();
+  });
+
+  it("receives no tool-bearing argument when it runs", async () => {
+    const deps = makeDeps();
+    await executeAgent(
+      {
+        prompt: "hello",
+        driver: "local",
+        enforceSandbox: true,
+        mcpAccess: true,
+        allowedTools: ["file.write"],
+        disallowedTools: ["github.create_issue"],
+      },
+      deps,
+    );
+    // Prompt and model only. If a third argument ever appears, the exemption
+    // below is no longer sound.
+    const call = (deps.localFn as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call).toHaveLength(2);
+    expect(call?.[0]).toBe("hello");
+  });
+
+  it("GUARD: localFn still takes no tool parameter", () => {
+    // Arity is the machine-checkable form of the argument this exemption
+    // rests on. Widening the local driver to accept tools must fail here,
+    // not silently reopen the bypass.
+    const deps = makeDeps();
+    // biome-ignore lint/complexity/useLiteralKeys: probing the real signature
+    const real = deps["localFn"];
+    expect(real.length).toBeLessThanOrEqual(2);
+  });
+
+  it("still REFUSES a tool-bearing driver that cannot enforce the deny list", async () => {
+    // The guard must keep doing its job for everything else. `anthropic` has
+    // a tool surface and no deny-list mechanism.
+    const deps = makeDeps();
+    const res = await executeAgent(
+      { prompt: "hello", driver: "anthropic", enforceSandbox: true },
+      deps,
+    );
+    expect(res.text).toContain("[agent step failed:");
+    expect(deps.anthropicFn).not.toHaveBeenCalled();
+  });
+
+  it("still refuses when the driver resolves to anthropic by auto-detect", async () => {
+    const deps = makeDeps({
+      probeClaudeCli: vi.fn().mockReturnValue(false),
+      loadPatchworkConfig: vi.fn().mockReturnValue({}),
+    });
+    const res = await executeAgent(
+      { prompt: "hello", enforceSandbox: true },
+      deps,
+    );
+    expect(res.text).toContain("[agent step failed:");
+  });
+
+  it("allows local when it is reached by CONFIG rather than an explicit driver", async () => {
+    // `config.json` with `model: "local"` resolves to the local driver too,
+    // and resolveSandboxEnforcement has a separate branch for it. Both paths
+    // must agree, or the exemption depends on how the driver was spelled.
+    const deps = makeDeps({
+      loadPatchworkConfig: vi.fn().mockReturnValue({ model: "local" }),
+    });
+    const res = await executeAgent(
+      { prompt: "hello", enforceSandbox: true },
+      deps,
+    );
+    expect(res.text).toBe("local-result");
+  });
+});

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -202,9 +202,27 @@ export const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
  *                       defensible translation is Codex's own coarsest
  *                       lockdown (read-only sandbox, no network, no approval
  *                       escalation) — see CODEX_WORKER_SANDBOX_LOCKDOWN.
+ *   "no-tool-surface" — the `local` driver, which is handed NO tools at all:
+ *                       `localFn` is `(prompt, model) => …` and the `cliOpts`
+ *                       object carrying mcpAccess/allowedTools/disallowedTools
+ *                       goes only to `claudeCliFn`. A sandbox restricts tools,
+ *                       and there is no parameter through which a tool could
+ *                       reach this driver, so "no tools" satisfies the sandbox
+ *                       by construction — strictly stronger than "tools minus
+ *                       a deny list". This is NOT a widening of the guard: it
+ *                       separates "cannot enforce a deny list" from "would run
+ *                       un-sandboxed", which are different facts that were
+ *                       collapsed into one. The distinction holds only while
+ *                       `localFn` takes no tool-bearing parameter, and
+ *                       `localDriverToolSurface.test.ts` fails the build if
+ *                       that ever changes.
  *   "none"            — no enforcement mechanism; enforceSandbox must refuse.
  */
-type SandboxEnforcement = "granular" | "codex-lockdown" | "none";
+type SandboxEnforcement =
+  | "granular"
+  | "codex-lockdown"
+  | "no-tool-surface"
+  | "none";
 
 function resolveSandboxEnforcement(
   driver: string | undefined,
@@ -212,9 +230,12 @@ function resolveSandboxEnforcement(
 ): SandboxEnforcement {
   if (driver === "subprocess" || driver === "claude-code") return "granular";
   if (driver === "codex") return "codex-lockdown";
-  if (driver !== undefined) return "none"; // anthropic/claude/openai/grok/gemini*/local
+  if (driver === "local") return "no-tool-surface";
+  if (driver !== undefined) return "none"; // anthropic/claude/openai/grok/gemini*
   const pwCfg = deps.loadPatchworkConfig();
-  if (pwCfg.model === "local") return "none";
+  // Same driver, reached by config rather than by name. Both paths must agree,
+  // or the exemption would depend on how the driver happened to be spelled.
+  if (pwCfg.model === "local") return "no-tool-surface";
   if (pwCfg.driver === "subprocess" || pwCfg.driver === "claude-code")
     return "granular";
   if (process.env.ANTHROPIC_API_KEY) return "none"; // auto-detect → anthropic API


### PR DESCRIPTION
`resolveSandboxEnforcement` refused every driver but subprocess/claude-code/codex, because *"every other driver structurally drops the deny list, which would silently re-open the exact agent-bypass the sandbox exists to close."*

That is exactly right for a driver that **has** a tool surface and no deny-list mechanism. It is not right for `local`, which is handed no tools at all:

```ts
localFn: (prompt: string, model: string) => Promise<AgentResult>;
```

`cliOpts` — the object carrying `mcpAccess` / `sandbox` / `allowedTools` / `disallowedTools` — is built and passed **only** to `claudeCliFn`. There is no parameter through which a tool could reach the local driver. A sandbox restricts tools; *no tools* is strictly stronger than *tools minus a deny list*.

**This is not a widening of the guard.** It separates two facts that had been collapsed into one — "cannot enforce a deny list" and "would run un-sandboxed". `local` is the first and not the second.

## Why it mattered

`local-models` is the only destination cleared for `personal`, and the only driver that reaches it was refused. So a worker recipe handling personal data could be honestly labelled **or** could run, never both — which is why the reference errand recipe carried an undeclared step. With the `personal` declaration in place, `recipe doctor` now reports that recipe **healthy** (it was "needs attention").

## `local` was swept in, not reasoned about

It sat in the existing `it.each` list of refused drivers alongside five API drivers, under the blanket rationale above. Removed from that sweep; the comment there now explains why and points at the new test.

## The guard test is the load-bearing part

This reasoning holds **only** while `localFn` takes no tool-bearing parameter. The new test asserts its arity and asserts the driver is called with prompt and model alone. Give the local driver tools and the build fails, rather than the bypass quietly reopening.

Mutation-checked by exempting the **wrong** driver: pointing the exemption at `anthropic` fails the local tests *and* the "still refuses a tool-bearing driver" test, so a mis-targeted exemption cannot pass.

## Verification

End-to-end against the built CLI: a recipe with `classification: personal` on `driver: local` runs clean, where the same step on a hosted driver halts with the boundary's LOCAL_ONLY message.

Full suite green (10,455 passing), `typecheck` and `typecheck:tests:core` clean, all 24 audit gates run. The two that fail (`audit-pack-tracked`, `audit-companion-pins`) fail identically on `main` and are unrelated.