### PR TITLE
chore(companions): a held pin is a decision; a red gate is not

### DIFF
--- a/scripts/audit-companion-pins-holdback.json
+++ b/scripts/audit-companion-pins-holdback.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Companion pins DELIBERATELY held back from latest. A pin controls what runs on a USER's machine (`npx -y pkg@version`), so bumping one is a change to their setup, not to ours — and these are third-party MCP servers this repo cannot meaningfully test. Silencing the gate by bumping blind would trade a visible warning for an invisible risk. Each entry needs a reason and a reviewOn date; the gate reports an entry whose pin has MOVED as stale, so a hold-back cannot outlive the pin it was written about.",
+  "holdback": [
+    {
+      "package": "superpowers-mcp",
+      "pinned": "4.3.2",
+      "reason": "Two major versions behind. A major bump to a planning/task-decomposition server changes behaviour users have configured around, and nothing here exercises it. Needs a manual trial before moving.",
+      "reviewOn": "2026-11-01"
+    },
+    {
+      "package": "@bytebase/dbhub",
+      "pinned": "0.21.2",
+      "reason": "0.x to 1.x crosses the first stable major. A database companion is the worst place to discover a breaking connection-string or auth change by shipping it. Needs a manual trial against a real database first.",
+      "reviewOn": "2026-11-01"
+    }
+  ]
+}

--- a/scripts/audit-companion-pins.mjs
+++ b/scripts/audit-companion-pins.mjs
@@ -18,6 +18,37 @@ const jsonMode = process.argv.includes("--json");
 // ── Parse registry.ts as text ────────────────────────────────────────────────
 
 const registryPath = resolve(ROOT, "src/companions/registry.ts");
+
+/**
+ * Pins deliberately held back from latest.
+ *
+ * A pin controls what runs on a USER's machine (`npx -y pkg@version`), so
+ * bumping one changes their setup, not ours — and these are third-party MCP
+ * servers this repo cannot meaningfully test. Without this file the only way
+ * to clear the gate was to bump blind, trading a visible warning for an
+ * invisible risk, so the gate stayed red instead and everyone stopped reading
+ * it. A held pin is a decision with a reason and a date; a red gate is not.
+ *
+ * A hold-back CANNOT outlive the pin it was written about: if `pinned` no
+ * longer matches the registry, the entry is reported stale and the gate fails.
+ * Otherwise a bump would silently inherit an exemption argued for a version
+ * nobody is running any more.
+ */
+function loadHoldback() {
+  try {
+    const raw = readFileSync(
+      resolve(__dirname, "audit-companion-pins-holdback.json"),
+      "utf-8",
+    );
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed.holdback) ? parsed.holdback : [];
+  } catch {
+    // Absent or unreadable ⇒ nothing held back. Fail toward reporting MORE,
+    // never fewer, stale pins.
+    return [];
+  }
+}
+const holdback = loadHoldback();
 const registryText = readFileSync(registryPath, "utf8");
 
 // Match patterns like: "@modelcontextprotocol/server-memory@2026.1.26"
@@ -130,9 +161,22 @@ await Promise.all(
       cmp.behind === true &&
       (cmp.level === "major" || (cmp.level === "minor" && cmp.by > 5));
 
+    // A hold-back suppresses the VERDICT as well as the tag. Suppressing only
+    // the tag is the exact divergence this file already warns about a few
+    // lines up — "the reader's summary and the build's verdict telling
+    // different stories" — and it would leave the gate red while printing
+    // nothing red, which is worse than either alone.
+    //
+    // Only an EXACT pin match counts: once the pin moves, the exemption stops
+    // applying and the display path reports it stale, so a bump cannot inherit
+    // an argument made about a version nobody runs.
+    const heldExactly = holdback.some(
+      (h) => h.package === pkg && h.pinned === pinned,
+    );
+
     results.push({ package: pkg, pinned, latest, upToDate, distance, error });
 
-    if (error || significantlyBehind) anyFailed = true;
+    if (error || (significantlyBehind && !heldExactly)) anyFailed = true;
   }),
 );
 
@@ -176,6 +220,27 @@ if (jsonMode) {
       const c = compareVersions(pinned, latest);
       const stale =
         c.behind && (c.level === "major" || (c.level === "minor" && c.by > 5));
+      const held = holdback.find((h) => h.package === pkg);
+      if (held && held.pinned === pinned) {
+        console.log(
+          `HELD  ${pkg}@${pinned} → latest ${latest} (${c.by} ${c.level}(s) behind) — reviewOn ${held.reviewOn}`,
+        );
+        console.log(`      ${held.reason}`);
+        // Deliberately NOT a warning. A decision with a reason and a date is
+        // not the same fact as an unexamined stale pin, and printing them
+        // identically is what taught everyone to skip this output.
+        continue;
+      }
+      if (held) {
+        // The pin moved out from under the exemption. Report it rather than
+        // letting a new version inherit an argument made about an old one.
+        console.warn(
+          `STALE ${pkg}@${pinned} — hold-back entry names ${held.pinned}, which is no longer the pin. Re-justify or remove it.`,
+        );
+        hasWarning = true;
+        anyFailed = true;
+        continue;
+      }
       const tag = stale ? "STALE" : "WARN ";
       console.warn(
         `${tag} ${pkg}@${pinned} → latest ${latest} (${c.by} ${c.level}(s) behind)`,

--- a/src/companions/registry.ts
+++ b/src/companions/registry.ts
@@ -25,8 +25,8 @@ export const COMPANIONS: Record<string, CompanionEntry> = {
     description: "Persistent memory across Claude sessions",
     npmPackage: "@modelcontextprotocol/server-memory",
     command: "npx",
-    // Pinned: npm view @modelcontextprotocol/server-memory version → 2026.1.26 (2026-05-23)
-    args: ["-y", "@modelcontextprotocol/server-memory@2026.1.26"],
+    // Pinned: npm view @modelcontextprotocol/server-memory version → 2026.7.4 (2026-08-28)
+    args: ["-y", "@modelcontextprotocol/server-memory@2026.7.4"],
   },
   superpowers: {
     description: "Structured planning, task decomposition",
@@ -42,8 +42,8 @@ export const COMPANIONS: Record<string, CompanionEntry> = {
       "Full Chrome browser control — automate, debug, inspect network/console/performance",
     npmPackage: "chrome-devtools-mcp",
     command: "npx",
-    // Pinned: npm view chrome-devtools-mcp version → 1.0.1 (2026-05-23)
-    args: ["-y", "chrome-devtools-mcp@1.0.1"],
+    // Pinned: npm view chrome-devtools-mcp version → 1.8.0 (2026-08-28)
+    args: ["-y", "chrome-devtools-mcp@1.8.0"],
   },
   database: {
     description:


### PR DESCRIPTION
Two audit gates failed on every run for a day, and I scrolled past them about fifteen times. That is the failure this repo already documents: *a check that always reports the same thing consumes the attention a real failure needs.* Both are green now, and neither was silenced.

## `audit-pack-tracked` was right

Three personal recipes sat in `templates/recipes/`, and `package.json` includes `templates` wholesale — **npm would have published them.** They differ from the copies in `~/.patchwork/recipes`, so they were moved out of the packed tree rather than deleted.

The gate never printed their names, correctly: the name of a deliberately-excluded file is itself the disclosure.

## `audit-companion-pins` had no way to say "not yet"

The only way to clear it was to bump. Two of the four stale pins are **major** jumps in third-party MCP servers (superpowers 4.x → 6.x, dbhub 0.x → 1.x).

A pin is a literal `npx -y pkg@version` in a **user's** config, so bumping one changes what runs on *their* machine — and nothing here exercises either server. Bumping blind to clear a warning trades a visible risk for an invisible one.

So: the two same-major pins are bumped (server-memory `2026.1.26 → 2026.7.4`, chrome-devtools `1.0.1 → 1.8.0`), and the two majors are **HELD** with a reason and a review date — mirroring the `outputSchema` allowlist that already works this way.

```
HELD  @bytebase/dbhub@0.21.2 → latest 1.2.1 (1 major(s) behind) — reviewOn 2026-11-01
      0.x to 1.x crosses the first stable major. A database companion is the
      worst place to discover a breaking auth change by shipping it.
```

## The hold-back suppresses the verdict, not just the tag

Suppressing only the tag is the exact divergence this file warns about a few lines up — *"the reader's summary and the build's verdict telling different stories."* It would have left the gate red while printing nothing red, which is worse than either alone.

That **was** my first version. The real exit code caught it: `node script | head` reports `head`'s status, not the script's.

## It cannot outlive the pin it argues about

A hold-back matches the **exact** pinned version. A later bump does not inherit an exemption written for a version nobody runs — the entry is reported stale and the gate fails.

**Mutation-checked twice**, because an exemption mechanism that cannot fail is just an off-switch:

- pin moved out from under its hold-back → exit 1, names it
- a genuinely new stale pin → exit 1

**All 24 audit gates now pass** — first time today. Full suite green (10,532 passing), typecheck clean.