### PR TITLE
fix(release): the packaged-artifact check ran nowhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,45 @@ jobs:
       - name: Audit tool schemas against snapshot
         run: node scripts/audit-schema-changes.mjs
 
+  fresh-install:
+    # Does the PACKAGED, INSTALLED product work — not the source checkout?
+    #
+    # `smoke:fresh-install` existed as an npm script wired into NOTHING: not
+    # CI, not `prepublishOnly`, not any of the three publish jobs, each of
+    # which ran `npm ci && build && test` against the source tree and then
+    # published. A correct check pointed at nothing.
+    #
+    # It now also runs from `prepublishOnly`, which is the last moment before
+    # a real publish and covers all three jobs at once. This job is the other
+    # half: `prepublishOnly` only fires on a publish, so without it a break
+    # would surface during a release rather than on the PR that caused it.
+    #
+    # `npm_config_dry_run` is set on purpose. npm config reaches children as
+    # env vars, and under `npm publish --dry-run` the inner `npm pack`
+    # inherited this flag and wrote no tarball — eight failures that looked
+    # exactly like a broken package during the rehearsal a release engineer
+    # runs before a real publish. Setting it here pins that fix: without it the
+    # job is green either way and the guard could be deleted unnoticed.
+    name: Fresh install (packaged artifact)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: npm run build
+      - name: Pack, install into a throwaway prefix, and drive the binary
+        run: npm run smoke:fresh-install
+        timeout-minutes: 10
+        env:
+          npm_config_dry_run: "true"
+
   lsp-audit:
     name: LSP tool registry audit
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "typecheck:tests:core": "tsc --noEmit -p tsconfig.tests.core.json",
     "postinstall": "node scripts/postinstall.mjs || true",
     "audit:pack": "node scripts/audit-pack-tracked.mjs",
-    "prepublishOnly": "node scripts/audit-pack-tracked.mjs && npm run build && node -e \"const h=require('child_process').execFileSync('node',['dist/index.js','--workspace','.','--help'],{encoding:'utf8'});if(!h.includes('issuer-url'))process.exit(1)\" && node scripts/publish-schemas.mjs",
+    "prepublishOnly": "node scripts/audit-pack-tracked.mjs && npm run build && node -e \"const h=require('child_process').execFileSync('node',['dist/index.js','--workspace','.','--help'],{encoding:'utf8'});if(!h.includes('issuer-url'))process.exit(1)\" && node scripts/publish-schemas.mjs && node scripts/fresh-install-smoke.mjs",
     "smoke": "node smoke-test-v2.mjs",
     "remote": "bash scripts/start-remote.sh",
     "remote:node": "node scripts/start-remote.mjs",

--- a/scripts/fresh-install-smoke.mjs
+++ b/scripts/fresh-install-smoke.mjs
@@ -58,11 +58,34 @@ function step(name, fn) {
   }
 }
 
+/**
+ * npm config reaches a child process as `npm_config_*` env vars, and this
+ * script runs `npm pack` and `npm install` as children.
+ *
+ * `npm_config_dry_run` is the one that matters. Under `npm publish --dry-run`
+ * it is inherited by the inner `npm pack`, which then writes no tarball — and
+ * every subsequent check fails against a file that was never meant to exist.
+ * The rehearsal a release engineer runs before a real publish would report
+ * eight failures that look exactly like a broken package.
+ *
+ * That is the failure mode this script's own notes warn about: a verifier that
+ * is wrong in the FAILING direction burns real time chasing a bug in the
+ * product that is actually a bug in the check. This script is never itself a
+ * dry run — it packs and installs for real, into a throwaway prefix — so the
+ * inherited flag is always wrong here.
+ *
+ * Scoped to `dry_run` deliberately. Stripping every `npm_config_*` would also
+ * drop `registry`, proxy and auth settings that the inner install genuinely
+ * needs to fetch dependencies behind a corporate mirror or in CI.
+ */
+const { npm_config_dry_run: _ignoredDryRun, ...cleanEnv } = process.env;
+
 function run(cmd, args, opts = {}) {
   return execFileSync(cmd, args, {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
     maxBuffer: 32 * 1024 * 1024,
+    env: cleanEnv,
     ...opts,
   });
 }


### PR DESCRIPTION
`smoke:fresh-install` is the only check in this repository that verifies the
**packaged, installed** product rather than the source tree. It was wired into
nothing — not CI, not `prepublishOnly`, not any of the three publish jobs, each
of which runs `npm ci && build && test` against the checkout and then publishes.
Everything it exists to catch — a tarball missing a file, a broken `bin`, an
artifact that installs and then cannot run — reaches npm with every gate green.

## Wired in two places, because they fail at different times

- **`prepublishOnly`** — the last moment before a real publish, and one edit
  rather than three. Editing the alpha, beta and latest jobs separately is three
  places to forget, which is this repository's recurring defect.
- **A CI job** — `prepublishOnly` only fires on a publish, so alone it would
  surface a break during a release instead of on the PR that caused it.

## The verifier could not survive its own wiring

npm config reaches child processes as `npm_config_*` env vars, and this script
runs `npm pack` and `npm install` as children. Under `npm publish --dry-run` the
inner `npm pack` inherited `npm_config_dry_run`, wrote no tarball, and every
later check failed against a file that was never created: **eight failures that
look exactly like a broken package**, during the rehearsal a release engineer
runs before a real publish.

That is the failure this script's own notes warn about — a verifier wrong in the
*failing* direction burns real time chasing a bug in the product that is a bug in
the check. It is never itself a dry run (it packs and installs for real, into a
throwaway prefix), so the flag is always wrong here.

Scoped to `dry_run` alone: stripping every `npm_config_*` would also drop
registry, proxy and auth settings the inner install needs to fetch dependencies
behind a mirror or in CI.

## Verification

- The CI job sets `npm_config_dry_run=true` **deliberately**, so it pins the fix.
  Without it the job is green either way and the guard could be deleted
  unnoticed.
- **Mutation-checked**: removing the guard takes the same command from 8/8 to
  0/8.
- `npm publish --dry-run` now completes the whole prepublish chain, 8/8. Its
  remaining non-zero exit is npm refusing a prerelease without `--tag`, after the
  hook has run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
