### PR TITLE
fix(pr-outcomes): the collector blamed the repository for an auth failure

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,12 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-28 `fix/pr-outcomes-swallows-the-real-error` — `gh repo view` ran with stderr
+  ignored, so an expired credential, a missing gh and a missing remote all reported the same
+  guess about the repository. A stale `GITHUB_TOKEN` produced `HTTP 401` and the operator was
+  told to pass `--repo`, which would not have helped. The sibling query path in the same
+  command already piped stderr; detection now matches it. — merged as #1547
+
 - 2026-08-27 `feat/authority-delta-classifier` — a repository gate must judge a manifest edit
   with the SAME primitives that govern the worker at runtime, or the two notions of authority
   drift silently and permissively. One inversion is the point: `parseForbidRules` fails OPEN

--- a/src/index.ts
+++ b/src/index.ts
@@ -5096,21 +5096,47 @@ if (process.argv[2] === "pr-outcomes") {
       const limit = limIdx >= 0 ? Number(args[limIdx + 1]) : 100;
       let repo = repoIdx >= 0 ? args[repoIdx + 1] : undefined;
       if (repo === undefined) {
-        try {
-          repo = execFileSync(
-            "gh",
-            ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-            {
-              encoding: "utf-8",
-              stdio: ["ignore", "pipe", "ignore"],
-            },
-          ).trim();
-        } catch {
+        // stderr is PIPED, not ignored. It used to be ignored, so every
+        // failure — expired credentials, no network, gh missing, not a git
+        // repo — collapsed into one guess about the repository. A stale
+        // GITHUB_TOKEN producing `HTTP 401: Bad credentials` was reported as a
+        // repository problem, and `--repo` would not have helped.
+        const { resolveRepoSlug } = await import(
+          "./maintenance/prOutcomeLedger.js"
+        );
+        const res = resolveRepoSlug(() => {
+          try {
+            return {
+              ok: true as const,
+              stdout: execFileSync(
+                "gh",
+                [
+                  "repo",
+                  "view",
+                  "--json",
+                  "nameWithOwner",
+                  "-q",
+                  ".nameWithOwner",
+                ],
+                { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+              ),
+            };
+          } catch (err) {
+            const e = err as { stderr?: string | Buffer; message?: string };
+            return {
+              ok: false as const,
+              stderr: String(e.stderr ?? e.message ?? ""),
+            };
+          }
+        });
+        if (res.repo === undefined) {
           process.stderr.write(
-            "[pr-outcomes] could not determine the repository. Pass --repo owner/name.\n",
+            `[pr-outcomes] could not resolve the repository: ${res.error}\n` +
+              "  Pass --repo owner/name to skip detection.\n",
           );
           process.exit(2);
         }
+        repo = res.repo;
       }
       let payload = "";
       try {

--- a/src/maintenance/__tests__/resolveRepoSlug.test.ts
+++ b/src/maintenance/__tests__/resolveRepoSlug.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The collector must say why it failed, in the failing tool's own words.
+ *
+ * `gh repo view` ran with stderr set to "ignore", so every failure — expired
+ * credentials, no network, gh not installed, not a git repo — collapsed into
+ * one guess: "could not determine the repository. Pass --repo owner/name."
+ *
+ * Observed 2026-08-28 with a stale `GITHUB_TOKEN` in the environment: gh
+ * returned `HTTP 401: Bad credentials` and the operator was told they had a
+ * repository problem. Nothing about the repository was wrong, and `--repo`
+ * would not have helped.
+ *
+ * The tests assert the underlying message SURVIVES. Asserting that some error
+ * is returned would pass against the version that threw the cause away.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveRepoSlug } from "../prOutcomeLedger.js";
+
+describe("resolveRepoSlug", () => {
+  it("returns the slug when gh succeeds", () => {
+    const r = resolveRepoSlug(() => ({ ok: true, stdout: "acme/widgets\n" }));
+    expect(r.repo).toBe("acme/widgets");
+    expect(r.error).toBeUndefined();
+  });
+
+  it("surfaces an auth failure verbatim, not as a repository problem", () => {
+    const r = resolveRepoSlug(() => ({
+      ok: false,
+      stderr: "HTTP 401: Bad credentials (https://api.github.com/graphql)\n",
+    }));
+    expect(r.repo).toBeUndefined();
+    expect(r.error).toContain("401");
+    expect(r.error).toContain("Bad credentials");
+    // The old message actively misdirected. It must not come back.
+    expect(r.error).not.toMatch(/could not determine the repository/i);
+  });
+
+  it("surfaces a not-a-repo failure verbatim too", () => {
+    const r = resolveRepoSlug(() => ({
+      ok: false,
+      stderr: "no git remotes found\n",
+    }));
+    expect(r.error).toContain("no git remotes found");
+  });
+
+  it("says so when the tool failed and explained nothing", () => {
+    // Silence is its own fact and must not be dressed up as a diagnosis.
+    const r = resolveRepoSlug(() => ({ ok: false, stderr: "   \n" }));
+    expect(r.error).toMatch(/said nothing/);
+  });
+
+  it("distinguishes an unusable ANSWER from a failure", () => {
+    // gh exited 0 and handed back something unusable. Reporting that as
+    // "could not determine" would misdescribe a value we did receive.
+    const r = resolveRepoSlug(() => ({ ok: true, stdout: "\n" }));
+    expect(r.repo).toBeUndefined();
+    expect(r.error).toMatch(/unusable value/);
+  });
+
+  it("rejects a slug that is not owner/name", () => {
+    const r = resolveRepoSlug(() => ({ ok: true, stdout: "just-a-name\n" }));
+    expect(r.repo).toBeUndefined();
+    expect(r.error).toMatch(/unusable value/);
+  });
+});

--- a/src/maintenance/prOutcomeLedger.ts
+++ b/src/maintenance/prOutcomeLedger.ts
@@ -290,3 +290,49 @@ export function formatLedgerSummary(s: LedgerSummary): string {
   L.push("  weigh it against.");
   return L.join("\n");
 }
+
+/**
+ * Resolve `owner/name` for the repository the collector should query.
+ *
+ * Extracted and injectable because the inline version swallowed the real
+ * failure. It ran `gh repo view` with stderr set to `"ignore"`, so when `gh`
+ * failed for any reason the catch could only report a guess — "could not
+ * determine the repository" — and the operator went looking for a missing
+ * remote.
+ *
+ * Observed 2026-08-28: a stale `GITHUB_TOKEN` in the environment made `gh`
+ * return `HTTP 401: Bad credentials`, and the collector reported a repository
+ * problem. Nothing about the repository was wrong.
+ *
+ * The sibling query path in the same command already did this correctly —
+ * pipes stderr, surfaces the message, exits loudly. This brings the two into
+ * line rather than inventing a third convention.
+ */
+export interface RepoResolution {
+  /** `owner/name` when it could be determined. */
+  repo?: string;
+  /** Why not, in the underlying tool's own words. Never a guess. */
+  error?: string;
+}
+
+export function resolveRepoSlug(
+  run: () => { ok: true; stdout: string } | { ok: false; stderr: string },
+): RepoResolution {
+  const r = run();
+  if (!r.ok) {
+    const first = r.stderr.split("\n").find((l) => l.trim().length > 0);
+    return {
+      error:
+        first && first.trim().length > 0
+          ? first.trim()
+          : "`gh repo view` failed and said nothing",
+    };
+  }
+  const slug = r.stdout.trim();
+  if (!/^[^/\s]+\/[^/\s]+$/.test(slug)) {
+    // A blank or malformed answer is not the same as a failure, and saying
+    // "could not determine" about a value we DID receive would misdescribe it.
+    return { error: `\`gh repo view\` returned an unusable value: "${slug}"` };
+  }
+  return { repo: slug };
+}


### PR DESCRIPTION
`gh repo view` ran with stderr set to `"ignore"`, so every reason detection could fail — expired credentials, no network, gh not installed, not a git repo — collapsed into one guess:

```
[pr-outcomes] could not determine the repository. Pass --repo owner/name.
```

Observed today: a stale `GITHUB_TOKEN` in the environment made gh return `HTTP 401: Bad credentials`, and the collector reported a **repository** problem. Nothing about the repository was wrong, and `--repo` would not have helped — the suggested remedy was for a different fault.

The sibling query path *in the same command* already handled this correctly: pipes stderr, surfaces the underlying message, exits loudly, on the stated grounds that a silent gap is indistinguishable from a quiet week. Detection is brought into line rather than inventing a third convention.

## Why it is extracted

`resolveRepoSlug` takes an injected runner, because the behaviour worth pinning is that **the underlying message survives**. A test asserting merely that *some* error is returned passes against the version that threw the cause away.

Two states are now distinct that the old code could not tell apart:

- gh **failing** → report what it said
- gh succeeding while handing back something **unusable** → say that instead; calling it "could not determine" misdescribes a value we did receive

And a tool that fails while saying nothing is reported as exactly that, rather than dressed up as a diagnosis.

## Verified end-to-end against the built CLI

```
GITHUB_TOKEN=invalid → could not resolve the repository:
    HTTP 401: Bad credentials (https://api.github.com/graphql)
    Pass --repo owner/name to skip detection.

clean env            → Oolab-labs/patchwork-os: 5 pull request(s) queried
                       0 appended, 5 unchanged since the last collection
```

6 unit tests. Full suite green (10,519 passing), typechecks clean, all 24 audit gates run; the usual two pre-existing failures are unrelated.
