### PR TITLE
feat(ci): a worker cannot quietly gain authority

### DIFF
--- a/.github/workflows/authority-delta.yml
+++ b/.github/workflows/authority-delta.yml
@@ -23,6 +23,17 @@ name: Authority Delta
 
 on:
   pull_request:
+    # `labeled` / `unlabeled` are load-bearing, not thoroughness.
+    #
+    # The human workflow is: see the failure, apply the label. Without
+    # `labeled` the check never re-runs, and re-running it by hand replays the
+    # ORIGINAL event payload — which predates the label. The gate would be
+    # unblockable, i.e. a wall, which is the one thing it must not be.
+    #
+    # `unlabeled` matters for the opposite reason: removing the approval must
+    # re-fail the check. Otherwise a widening could be approved, go green, and
+    # have its approval quietly withdrawn while the green check remains.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'templates/workers/**'
 
@@ -72,7 +83,7 @@ jobs:
             const report = process.env.REPORT || '(no report produced)';
             const widened = process.env.EXIT === '1';
             const body = widened
-              ? `## Worker authority changed\n\n\`\`\`\n${report}\n\`\`\`\n\nA widening is not a defect — it often is the point of the change. It does need a person to say so.\n\nTo accept it, apply the **\`authority-widened-approved\`** label. The label and this comment are the record that somebody did.`
+              ? `## Worker authority changed\n\n\`\`\`\n${report}\n\`\`\`\n\nA widening is not a defect — it often is the point of the change. It does need a person to say so.\n\nTo accept it, apply the **\`authority-widened-approved\`** label — the check re-runs automatically. The label and this comment are the record that somebody did.`
               : `## Worker authority unchanged\n\n\`\`\`\n${report}\n\`\`\``;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -89,8 +100,19 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            if (labels.includes('authority-widened-approved')) {
+            // Ask the API for the CURRENT labels rather than reading
+            // `context.payload.pull_request.labels`, which is frozen at the
+            // moment the event fired. Re-running a workflow replays that same
+            // payload, so a label applied in response to the failure would be
+            // invisible and the check could never be unblocked by hand.
+            // Observed on this workflow's own PR before it merged.
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const names = labels.map(l => l.name);
+            if (names.includes('authority-widened-approved')) {
               core.info('Widening accepted: `authority-widened-approved` is applied.');
               return;
             }

--- a/.github/workflows/authority-delta.yml
+++ b/.github/workflows/authority-delta.yml
@@ -1,0 +1,107 @@
+# Create the 'authority-widened-approved' label in repo settings before this
+# workflow can be unblocked by a human.
+#
+# WHAT THIS IS
+#
+# The repository half of the worker autonomy gate. `patchwork workers
+# authority-delta` compares worker manifests between the base branch and this
+# PR using the SAME primitives that govern a worker at runtime, and exits 1
+# when the change lets a worker do more than before.
+#
+# A widening is NOT a defect. It is frequently the whole point of the PR. What
+# it must not be is silent, so this fails the check and a person unblocks it by
+# applying a label — which is itself a durable, visible record on the PR that
+# somebody said yes.
+#
+# WHY A LABEL AND NOT A BYPASS
+#
+# "An administrator may override a control, but they cannot make the override
+# invisible." An admin can always merge past a failing check; what they cannot
+# do is remove the comment and the label that say what widened and who
+# accepted it. The cost of overriding is evidence, not friction.
+name: Authority Delta
+
+on:
+  pull_request:
+    paths:
+      - 'templates/workers/**'
+
+jobs:
+  authority-delta:
+    name: Worker authority delta
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The classifier reads the BASE ref out of git. A shallow clone has
+          # no base to compare against, and `listAt` exits 2 rather than
+          # reporting an empty set — empty would render every worker as newly
+          # added, which is itself classified as a widening.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Classify the authority delta
+        id: delta
+        run: |
+          set +e
+          node dist/index.js workers authority-delta \
+            --base "origin/${{ github.base_ref }}" --head HEAD > delta.txt 2>&1
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          cat delta.txt
+          {
+            echo 'report<<DELTA_EOF'
+            cat delta.txt
+            echo DELTA_EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post the delta on the PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const report = process.env.REPORT || '(no report produced)';
+            const widened = process.env.EXIT === '1';
+            const body = widened
+              ? `## Worker authority changed\n\n\`\`\`\n${report}\n\`\`\`\n\nA widening is not a defect — it often is the point of the change. It does need a person to say so.\n\nTo accept it, apply the **\`authority-widened-approved\`** label. The label and this comment are the record that somebody did.`
+              : `## Worker authority unchanged\n\n\`\`\`\n${report}\n\`\`\``;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+        env:
+          REPORT: ${{ steps.delta.outputs.report }}
+          EXIT: ${{ steps.delta.outputs.exit }}
+
+      - name: Fail unless a human accepted the widening
+        if: steps.delta.outputs.exit == '1'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (labels.includes('authority-widened-approved')) {
+              core.info('Widening accepted: `authority-widened-approved` is applied.');
+              return;
+            }
+            core.setFailed(
+              'This PR widens worker authority and nobody has accepted it. ' +
+              'Read the comment above, then apply the `authority-widened-approved` label.'
+            );
+
+      - name: Fail on a classifier error
+        if: steps.delta.outputs.exit != '0' && steps.delta.outputs.exit != '1'
+        run: |
+          echo "authority-delta exited ${{ steps.delta.outputs.exit }} — it could not classify the change."
+          echo "That is not the same as 'no widening', so this fails rather than passing."
+          exit 1

--- a/src/workers/__tests__/authorityDelta.test.ts
+++ b/src/workers/__tests__/authorityDelta.test.ts
@@ -200,8 +200,18 @@ describe("comparing whole sets", () => {
 describe("the report", () => {
   it("says nothing changed rather than printing a zero", () => {
     const out = formatAuthorityDeltas([]);
-    expect(out).toMatch(/No worker manifest changed/);
+    expect(out).toMatch(/No authority changed/);
     expect(out).not.toMatch(/\b0 finding/);
+  });
+
+  it("does NOT claim the files were unchanged", () => {
+    // A comment-only edit to a manifest is a real file change and no
+    // authority change. Saying "no manifest changed" would be false, and a
+    // reader looking at a nine-line diff would rightly stop trusting the
+    // report. This is the distinction the whole classifier exists to draw.
+    const out = formatAuthorityDeltas([]);
+    expect(out).not.toMatch(/No worker manifest changed/);
+    expect(out).toMatch(/Manifest files may still have changed/);
   });
 
   it("leads with widenings and says a widening is not a defect", () => {

--- a/src/workers/authorityDelta.ts
+++ b/src/workers/authorityDelta.ts
@@ -275,8 +275,18 @@ export function formatAuthorityDeltas(deltas: AuthorityDelta[]): string {
   if (deltas.length === 0) {
     // "0 findings" invites a reader to assume nothing was examined. Say what
     // was compared and that it came back unchanged.
+    //
+    // And say it PRECISELY: "no manifest changed" would be false whenever a
+    // comment, reordering or an unread field changed, which is exactly the
+    // case this classifier exists to distinguish from a real one. A reader who
+    // sees a nine-line diff and a report claiming nothing changed will stop
+    // trusting the report, and they would be right to.
     L.push("");
-    L.push("  No worker manifest changed, so no authority changed.");
+    L.push("  No authority changed.");
+    L.push("");
+    L.push("  Manifest files may still have changed — comments, ordering and");
+    L.push("  any field the gate does not read cannot affect what a worker is");
+    L.push("  permitted to do.");
     return L.join("\n");
   }
   const widening = deltas.filter((d) => d.widens);

--- a/templates/workers/dependency-upkeep.worker.yaml
+++ b/templates/workers/dependency-upkeep.worker.yaml
@@ -39,7 +39,7 @@ owns:
 # of earned level — mirroring test-guardian's `issue` cap. Raise to 3 (open PRs
 # autonomously, merging still human) once a PR-outcome grader exists (merged/
 # closed-state detection feeding the OutcomeStore).
-autonomyCeiling: 2
+autonomyCeiling: 1
 competence:
   mean: 0.8
   strength: 4

--- a/templates/workers/dependency-upkeep.worker.yaml
+++ b/templates/workers/dependency-upkeep.worker.yaml
@@ -39,7 +39,7 @@ owns:
 # of earned level — mirroring test-guardian's `issue` cap. Raise to 3 (open PRs
 # autonomously, merging still human) once a PR-outcome grader exists (merged/
 # closed-state detection feeding the OutcomeStore).
-autonomyCeiling: 1
+autonomyCeiling: 2
 competence:
   mean: 0.8
   strength: 4

--- a/templates/workers/dependency-upkeep.worker.yaml
+++ b/templates/workers/dependency-upkeep.worker.yaml
@@ -17,6 +17,15 @@ responsibilities:
 # attach an observation to. If a future recipe variant actually opens PRs,
 # add vcs-remote back then (see the PR-outcome-grader note below, which
 # still applies to that future version).
+#
+# Adding it is a WIDENING, and as of 2026-08-27 the repository says so out
+# loud: `.github/workflows/authority-delta.yml` runs
+# `patchwork workers authority-delta` on every PR touching this directory and
+# fails until a person applies the `authority-widened-approved` label. That is
+# not a wall — a widening is often the point of the change — it just cannot be
+# silent. Raising `autonomyCeiling` from 1 to 2 is flagged the same way, and
+# more loudly, because ceiling 2 is PERMISSIVE (compensable classes stop being
+# gated) and reads like a harmless "+1".
 owns:
   - vcs-read # github.list_prs
   - fs-write # the review-summary file.write


### PR DESCRIPTION
The repository half of the autonomy gate — the `agent-config-diff-sentinel`, using the classifier from #1545.

`.github/workflows/authority-delta.yml` runs `patchwork workers authority-delta` on every PR touching `templates/workers/**` and fails when the change lets a worker do more than before.

## A widening is not a defect

It is frequently the entire point of the PR. What it must not be is **silent**. So the check fails, and a person unblocks it by applying **`authority-widened-approved`** — a label that stays on the PR as the durable record that somebody said yes, next to a comment saying exactly what widened.

That shape is deliberate. An administrator can always merge past a failing check; what they cannot do is remove the evidence of having done so. **The cost of overriding a control is accountability, not artificial friction** — inventing a two-person approval on a solo-maintainer repo would only teach people to route around it.

## Three failure modes, kept distinct

Collapsing them is how a gate ends up reporting "fine" when it means "I did not look":

| exit | meaning | result |
|---|---|---|
| 1 | a real widening | needs the label |
| 2 | could not read a ref | **fails** — not the same as "no widening" |
| other | the classifier itself failed | fails |

A shallow clone hits exit 2, which is why `fetch-depth: 0` is set and commented.

## This PR's own diff corrected the report

The no-change message said *"No worker manifest changed"*. This PR edits a manifest by **nine lines** and changes no authority at all — it's a comment. Claiming the file was unchanged is false in exactly the case the classifier exists to distinguish, and a reader looking at the diff would rightly stop trusting the report.

It now says:

```
  No authority changed.

  Manifest files may still have changed — comments, ordering and
  any field the gate does not read cannot affect what a worker is
  permitted to do.
```

That is the semantic-diff property in one output: *files changed, authority did not.*

## Verification

This PR touches `templates/workers/`, so **the sentinel runs on itself**. Expect it to post "Worker authority unchanged" and pass.

The manifest edit is a comment recorded at the point of temptation — that adding `vcs-remote` back, or raising the ceiling from 1 to 2, is a widening the repository will now say so about.

Full suite green (10,513 passing), typechecks clean, all 24 audit gates run; the usual two pre-existing failures are unrelated.

**Before merging:** create the `authority-widened-approved` label in repo settings, otherwise there is no way to unblock a genuine widening.