### PR TITLE
fix(approvals): a recipe could stop for a human and never tell one

### DIFF
--- a/src/__tests__/recipeApprovalNotifies.test.ts
+++ b/src/__tests__/recipeApprovalNotifies.test.ts
@@ -1,0 +1,123 @@
+/**
+ * A recipe step that stops for approval must reach your phone.
+ *
+ * There are two ways to enqueue an approval in this codebase, and only one of
+ * them notifies anybody:
+ *
+ *   - `enqueueApprovalWithDispatch` (approvalHttp.ts) queues AND fans out to
+ *     every configured channel — webhook, Web Push, ntfy.
+ *   - `queue.request()` queues silently.
+ *
+ * That distinction has already caused this exact bug once. The doc comment on
+ * `enqueueApprovalWithDispatch` records it: the CLI gate "silently enqueued
+ * with NO notification of any kind, since the CLI gate called
+ * `queue.request()` directly and never touched the dispatch* helpers". The fix
+ * reached the HTTP route and the CLI gate — and missed the recipe runner,
+ * which still called `queue.request()` directly.
+ *
+ * The symptom is the worst kind: a recipe halts mid-run waiting for a human,
+ * the human is never told, and the approval expires. A stalled worker and a
+ * broken worker look identical from the outside. Observed twice on 2026-08-27
+ * with a live errand recipe, on a machine where `ntfyTopic` was configured
+ * correctly the whole time.
+ *
+ * The first test is a SOURCE-LEVEL wiring check, deliberately. The regression
+ * it guards is a line going missing, and a behavioural test with hand-injected
+ * deps proves the logic while staying blind to whether production wires it —
+ * the same reasoning that put a source-level assertion on the privacy
+ * boundary's deps.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { enqueueApprovalWithDispatch } from "../approvalHttp.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const orchestration = readFileSync(
+  join(here, "..", "recipeOrchestration.ts"),
+  "utf-8",
+);
+
+describe("recipe approvals are wired to the notifying path", () => {
+  it("recipeOrchestration imports the dispatching helper", () => {
+    expect(orchestration).toMatch(/enqueueApprovalWithDispatch/);
+  });
+
+  it("the recipe approval fn does NOT call queue.request directly", () => {
+    // The whole defect in one assertion. `queue.request(` inside
+    // makeRecipeApprovalFn is the silent path.
+    const fn = orchestration.slice(
+      orchestration.indexOf("async function makeRecipeApprovalFn"),
+      orchestration.indexOf("async function makeRecipeApprovalFn") + 2000,
+    );
+    expect(fn).not.toMatch(/queue\.request\(/);
+    expect(fn).toMatch(/enqueueApprovalWithDispatch/);
+  });
+
+  it("the CALL SITE hands it the server, or the channels are all undefined", () => {
+    // Caught by mutation: an earlier version of this file asserted only that
+    // the function BODY mentions ntfyTopic. Removing `this.deps.server` from
+    // the call site left every channel undefined at runtime — silent again —
+    // and all the other tests still passed, because `server` is an optional
+    // parameter so the compiler says nothing either.
+    expect(orchestration).toMatch(
+      /makeRecipeApprovalFn\(\s*approvalGate\s*,\s*this\.deps\.server\s*\)/,
+    );
+  });
+
+  it("it passes the notification channels through", () => {
+    const fn = orchestration.slice(
+      orchestration.indexOf("async function makeRecipeApprovalFn"),
+      orchestration.indexOf("async function makeRecipeApprovalFn") + 2000,
+    );
+    // ntfyTopic is the channel that was configured and silent. If the deps are
+    // not threaded through, the helper mints no token and dispatches nothing.
+    expect(fn).toMatch(/ntfyTopic/);
+    expect(fn).toMatch(/pushServiceBaseUrl/);
+  });
+});
+
+describe("enqueueApprovalWithDispatch forwards an abort signal", () => {
+  it("passes opts.signal to the queue", () => {
+    // The recipe path cancels its wait when the run is cancelled, instead of
+    // blocking for the full approval TTL. Routing it through the dispatching
+    // helper must not silently drop that — a cancelled run would then hold a
+    // step open for up to four hours.
+    const request = vi.fn().mockReturnValue({
+      callId: "c1",
+      approvalToken: "t1",
+      promise: Promise.resolve("approved"),
+    });
+    const peek = vi.fn().mockReturnValue({ expiresAt: Date.now() + 60_000 });
+    const controller = new AbortController();
+    enqueueApprovalWithDispatch(
+      { queue: { request, peek } as never },
+      {
+        toolName: "example.tool",
+        params: {},
+        tier: "high",
+        riskSignals: [],
+      },
+      { signal: controller.signal },
+    );
+    expect(request).toHaveBeenCalledTimes(1);
+    const opts = request.mock.calls[0]?.[1];
+    expect(opts?.signal).toBe(controller.signal);
+  });
+
+  it("still mints a token when a channel is configured", () => {
+    const request = vi.fn().mockReturnValue({
+      callId: "c1",
+      approvalToken: "t1",
+      promise: Promise.resolve("approved"),
+    });
+    const peek = vi.fn().mockReturnValue({ expiresAt: Date.now() + 60_000 });
+    enqueueApprovalWithDispatch(
+      { queue: { request, peek } as never, ntfyTopic: "some-topic" },
+      { toolName: "t", params: {}, tier: "high", riskSignals: [] },
+    );
+    expect(request.mock.calls[0]?.[1]?.withToken).toBe(true);
+  });
+});

--- a/src/approvalHttp.ts
+++ b/src/approvalHttp.ts
@@ -971,6 +971,13 @@ export function enqueueApprovalWithDispatch(
     sessionId?: string;
     personalSignals?: ReturnType<typeof computePersonalSignals>;
   },
+  /**
+   * Forwarded to `queue.request`. The recipe runner cancels its wait when the
+   * run is cancelled rather than blocking for the full approval TTL; routing
+   * it through here must not silently drop that, or a cancelled run would
+   * hold a step open for up to the tier's timeout.
+   */
+  opts: { signal?: AbortSignal } = {},
 ): {
   callId: string;
   promise: Promise<ApprovalDecision>;
@@ -989,7 +996,10 @@ export function enqueueApprovalWithDispatch(
         personalSignals: request.personalSignals,
       }),
     },
-    { withToken: !!deps.pushServiceUrl || !!deps.ntfyTopic },
+    {
+      withToken: !!deps.pushServiceUrl || !!deps.ntfyTopic,
+      ...(opts.signal !== undefined && { signal: opts.signal }),
+    },
   );
   recordApprovalPrompted();
 

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -109,18 +109,56 @@ export function agentTextFromTask(task: {
  * human approval and resolves true only on an explicit "approved" decision
  * (a reject / expire / cancel halts the run — fail-closed, ADR-0016 spirit).
  */
-async function makeRecipeApprovalFn(gate: "high" | "all"): Promise<ApprovalFn> {
+async function makeRecipeApprovalFn(
+  gate: "high" | "all",
+  server?: Server,
+): Promise<ApprovalFn> {
   const { getApprovalQueue } = await import("./approvalQueue.js");
+  const { enqueueApprovalWithDispatch } = await import("./approvalHttp.js");
   const queue = getApprovalQueue();
   return async (input) => {
     // Below-threshold steps don't need sign-off.
     if (gate === "high" && input.tier !== "high") return true;
-    const { promise } = queue.request(
+    // Goes through `enqueueApprovalWithDispatch`, NOT `queue.request`. The
+    // second queues silently; only the first fans out to the configured
+    // channels (webhook, Web Push, ntfy).
+    //
+    // This path called `queue.request` directly until 2026-08-28, so a recipe
+    // could halt mid-run waiting for a human and never tell one — the
+    // approval then expired, and a stalled worker is indistinguishable from a
+    // broken one. That is the same defect the dispatch helper's own doc
+    // comment records being fixed for the CLI gate; the fix reached the HTTP
+    // route and the CLI gate and missed this third caller.
+    const { promise } = enqueueApprovalWithDispatch(
+      {
+        queue,
+        ...(server?.approvalWebhookUrl && {
+          webhookUrl: server.approvalWebhookUrl,
+        }),
+        ...(server?.pushServiceUrl && {
+          pushServiceUrl: server.pushServiceUrl,
+        }),
+        ...(server?.pushServiceToken && {
+          pushServiceToken: server.pushServiceToken,
+        }),
+        ...(server?.pushServiceBaseUrl && {
+          pushServiceBaseUrl: server.pushServiceBaseUrl,
+        }),
+        ...(server?.pushServiceAllowPrivate !== undefined && {
+          pushServiceAllowPrivate: server.pushServiceAllowPrivate,
+        }),
+        ...(server?.ntfyTopic && { ntfyTopic: server.ntfyTopic }),
+        ...(server?.ntfyServer && { ntfyServer: server.ntfyServer }),
+      },
       {
         toolName: input.toolId,
         params: input.params ?? {},
         tier: input.tier,
         sessionId: "recipe",
+        // No risk signals on this path — the recipe runner computes none. An
+        // empty list is honest; inventing signals to fill the shape would put
+        // fabricated evidence into a notification and a receipt.
+        riskSignals: [],
         ...(input.summary !== undefined && { summary: input.summary }),
       },
       // L1: abort the wait if the run is cancelled (→ "cancelled" → halt)
@@ -1609,7 +1647,7 @@ export class RecipeOrchestration {
     const tierApprovalFn =
       approvalGate === "off"
         ? undefined
-        : await makeRecipeApprovalFn(approvalGate);
+        : await makeRecipeApprovalFn(approvalGate, this.deps.server);
     // worker.autonomy flip (flag-gated, default off). When a worker owns this
     // recipe and the flag is on, the worker-aware fn wraps the tier fn (FLOOR
     // composition — it can only ADD gating, never drop tier-policy protection)


### PR DESCRIPTION
There are two ways to enqueue an approval in this codebase, and only one notifies anybody:

- **`enqueueApprovalWithDispatch`** — queues *and* fans out to every configured channel (webhook, Web Push, ntfy)
- **`queue.request()`** — queues silently

The recipe runner called `queue.request()` directly. So a recipe could halt mid-run waiting for a human, **the human was never told**, and the approval expired on its own timeout. A stalled worker and a broken worker look identical from the outside — the worst property this failure could have.

## The same bug was already fixed once

The dispatch helper's own doc comment records it:

> before this extraction, CLI-originated approvals … **silently enqueued with NO notification of any kind**, since the CLI gate called `queue.request()` directly and never touched the dispatch* helpers below.

That fix reached the HTTP route and the CLI gate, and missed this third caller.

## Nothing was misconfigured

`ntfyTopic` and `pushServiceBaseUrl` were both set correctly on the reference machine the whole time. The notifying code simply was not on this path. Observed twice on 2026-08-27 with a live errand recipe — the first approval expired unseen, which is what sent me looking.

## Two details

**`signal` passthrough.** The recipe path aborts its wait when the run is cancelled rather than blocking for the full tier timeout. Routing through the helper without forwarding the signal would hold a cancelled run's step open for up to four hours.

**`riskSignals: []` is honest.** The recipe runner computes none. Inventing signals to fill the shape would put fabricated evidence into a notification *and* into a receipt.

## The call-site test exists because mutation caught me

The first version of the test asserted only that the function **body** mentions `ntfyTopic`. Removing `this.deps.server` from the call site left every channel undefined at runtime — silent again — and **every test still passed**, with no compiler complaint either, since `server` is an optional parameter.

The added assertion pins the call site. Re-running the same mutation now fails it.

Full suite green (10,525 passing), typechecks clean, 24 audit gates run; the usual two pre-existing failures are unrelated.