### PR TITLE
fix(butler): the shadow summary counted observations and called them errands

### DIFF
--- a/src/butler/__tests__/outcomeIngester.test.ts
+++ b/src/butler/__tests__/outcomeIngester.test.ts
@@ -154,11 +154,18 @@ describe("grading a batch", () => {
       now: NOW + 1000,
       dir,
     });
+    // The LEDGER keeps both observations — that is the append-only design and
+    // the point of this test.
     expect(rows()).toHaveLength(2);
+    // The SUMMARY folds them back into the one errand they describe. This
+    // previously asserted `total: 2, confirmed: 1, unknown: 1`, which counted a
+    // single errand as simultaneously unknown AND confirmed — the row count
+    // wearing the name of an errand count. One errand that went from open to
+    // completed is one confirmed errand.
     expect(summariseShadowLog({ dir })).toMatchObject({
-      total: 2,
+      total: 1,
       confirmed: 1,
-      unknown: 1,
+      unknown: 0,
     });
   });
 });

--- a/src/butler/__tests__/shadowSummaryDedupe.test.ts
+++ b/src/butler/__tests__/shadowSummaryDedupe.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The shadow summary must count ERRANDS, not observations of them.
+ *
+ * The ledger is append-only and an errand is observed repeatedly — that is the
+ * design, and `promoteShadowOutcomes` states it plainly: "Last grade wins per
+ * ref. The ledger is append-only and an errand is observed repeatedly, so the
+ * same ref legitimately appears many times."
+ *
+ * The summary did not apply that rule. It counted every row, so one errand
+ * observed five times contributed five to the totals. On the reference machine
+ * that produced "17 graded rows: confirmed 3 (17.6%)" over FOUR errands of
+ * which ONE was confirmed — the true figure being 25%.
+ *
+ * Two things make this worse than a cosmetic miscount:
+ *
+ *   - It drifts. Every observation pushes the reported percentages further
+ *     from the truth, so scheduling observation — the obvious next step, and
+ *     the reason this was found — degrades the number steadily.
+ *   - The summary is what a person reads before deciding to promote, and
+ *     promotion is one-way. This module's own doc comment names the hazard:
+ *     "Two readers of one append-only file with two copies of 'what counts as
+ *     a row' is how a report and the thing it reports on come to disagree."
+ *
+ * So the summary now folds by ref with last-grade-wins — the same rule the
+ * promoter uses, deliberately, so the report and the action cannot diverge.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { summariseShadowLog } from "../outcomeShadowLog.js";
+
+let dir: string;
+
+function write(rows: Array<Record<string, unknown>>) {
+  const p = path.join(dir, "butler_outcome_shadow.jsonl");
+  writeFileSync(p, rows.map((r) => JSON.stringify(r)).join("\n") + "\n");
+}
+
+const row = (
+  ref: string,
+  disposition: string,
+  gradedAt: number,
+  reason = "open-recent",
+) => ({
+  ref,
+  disposition,
+  reason,
+  gradedAt,
+  recipe: "example-recipe",
+  wouldCountAsEvidence: disposition === "confirmed",
+});
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "butler-shadow-"));
+  mkdirSync(dir, { recursive: true });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("summary folds by errand", () => {
+  it("counts one errand once however many times it was observed", () => {
+    write([
+      row("tool:a", "unknown", 1),
+      row("tool:a", "unknown", 2),
+      row("tool:a", "confirmed", 3, "completed"),
+    ]);
+    const s = summariseShadowLog({ dir });
+    expect(s.total).toBe(1);
+    expect(s.confirmed).toBe(1);
+    expect(s.unknown).toBe(0);
+  });
+
+  it("takes the LATEST grade, not the first", () => {
+    // An errand starts unknown and later completes. Reporting it as unknown
+    // because that grade came first would hide every completion.
+    write([
+      row("tool:a", "confirmed", 5, "completed"),
+      row("tool:a", "unknown", 1),
+    ]);
+    const s = summariseShadowLog({ dir });
+    expect(s.confirmed).toBe(1);
+    expect(s.unknown).toBe(0);
+  });
+
+  it("reproduces the live case: 4 errands, not 17 rows", () => {
+    const rows = [];
+    for (let i = 0; i < 4; i++) {
+      for (let obs = 0; obs < 4; obs++) {
+        rows.push(row(`tool:${i}`, "unknown", obs));
+      }
+    }
+    rows.push(row("tool:0", "confirmed", 99, "completed"));
+    write(rows);
+    const s = summariseShadowLog({ dir });
+    expect(s.total).toBe(4);
+    expect(s.confirmed).toBe(1);
+    expect(s.unknown).toBe(3);
+    // The figure a person acts on: 1 of 4, not 5 of 17.
+    expect(s.wouldCount).toBe(1);
+  });
+
+  it("keeps distinct errands distinct", () => {
+    write([
+      row("tool:a", "confirmed", 1, "completed"),
+      row("tool:b", "junk", 1, "stale"),
+      row("tool:c", "unknown", 1),
+    ]);
+    const s = summariseShadowLog({ dir });
+    expect(s.total).toBe(3);
+    expect(s.confirmed).toBe(1);
+    expect(s.junk).toBe(1);
+    expect(s.unknown).toBe(1);
+  });
+
+  it("attributes byReason from the surviving grade only", () => {
+    write([
+      row("tool:a", "unknown", 1, "open-recent"),
+      row("tool:a", "confirmed", 2, "completed"),
+    ]);
+    const s = summariseShadowLog({ dir });
+    expect(s.byReason.completed).toBe(1);
+    expect(s.byReason["open-recent"]).toBe(0);
+  });
+});

--- a/src/butler/outcomeShadowLog.ts
+++ b/src/butler/outcomeShadowLog.ts
@@ -214,7 +214,30 @@ export function summariseShadowLog(opts: { dir?: string } = {}): ShadowSummary {
   // no test can distinguish the two while `empty` stays local, and a test that
   // passes either way would be worse than none.
   const out: ShadowSummary = { ...empty, byReason: emptyByReason() };
+  // Fold by ref, LAST GRADE WINS — the identical rule `promoteShadowOutcomes`
+  // applies, and deliberately so.
+  //
+  // The ledger is append-only and an errand is observed repeatedly; that is
+  // the design, not a defect. Counting rows therefore counted OBSERVATIONS and
+  // called them errands: on the reference machine, four errands observed
+  // several times each reported as "17 graded rows, confirmed 3 (17.6%)" when
+  // the truth was one confirmed errand of four.
+  //
+  // Two reasons that is worse than a cosmetic miscount. It DRIFTS — every
+  // observation pushes the percentage further from the truth, so scheduling
+  // observation degrades the number steadily. And this summary is what a
+  // person reads before deciding to promote, which is one-way. This module's
+  // own header names the hazard: two readers of one append-only file with two
+  // copies of "what counts as a row" is how a report and the thing it reports
+  // on come to disagree.
+  const latest = new Map<string, ShadowOutcomeRow>();
   for (const row of parseShadowRows(text)) {
+    const prev = latest.get(row.ref);
+    if (prev === undefined || row.gradedAt >= prev.gradedAt) {
+      latest.set(row.ref, row);
+    }
+  }
+  for (const row of latest.values()) {
     out.total++;
     out[row.disposition]++;
     if (row.wouldCountAsEvidence) out.wouldCount++;


### PR DESCRIPTION
The ledger is append-only and an errand is observed repeatedly. That is the design — `promoteShadowOutcomes` states it plainly:

> Last grade wins per ref. The ledger is append-only and an errand is observed repeatedly, so the same ref legitimately appears many times.

**The summary did not apply that rule.** It counted rows, so one errand observed five times contributed five to the totals. On the reference machine:

| | reported | true |
|---|---|---|
| errands | 17 | **4** |
| confirmed | 3 (17.6%) | **1 (25%)** |

## Why this is worse than a cosmetic miscount

**It drifts.** Every observation pushes the reported percentage further from the truth. That is how it was found: I wrote a daily `butler observe` agent — the fix for Butler's stalled outcome loop — ran it twice, and watched the totals grow by four each time for the same four errands. **The agent is unloaded until this ships**, because scheduling it would have steadily corrupted the number it exists to produce.

**The summary is what a person reads before promoting**, and promotion is one-way: trust replay absorbs a folded row into a checkpoint that deleting the row does not undo.

This module's own header names the hazard exactly:

> Two readers of one append-only file with two copies of "what counts as a row" is how a report and the thing it reports on come to disagree.

They did. The promoter folded by ref; the report did not. The fix is the promoter's own rule applied in the reader, so the two cannot diverge again.

## One existing test encoded the bug

It observes **one** errand twice — open, then completed — and asserted `total: 2, confirmed: 1, unknown: 1`, counting a single errand as simultaneously unknown *and* confirmed. Its ledger assertion (two rows appended) is untouched: that part was always right and is the append-only property the test exists to pin. Only the summary assertion changed.

## Verification

Mutation-checked by inverting the fold to first-grade-wins — four tests fail, including the one asserting that an errand which completes is not still reported as unknown.

Live output from the corrected build:

```
[butler-shadow] 4 graded row(s):
  confirmed  1 (25.0%)
  unknown    3 (75.0%) — withheld by the fold
```

Full suite green, typecheck clean, 24 audit gates run; the usual two pre-existing failures are unrelated.

**Follow-up:** once this merges and is installed, the daily `butler observe` agent gets reloaded — that was the original task, and it closes the loop where errands were filed and never checked.