### PR TITLE
feat(privacy): the orchestrator path was watched and never stopped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,9 +579,50 @@ worker may DO; this answers what a destination may RECEIVE.
 - **Coverage is enumerated, never asserted as total.** `agent` steps were 54 of
   1,795 logged steps (~3%) when this was built. A crossing count over a partial
   surface reads as "your policy is fine" when it partly means "we did not look".
-- **Orchestrator dispatch is OBSERVED but NOT ENFORCED** (#1397). Rows carry
-  `labelSource: "assumed"` — there is no declared-policy channel on that path,
-  and asserting one would claim intent nobody expressed.
+- **Orchestrator dispatch is now ENFORCED, on an operator opt-in** (2026-08-30
+  amendment to ADR-0021; #1397 was the observe-only half). `privacy.orchestrator
+  .classification` is a PATH-LEVEL default — its presence is the opt-in, and its
+  absence leaves the path observed-but-ungoverned exactly as before, so no
+  existing install changes behaviour by upgrading. A refused dispatch fails the
+  task with `InformationBoundaryRefusal` (an `error` with a named cause, not a
+  new lifecycle state).
+
+  **`labelSource` has THREE values, and `default` is not a synonym for either
+  other one.** `declared` = an operator classified THIS dispatch; `assumed` =
+  nobody said anything and the runtime fell back to `internal`; `default` = an
+  operator classified the CHANNEL. Folding `default` into `declared` asserts
+  intent about a prompt no operator saw — the exact claim ADR-0021 refused to
+  make, and the reason this path stayed ungoverned for two weeks. Folding it
+  into `assumed` erases the only operator statement on the path.
+
+  The choice of a path-level default over a per-task label was made from
+  MEASUREMENT, as the ADR required: 10 orchestrator dispatches against 288
+  recipe agent steps over 11 days. On ~3% of traffic an optional per-task label
+  is a field nobody fills, and a mostly-empty declaration channel is worse than
+  none because it looks like coverage.
+
+  **`labelSource` is on the RECEIPT now, not only the shadow row.** It was
+  observed-only from #1397, so the ENFORCING ledger could not distinguish an
+  operator's label from the runtime's fallback — the receipt-shape precondition
+  ADR-0021 set, unmet on the path that already enforced. Adding it meant three
+  edits, not one: the writer type, the `record()` constructor copy, and the
+  reader whitelist in `boundaryReceipts.ts`. That is the same trio `workspaceId`
+  was dropped by (declared twice, copied nowhere) and `forbid` was dropped by on
+  read (#1517).
+
+  **A malformed `privacy.orchestrator.classification` fails OPEN** — deliberate,
+  and asserted by a test so nobody quietly "fixes" it. Failing closed on a typo
+  would refuse every orchestrator task on the machine, automation hooks
+  included, with no hint of the cause in the symptom. A receipt that cannot be
+  WRITTEN does not reopen the boundary: the record is wrapped, the refusal is
+  outside the wrapper.
+
+  **Observation runs BEFORE enforcement.** Reversed, every refused dispatch goes
+  unobserved — dropping from the shadow report precisely the traffic a candidate
+  policy is being evaluated against. `boundaryScope.test.ts` pins the order, and
+  its first version did NOT: it compared the two function DECLARATIONS (which
+  sit in the opposite order and never move) and passed against a deliberately
+  swapped call site. Anchor a source-order guard on the CALL.
 - **Open-core**: engine here (MIT); organisation policy inheritance, retention,
   signed evidence and curated industry policy packs are control-plane
   (ADR-0019). **Never add a policy pack or a real-world policy example here** —

--- a/docs/adr/0021-information-boundary.md
+++ b/docs/adr/0021-information-boundary.md
@@ -127,12 +127,19 @@ before dispatch, with declared labels only. No detection in this ADR.**
 ### The invariant
 
 > No **recipe agent-step** context leaves Patchwork without passing the
-> information-boundary decision point.
+> information-boundary decision point — and, once `privacy.orchestrator` is
+> configured, no **orchestrator task** does either.
 
 The qualifier is load-bearing and was added after the fact — see
 [Scope: what the boundary does NOT cover](#scope-what-the-boundary-does-not-cover)
 below. As originally written this said "no model-bound context", which claimed
 coverage the code does not provide.
+
+The second clause carries a condition and it is not decoration. Orchestrator
+dispatch is enforced only where an operator has classified the channel; on an
+install that has not, the path is observed and ungoverned exactly as before.
+Stating the clause unconditionally would reintroduce, one path over, the
+overbroad-invariant failure this section exists to record.
 
 And, mirroring the never-widen rule the autonomy gate already relies on:
 
@@ -273,6 +280,11 @@ expressed.
 
 Until that exists, the honest statement is the one above: this path is
 ungoverned, and the ADR says so.
+
+**SUPERSEDED 2026-08-30 — the precondition was built. See "Orchestrator
+enforcement" below.** The section above is kept verbatim rather than rewritten,
+because the reasoning it records is the reason the amendment took the shape it
+did. What is no longer true is only its final sentence.
 
 **Observed in shadow since 2026-08-18 (#1397), still not enforced.** The
 objection above is to asserting a DECLARATION nobody made — it is not an
@@ -563,3 +575,94 @@ evidence, which this repository has already recorded as a mistake twice. The
 disclosure and the operator switch are small and can ship once granularity is
 chosen; the prompt, the queue wiring and the display policy wait for a second live
 step or for the scheduled recipes to be enabled.
+
+
+## Amendment 2026-08-30 — orchestrator enforcement, on a path-level default
+
+The section above left orchestrator dispatch out of scope and named exactly what
+would bring it in: *"a per-task label, or a workspace-level default that is
+recorded honestly as a default rather than as a declaration"*, with the receipt
+shape obliged to distinguish `declared` from `assumed`. It then deliberately
+declined to choose between the two, on the grounds that the choice was being
+made from zero measurements and the volume should make it.
+
+**The volume made it.** Measured on the reference machine's
+`privacy_shadow.jsonl`, 19–30 August: **10 orchestrator dispatches against 288
+recipe agent steps**, ~3% of observed traffic, all resolving to a single remote
+destination.
+
+At that share, a per-task label is the wrong instrument. An optional field on a
+free-form prompt is a field that goes unfilled, and a declaration channel which
+is mostly empty is worse than none: it manufactures rows that look like operator
+intent and are not. So the amendment takes the second option.
+
+### What changed
+
+- **`privacy.orchestrator.classification`** — a workspace-level classification
+  for the whole path. Its presence is the opt-in to enforcement. Absent, the
+  path is observed and ungoverned, exactly as it has been since #1397, so no
+  existing install changes behaviour by upgrading.
+- **`labelSource` gains a third value, `default`.** Not a synonym for either
+  existing one. `declared` means an operator classified THIS dispatch;
+  `assumed` means nobody said anything and the runtime fell back; `default`
+  means an operator classified the CHANNEL. Folding `default` into `declared`
+  would assert intent about a prompt no operator saw — the precise claim this
+  ADR refused to make. Folding it into `assumed` would erase the only operator
+  statement on the path and make enforcement look like the runtime helping
+  itself to a label.
+- **`labelSource` is now on the RECEIPT**, not only the shadow row. It was on
+  the shadow ledger from #1397 and absent from the enforcing one, so the log
+  that says what actually happened could not distinguish an operator's label
+  from the runtime's fallback. That was the receipt-shape requirement this ADR
+  set as a precondition, unmet until now on the path that already enforced.
+- **A refused dispatch fails the task** with `InformationBoundaryRefusal`. Not a
+  new lifecycle state: `error` with a named cause, because adding a `refused`
+  status reaches persistence, the dashboard and five MCP tools for a
+  distinction the message already carries.
+
+### What deliberately did NOT change
+
+- **No detection.** Nothing scans a prompt. The classification comes from
+  config; the decision stays a pure function of (classification, destination).
+  The ADR's rejection of detection as a boundary stands unamended.
+- **No per-field labels, no redaction, no purpose.** Those remain deferred
+  behind the same prerequisite — labels on the fields a prompt is assembled
+  from, at render time — which is a recipe-schema change and is still not
+  decided. `ALLOW_REDACTED` still refuses.
+- **Inert by default.** Two independent opt-ins are still required: a registered
+  destination AND the orchestrator key. Either alone enforces nothing.
+
+### Two failure directions, chosen opposite ways
+
+A malformed `privacy.orchestrator.classification` — a typo, an unknown
+classification — resolves to NOT ENFORCING, against the usual fail-closed
+instinct. Failing closed on a misspelling would refuse every orchestrator task
+on the machine, including the automation hooks an operator depends on, and the
+remedy would be invisible from the symptom. `patchwork privacy destinations`
+reports a misconfigured registry; a bridge that dispatches nothing does not.
+
+A receipt that cannot be WRITTEN, by contrast, does not reopen the boundary. The
+record is wrapped; the refusal is outside the wrapper. An enforcement that
+swallows its own errors is an enforcement that silently stops enforcing.
+
+### Ordering, which is load-bearing
+
+The shadow observation runs BEFORE enforcement, so a refused dispatch is still
+observed. A refusal is exactly the traffic a candidate policy is being evaluated
+against; enforcing first would drop those rows and leave the shadow report blind
+to its most interesting case. Relatedly, the shadow row now evaluates against
+the operator's path classification when one exists, and stamps `enforcing: true`
+— it previously hardcoded `false`, which would have told
+`patchwork privacy shadow` that no live policy was enforcing while one was.
+
+### Still open, unchanged by this amendment
+
+`REQUIRE_APPROVAL` remains unreachable — rule 1 returns `LOCAL_ONLY` before
+`approvable` is tested — and an approval expiring at 06:00 against a scheduled
+recipe still has no defensible default. Enforcing a second path does not make
+either question easier, and answering them inside this change would have bundled
+a decision about approval semantics into one about scope.
+
+`src/__tests__/boundaryScope.test.ts` is inverted in the same commit: it now
+fails if orchestrator dispatch LOSES its boundary decision, and still fails if
+the recipe path does, so it cannot pass by both sides being empty.

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -62,6 +62,14 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   either would make the command permanently red. A first run is a BASELINE, never "no changes".
   The snapshot holds counts only, reduced at the collection boundary: two inputs return operator
   data, and a health check is the last place anyone looks for accumulated secrets. — #1552
+- 2026-08-30 `feat/orchestrator-boundary-default` — ADR-0021 left orchestrator dispatch
+  ungoverned and named its own precondition: a path-level default "recorded honestly as a
+  default rather than as a declaration", with the choice between that and a per-task label to
+  be made from measured volume. The volume decided it — 10 orchestrator dispatches against 288
+  recipe agent steps over 11 days, so an optional per-task label is a field nobody fills.
+  `labelSource` gains a third value (`default`) and reaches the RECEIPT, not just the shadow
+  row; the enforcing ledger previously could not tell an operator's label from the runtime's
+  fallback. `boundaryScope.test.ts` is inverted rather than deleted. — PR pending
 
 - 2026-08-28 `fix/pr-outcomes-swallows-the-real-error` — `gh repo view` ran with stderr
   ignored, so an expired credential, a missing gh and a missing remote all reported the same

--- a/src/__tests__/boundaryScope.test.ts
+++ b/src/__tests__/boundaryScope.test.ts
@@ -62,20 +62,44 @@ describe("ADR-0021 scope — the boundary covers the recipe agent-step path", ()
     }
   });
 
-  it("orchestrator dispatch does NOT — and ADR-0021 says so", () => {
+  it("orchestrator dispatch DOES too, since the 2026-08-30 amendment", () => {
+    // INVERTED. This assertion used to require the ABSENCE of a boundary here,
+    // pinning ADR-0021's out-of-scope statement to the code. The amendment
+    // built the precondition that statement named, so the guard flips with it:
+    // the thing that must not silently change is no longer "this path is
+    // ungoverned" but "this path is governed, on an operator's path-level
+    // default".
+    //
+    // The direction matters more than the assertion. A guard that had simply
+    // been DELETED when enforcement landed would have left the path unpinned in
+    // both directions — free to lose its boundary again with nothing failing.
     const orchestrator = read("claudeOrchestrator.ts");
-    for (const marker of BOUNDARY_MARKERS) {
-      expect(
-        mentions(orchestrator, marker),
-        `claudeOrchestrator.ts contains "${marker}", so orchestrator dispatch ` +
-          "is now governed. That is good — but ADR-0021's 'Scope: what the " +
-          "boundary does NOT cover' section now describes something untrue " +
-          "and must be updated in the same change.",
-      ).toBe(false);
-    }
+    expect(
+      mentions(orchestrator, "governOrchestratorDispatch"),
+      "claudeOrchestrator.ts no longer declares governOrchestratorDispatch, " +
+        "so orchestrator dispatch is ungoverned again and ADR-0021's " +
+        "amendment describes something untrue.",
+    ).toBe(true);
+    // The CALL SITE, not just the declaration — the same trap this file's
+    // header records, and the one that left the shadow guard green with the
+    // observation deleted.
+    expect(
+      /governOrchestratorDispatch\s*\(\s*\n?\s*this\.driver/.test(orchestrator),
+      "claudeOrchestrator.ts declares governOrchestratorDispatch but no longer " +
+        "CALLS it at its dispatch point, so every orchestrator task flows " +
+        "unjudged while the ADR says the path is enforced",
+    ).toBe(true);
+    // And it must be able to REFUSE. An enforcement that computes a decision
+    // and never acts on it is the fail-open this whole ADR exists to prevent,
+    // and it looks identical from the outside to one that always allows.
+    expect(
+      mentions(orchestrator, "InformationBoundaryRefusal"),
+      "claudeOrchestrator.ts can no longer refuse a dispatch — the boundary " +
+        "decision is computed and discarded",
+    ).toBe(true);
   });
 
-  it("orchestrator dispatch IS observed in shadow, though not enforced (#1397)", () => {
+  it("orchestrator dispatch IS observed in shadow, alongside enforcement", () => {
     // The pair above only says orchestrator dispatch is not GOVERNED. On its
     // own that is one-sided: deleting the shadow observation would keep it
     // passing, and the privacy report would then show zero orchestrator rows —
@@ -93,9 +117,35 @@ describe("ADR-0021 scope — the boundary covers the recipe agent-step path", ()
         "dispatch point, so `patchwork privacy shadow` will report 0 " +
         "orchestrator rows and read as coverage rather than absence",
     ).toBe(true);
-    // And the observation must stay an OBSERVATION: `enforcing: false` is what
-    // keeps the ADR's out-of-scope statement true.
-    expect(orchestrator).toContain("enforcing: false");
+    // The observation must stay an OBSERVATION — but `enforcing` is no longer
+    // hardcoded. It reports whether a live policy WAS enforcing, which on this
+    // path is now sometimes true, so pinning the literal `false` would pin a
+    // lie. What must hold is that the shadow row still cannot refuse anything:
+    // `recordPrivacyShadow` is the only thing it calls, and the refusal lives
+    // in the other function entirely.
+    expect(orchestrator).toContain(
+      "enforcing: pathClassification !== undefined",
+    );
+    // Observation BEFORE enforcement. Reversed, every refused dispatch would go
+    // unobserved — dropping from the shadow report exactly the traffic a
+    // candidate policy is being evaluated against.
+    //
+    // Anchored on `this.driver`, i.e. the CALL, not the identifier. A first
+    // attempt used plain `indexOf` on the bare name and compared the two
+    // FUNCTION DECLARATIONS instead — which sit in the opposite order and never
+    // move — so it passed against a deliberately swapped call site. Found by
+    // making that swap and watching the guard stay green, not by reading it.
+    const callOf = (name: string) =>
+      orchestrator.search(new RegExp(`${name}\\(\\s*\\n\\s*this\\.driver`));
+    const observeAt = callOf("observeOrchestratorShadow");
+    const governAt = callOf("governOrchestratorDispatch");
+    expect(observeAt).toBeGreaterThan(-1);
+    expect(governAt).toBeGreaterThan(-1);
+    expect(
+      observeAt < governAt,
+      "enforcement now runs before observation, so refused dispatches are " +
+        "never recorded in the shadow ledger",
+    ).toBe(true);
   });
 
   it("the ADR documents the gap rather than leaving the invariant overbroad", () => {
@@ -108,10 +158,22 @@ describe("ADR-0021 scope — the boundary covers the recipe agent-step path", ()
     );
     expect(adr).toContain("Scope: what the boundary does NOT cover");
     expect(adr).toContain("Orchestrator task dispatch is out of scope");
+    // The original scope section stays. It is superseded, not deleted: the
+    // reasoning it records is why the amendment took the shape it did, and a
+    // reader who finds only the outcome cannot tell which alternatives were
+    // rejected or why.
+    expect(adr).toContain(
+      "Amendment 2026-08-30 — orchestrator enforcement, on a path-level default",
+    );
     // The invariant itself must carry the qualifier, not just the prose below
-    // it — the invariant is the line people quote.
+    // it — the invariant is the line people quote. It now names both paths AND
+    // the condition on the second; an unconditional claim here would be the
+    // overbroad invariant this ADR already had to correct once.
     expect(adr).toMatch(
       /No \*\*recipe agent-step\*\* context leaves Patchwork without passing/,
+    );
+    expect(adr).toMatch(
+      /once `privacy\.orchestrator` is\s*\n?> ?configured, no \*\*orchestrator task\*\* does either/,
     );
   });
 });

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -15,7 +15,10 @@ function getConfigDir(): string {
 
 import type { IClaudeDriver } from "./drivers/types.js";
 import { loadConfig as loadPatchworkConfig } from "./patchworkConfig.js";
+import { sharedBoundaryReceiptLog } from "./privacy/boundaryReceiptLog.js";
 import {
+  CLASSIFICATIONS,
+  type Classification,
   DEFAULT_CLASSIFICATION,
   decideBoundary,
 } from "./privacy/dataPolicy.js";
@@ -206,24 +209,34 @@ interface PersistedTask {
 function observeOrchestratorShadow(
   driverName: string | undefined,
   workspace: string | undefined,
+  /**
+   * The operator's PATH-LEVEL classification, if they have opted this path into
+   * enforcement. Passed in rather than re-read so the shadow row and the
+   * receipt describe the SAME dispatch with the same label — the two ledgers
+   * disagreeing about where a classification came from is the failure this
+   * field exists to prevent.
+   */
+  pathClassification: Classification | undefined,
 ): void {
   try {
     const cfg = (
       loadPatchworkConfig() as { privacy?: { shadow?: PrivacyConfig } }
     ).privacy?.shadow;
     if (!cfg) return;
+    // Once an operator has classified this channel, the candidate policy must
+    // be evaluated against THAT label. Continuing to shadow against the
+    // runtime's `internal` fallback would answer a question nobody is asking
+    // any more, and would answer it more permissively than the live policy.
+    const classification = pathClassification ?? DEFAULT_CLASSIFICATION;
     const registry = parseRegistry(cfg);
     const resolved = resolveDestination(
       registry,
       driverName,
-      DEFAULT_CLASSIFICATION,
+      classification,
       {},
     );
     if (!resolved) return;
-    const outcome = decideBoundary(
-      { classification: DEFAULT_CLASSIFICATION },
-      resolved.destination,
-    );
+    const outcome = decideBoundary({ classification }, resolved.destination);
     recordPrivacyShadow({
       ...(currentWorkspaceId(workspace) && {
         workspaceId: currentWorkspaceId(workspace),
@@ -232,15 +245,137 @@ function observeOrchestratorShadow(
       reason: outcome.reason,
       destinationId: resolved.destination.id,
       destinationType: resolved.destination.type,
-      classification: DEFAULT_CLASSIFICATION,
+      classification,
       path: "orchestrator-task",
-      // Always assumed. There is no declared-policy channel on this path, and
-      // saying otherwise would be the claim ADR-0021 refuses to make.
-      labelSource: "assumed",
-      enforcing: false,
+      // `default` when the operator classified the CHANNEL, `assumed` when
+      // nobody said anything and the runtime fell back. Never `declared`: no
+      // operator ever saw this prompt, which is the claim ADR-0021 refuses to
+      // make and the reason `default` is a third value rather than a synonym.
+      labelSource: pathClassification ? "default" : "assumed",
+      // TRUE once the path is governed. Leaving this hardcoded false would tell
+      // `patchwork privacy shadow` that a live policy was not enforcing while
+      // it was — turning a counterfactual report into a false one on exactly
+      // the rows an operator would check after switching enforcement on.
+      enforcing: pathClassification !== undefined,
     });
   } catch {
     // Observation must never disturb the dispatch it observes.
+  }
+}
+
+/**
+ * The class of failure a refused dispatch reports.
+ *
+ * A distinct Error subclass rather than a bare `throw new Error`: `_runTask`'s
+ * catch already distinguishes aborts from everything else, and a refusal is
+ * neither a crashed driver nor a cancellation. Naming it means a reader of the
+ * task list can tell "the boundary stopped this" from "the driver died", which
+ * is the entire operator-facing value of enforcing at all.
+ */
+export class InformationBoundaryRefusal extends Error {
+  constructor(reason: string) {
+    super(`information boundary — ${reason}`);
+    this.name = "InformationBoundaryRefusal";
+  }
+}
+
+/**
+ * Read the operator's PATH-LEVEL classification for orchestrator dispatch.
+ *
+ * Presence of `privacy.orchestrator.classification` is the opt-in to
+ * ENFORCEMENT on this path, and its absence leaves the path exactly as it was:
+ * observed in shadow, never refused. That is deliberate and is the same
+ * inert-until-opted-in posture ADR-0021 requires of the recipe path — no
+ * existing install changes behaviour by upgrading.
+ *
+ * An unparseable or unknown value returns undefined, i.e. NOT ENFORCING. That
+ * direction is chosen against the usual fail-closed instinct because the
+ * failure here is a typo in an optional key: failing closed would refuse every
+ * orchestrator task on the machine — including the automation hooks an operator
+ * relies on — on the strength of a misspelling. `patchwork privacy
+ * destinations` reports the misconfiguration; a dead bridge does not.
+ */
+function orchestratorPathClassification(
+  cfg: { orchestrator?: { classification?: unknown } } | undefined,
+): Classification | undefined {
+  const raw = cfg?.orchestrator?.classification;
+  if (typeof raw !== "string") return undefined;
+  return (CLASSIFICATIONS as readonly string[]).includes(raw)
+    ? (raw as Classification)
+    : undefined;
+}
+
+/**
+ * ENFORCE the information boundary on orchestrator dispatch (ADR-0021
+ * 2026-08-30 amendment, closing the gap #1397 recorded).
+ *
+ * ADR-0021 left this path ungoverned for one stated reason, and it was never
+ * "the wiring is hard": enforcing with the runtime's own `internal` default
+ * would write an affirmative receipt about a label nobody supplied. The ADR
+ * named the precondition — "a per-task label, or a workspace-level default that
+ * is recorded honestly as a default rather than as a declaration" — and left
+ * the choice between them to be made from measured volume rather than taste.
+ *
+ * The volume chose it. Over 11 days the shadow ledger recorded 10 orchestrator
+ * dispatches against 288 recipe agent steps. On a path carrying ~3% of traffic,
+ * an optional per-task label is a field nobody fills, and a declaration channel
+ * that is mostly empty manufactures `assumed` rows wearing a `declared` shape —
+ * worse than no channel, because it looks like coverage.
+ *
+ * So: a workspace-level default, stamped `labelSource: "default"` — a third
+ * value, never folded into either existing one. It says exactly what is true:
+ * an operator classified this CHANNEL, not this prompt.
+ *
+ * Returns normally when the dispatch may proceed, including when nothing is
+ * configured. THROWS to refuse. It must never be made fail-soft like the shadow
+ * observation beside it: an enforcement that swallows its own errors is an
+ * enforcement that silently stops enforcing.
+ */
+function governOrchestratorDispatch(
+  driverName: string | undefined,
+  workspace: string | undefined,
+  classification: Classification | undefined,
+): void {
+  // Not opted in. The path stays observed-but-ungoverned, as it has been
+  // since #1397.
+  if (classification === undefined) return;
+  const cfg = (loadPatchworkConfig() as { privacy?: PrivacyConfig }).privacy;
+  const registry = parseRegistry(cfg);
+  const resolved = resolveDestination(registry, driverName, classification, {});
+  // No destination registered for this driver and classification. The registry
+  // is the opt-in for the boundary as a whole (ADR-0021), so an unregistered
+  // destination is inert here exactly as it is on the recipe path — NOT a
+  // refusal, which would make configuring the orchestrator key alone break
+  // every dispatch.
+  if (!resolved) return;
+  const outcome = decideBoundary({ classification }, resolved.destination);
+  const wsId = currentWorkspaceId(workspace);
+  try {
+    sharedBoundaryReceiptLog().record({
+      ...(wsId && { workspaceId: wsId }),
+      decision: outcome.decision,
+      classification,
+      destinationId: resolved.destination.id,
+      destinationType: resolved.destination.type,
+      reason: outcome.reason,
+      // The precondition ADR-0021 names, in the ledger that says what actually
+      // happened. Never "declared": no operator saw this prompt.
+      labelSource: "default",
+      // No `categories`: a path-level default classifies the CHANNEL, and
+      // category names come from a per-dispatch `data_policy` that this path
+      // by definition does not have. Emitting an empty list would suggest the
+      // categories were examined and found to be none.
+      ...(outcome.redactCategories && {
+        redactCategories: outcome.redactCategories,
+      }),
+    });
+  } catch {
+    // A receipt that cannot be written must not change the decision it
+    // describes. This swallow covers the RECORD only — the refusal below is
+    // outside it, so a broken disk cannot quietly reopen the boundary.
+  }
+  if (outcome.decision !== "ALLOW") {
+    throw new InformationBoundaryRefusal(outcome.reason);
   }
 }
 
@@ -533,9 +668,34 @@ export class ClaudeOrchestrator {
       this.workspace;
 
     try {
-      // Shadow observation only — see observeOrchestratorShadow. Nothing here
-      // can refuse or alter this dispatch; #1397 remains open.
-      observeOrchestratorShadow(this.driver.name, resolvedWorkspace);
+      // Observation first, then enforcement — in that order, deliberately.
+      // The shadow ledger's job is to record what a CANDIDATE policy would have
+      // done, and a refused dispatch is exactly the case a candidate policy is
+      // being evaluated against. Enforcing first would drop the observation for
+      // every refusal, leaving the shadow report blind to the traffic that
+      // matters most to it.
+      //
+      // Read ONCE and handed to both, so the two ledgers cannot describe the
+      // same dispatch with different labels.
+      const pathClassification = orchestratorPathClassification(
+        (
+          loadPatchworkConfig() as {
+            privacy?: { orchestrator?: { classification?: unknown } };
+          }
+        ).privacy,
+      );
+      observeOrchestratorShadow(
+        this.driver.name,
+        resolvedWorkspace,
+        pathClassification,
+      );
+      // May THROW. Caught below as a non-abort error, so the task lands
+      // `error` with the boundary's reason as its message.
+      governOrchestratorDispatch(
+        this.driver.name,
+        resolvedWorkspace,
+        pathClassification,
+      );
       const result = await this.driver.run({
         prompt: task.prompt,
         contextFiles: task.contextFiles,

--- a/src/privacy/__tests__/orchestratorBoundary.test.ts
+++ b/src/privacy/__tests__/orchestratorBoundary.test.ts
@@ -1,0 +1,173 @@
+/**
+ * ADR-0021 (2026-08-30 amendment) — orchestrator dispatch is ENFORCED.
+ *
+ * `boundaryScope.test.ts` pins the wiring by reading the source: that the call
+ * exists, at the dispatch point, before the observation. It cannot tell whether
+ * the boundary actually STOPS anything, because a source-shaped guard passes
+ * against an enforcement that computes a decision and discards it.
+ *
+ * So this file drives a real `ClaudeOrchestrator` with a driver that records
+ * whether it ran. Every test here turns on whether the DRIVER was reached — not
+ * on a status string, and not on a log line — because "the prompt did not leave
+ * this machine" is the only claim the boundary actually makes.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ClaudeOrchestrator } from "../../claudeOrchestrator.js";
+import type { ProviderDriver, ProviderTaskInput } from "../../drivers/types.js";
+
+const noop = () => {};
+
+/** Records whether the prompt ever reached a driver. That is the whole claim. */
+function makeSpyDriver(): { driver: ProviderDriver; ran: () => boolean } {
+  let ran = false;
+  return {
+    ran: () => ran,
+    driver: {
+      name: "remote-driver",
+      async run(_input: ProviderTaskInput) {
+        ran = true;
+        return { text: "dispatched", exitCode: 0, durationMs: 1 };
+      },
+    },
+  };
+}
+
+let home: string;
+let prevHome: string | undefined;
+
+function writeConfig(privacy: unknown): void {
+  writeFileSync(
+    path.join(home, "config.json"),
+    JSON.stringify({ model: "sonnet", privacy }),
+  );
+}
+
+/**
+ * A registry that admits `internal` to a remote destination and refuses
+ * `personal`. Both classifications resolve to the SAME destination, so a test
+ * that flips only the operator's path-level label changes exactly one variable.
+ */
+const REGISTRY = {
+  destinations: {
+    "candidate-remote": {
+      type: "remote",
+      drivers: ["remote-driver"],
+      classifications: ["public", "internal"],
+    },
+  },
+};
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(os.tmpdir(), "pw-orch-boundary-"));
+  prevHome = process.env.PATCHWORK_HOME;
+  process.env.PATCHWORK_HOME = home;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.PATCHWORK_HOME;
+  else process.env.PATCHWORK_HOME = prevHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+async function runOne(prompt = "free-form task"): Promise<{
+  status: string | undefined;
+  errorMessage: string | undefined;
+  ran: boolean;
+}> {
+  const spy = makeSpyDriver();
+  const orch = new ClaudeOrchestrator(spy.driver, home, noop);
+  const task = await orch.runAndWait({ prompt });
+  return {
+    status: task.status,
+    errorMessage: task.errorMessage,
+    ran: spy.ran(),
+  };
+}
+
+describe("orchestrator information boundary", () => {
+  it("refuses a dispatch the operator's path classification does not permit", async () => {
+    writeConfig({ ...REGISTRY, orchestrator: { classification: "personal" } });
+    const r = await runOne();
+    expect(r.ran, "the prompt reached the driver despite being refused").toBe(
+      false,
+    );
+    expect(r.status).toBe("error");
+    expect(r.errorMessage).toContain("information boundary");
+  });
+
+  it("allows the same dispatch when the classification IS permitted", async () => {
+    // The control, and it is not optional. Without it the assertion above
+    // passes just as happily against an orchestrator that refuses everything,
+    // or one whose driver is simply broken — the failure mode that makes a
+    // security test read green while protecting nothing.
+    writeConfig({ ...REGISTRY, orchestrator: { classification: "internal" } });
+    const r = await runOne();
+    expect(r.ran).toBe(true);
+    expect(r.status).toBe("done");
+  });
+
+  it("stays inert when the operator has NOT opted the path in", async () => {
+    // Registry configured, orchestrator key absent. ADR-0021's opt-in posture:
+    // upgrading must not start refusing traffic on an install that never asked
+    // for it. `personal` would be refused if the key were present, so this
+    // pins the ABSENCE of the key as the thing doing the allowing.
+    writeConfig(REGISTRY);
+    const r = await runOne();
+    expect(r.ran).toBe(true);
+    expect(r.status).toBe("done");
+  });
+
+  it("stays inert when no destination is registered at all", async () => {
+    writeConfig({ orchestrator: { classification: "personal" } });
+    const r = await runOne();
+    expect(r.ran).toBe(true);
+    expect(r.status).toBe("done");
+  });
+
+  it("does NOT enforce on an unparseable classification", async () => {
+    // Fail-OPEN, deliberately, and asserted so nobody "fixes" it quietly. A
+    // typo in an optional key must not refuse every orchestrator task on the
+    // machine — including the automation hooks an operator depends on — when
+    // the symptom gives no hint of the cause. Recorded in the ADR amendment.
+    writeConfig({ ...REGISTRY, orchestrator: { classification: "persnoal" } });
+    const r = await runOne();
+    expect(r.ran).toBe(true);
+    expect(r.status).toBe("done");
+  });
+
+  it("writes a receipt stamped `default`, never `declared`", async () => {
+    writeConfig({ ...REGISTRY, orchestrator: { classification: "personal" } });
+    await runOne();
+    const { summariseBoundaryReceipts } = await import(
+      "../boundaryReceipts.js"
+    );
+    const s = summariseBoundaryReceipts({ dir: home });
+    expect(s.recorded).toBe(1);
+    const [receipt] = s.recent;
+    // The precondition ADR-0021 set for enforcing a path with no per-dispatch
+    // label. `declared` here would assert that an operator classified a
+    // free-form prompt they never saw.
+    expect(receipt?.labelSource).toBe("default");
+    expect(receipt?.classification).toBe("personal");
+    expect(receipt?.decision).not.toBe("ALLOW");
+  });
+
+  it("records an ALLOWED dispatch too, so the denominator is real", async () => {
+    // A ledger holding only refusals has its numerator as its denominator and
+    // always reads 100%.
+    writeConfig({ ...REGISTRY, orchestrator: { classification: "internal" } });
+    await runOne();
+    const { summariseBoundaryReceipts } = await import(
+      "../boundaryReceipts.js"
+    );
+    const s = summariseBoundaryReceipts({ dir: home });
+    expect(s.recorded).toBe(1);
+    expect(s.refusals).toBe(0);
+    expect(s.recent[0]?.labelSource).toBe("default");
+  });
+});

--- a/src/privacy/__tests__/productionWiring.test.ts
+++ b/src/privacy/__tests__/productionWiring.test.ts
@@ -54,10 +54,27 @@ describe("the information boundary is wired into production dispatch", () => {
   it("the receipt log is a shared instance, not per call", () => {
     // A per-call instance restarts `seq` at 1 on every dispatch — the same
     // per-instance-counter-on-a-shared-file defect that collided 142 of 145
-    // run-log seqs (#1324). The lazy singleton is what prevents it.
-    const src = read("src/recipes/yamlRunner.ts");
-    expect(src).toMatch(/_boundaryReceiptLogs = new Map/);
-    expect(src).toMatch(/function boundaryReceiptLog\(\)/);
+    // run-log seqs (#1324). The per-directory map is what prevents it.
+    //
+    // It MOVED to `boundaryReceiptLog.ts` when the orchestrator path gained
+    // enforcement: two writers each holding their own map is the very defect
+    // above, so the map has to be shared between them and not copied. The
+    // guard follows it rather than being deleted — the property being pinned
+    // did not change, only its address.
+    const src = read("src/privacy/boundaryReceiptLog.ts");
+    expect(src).toMatch(/_sharedLogs = new Map/);
+    expect(src).toMatch(/function sharedBoundaryReceiptLog\(\)/);
+    // And both writers must go through it. A second `new BoundaryReceiptLog`
+    // in production code would reintroduce the colliding counter silently.
+    for (const f of [
+      "src/recipes/yamlRunner.ts",
+      "src/claudeOrchestrator.ts",
+    ]) {
+      expect(read(f), `${f} builds its own receipt log`).not.toMatch(
+        /new BoundaryReceiptLog\(/,
+      );
+      expect(read(f)).toMatch(/sharedBoundaryReceiptLog\(\)/);
+    }
   });
 
   it("reads config per call so an edit takes effect without a restart", () => {

--- a/src/privacy/boundaryReceiptLog.ts
+++ b/src/privacy/boundaryReceiptLog.ts
@@ -30,7 +30,10 @@
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+import { patchworkPath } from "../patchworkHome.js";
+
 import type { BoundaryDecision, Classification } from "./dataPolicy.js";
+import type { LabelSource } from "./shadowLog.js";
 
 /**
  * Writer-stamped record level for this ledger.
@@ -106,6 +109,20 @@ export interface BoundaryReceipt {
    * exists when it does not.
    */
   recipeName?: string;
+  /**
+   * Where `classification` came from — see `LabelSource` in `shadowLog.ts`.
+   *
+   * ADR-0021 makes this the PRECONDITION for enforcing a path that has no
+   * per-dispatch label: a workspace-level default must be "recorded honestly as
+   * a default rather than as a declaration". Without this field on the RECEIPT
+   * (not merely on the shadow row), an enforced orchestrator decision would
+   * assert that an operator classified a free-form prompt they never saw.
+   *
+   * Optional on the type because rows written before the field exist without
+   * it, and that absence is not `assumed` — it is "this writer did not say".
+   * Never defaulted on read.
+   */
+  labelSource?: LabelSource;
   /** Short workspace id — a tag for attribution, never a filter. */
   workspaceId?: string;
 }
@@ -125,6 +142,7 @@ export interface RecordBoundaryReceiptInput {
   redactCategories?: string[];
   reason: string;
   recipeName?: string;
+  labelSource?: LabelSource;
   workspaceId?: string;
 }
 
@@ -209,6 +227,11 @@ export class BoundaryReceiptLog {
         ? { redactCategories: input.redactCategories }
         : {}),
       ...(input.recipeName ? { recipeName: input.recipeName } : {}),
+      // Copied HERE as well as declared on both types. `workspaceId` was
+      // declared on both and never copied by this constructor, so it could not
+      // appear on a receipt from any bridge — the defect the comment below
+      // records. A new field is one omission away from repeating it.
+      ...(input.labelSource ? { labelSource: input.labelSource } : {}),
       // Both types have declared `workspaceId` since #1455 and the caller has
       // been passing it since; this constructor never copied it, so the field
       // could not appear on a receipt from any bridge, in any working
@@ -249,4 +272,32 @@ export class BoundaryReceiptLog {
     for (const r of this.receipts) out[r.decision]++;
     return out;
   }
+}
+
+const _sharedLogs = new Map<string, BoundaryReceiptLog>();
+
+/**
+ * The receipt log for the CURRENT patchwork home, one instance per directory.
+ *
+ * Lifted out of `yamlRunner` when the orchestrator path gained enforcement
+ * (ADR-0021 2026-08-30 amendment), because two writers each holding their own
+ * instance is the bug this shape already exists to prevent: `seq` is a
+ * per-INSTANCE counter over a shared file, and a second instance restarts it at
+ * 1 — the collision that put 142 of 145 run-log seqs on top of each other
+ * (#1324). Sharing the map is the whole point of extracting it; copying the
+ * helper into the orchestrator would have reproduced the defect its own comment
+ * warns about.
+ *
+ * Keyed by resolved directory, NOT a plain singleton: a singleton captures
+ * whichever home existed at first use and then ignores `PATCHWORK_HOME`, the
+ * frozen-at-first-use defect of #1265 and #1266.
+ */
+export function sharedBoundaryReceiptLog(): BoundaryReceiptLog {
+  const dir = patchworkPath();
+  let log = _sharedLogs.get(dir);
+  if (!log) {
+    log = new BoundaryReceiptLog({ dir });
+    _sharedLogs.set(dir, log);
+  }
+  return log;
 }

--- a/src/privacy/boundaryReceipts.ts
+++ b/src/privacy/boundaryReceipts.ts
@@ -40,6 +40,7 @@ import path from "node:path";
 
 import { patchworkPath } from "../patchworkHome.js";
 import type { BoundaryDecision, Classification } from "./dataPolicy.js";
+import type { LabelSource } from "./shadowLog.js";
 
 export const BOUNDARY_RECEIPTS_BASENAME = "boundary_receipts.jsonl";
 
@@ -78,6 +79,13 @@ export interface BoundaryReceiptView {
   redactCategories?: string[];
   reason: string;
   recipeName?: string;
+  /**
+   * Where the classification came from. Carried through because this reader
+   * copies a WHITELIST — a field added to the writer and not added here is
+   * silently dropped on read, which is #1517's defect exactly and was caught
+   * last time only because someone checked.
+   */
+  labelSource?: LabelSource;
   workspaceId?: string;
 }
 
@@ -138,6 +146,11 @@ function view(r: Record<string, unknown>): BoundaryReceiptView | null {
       ? (r[k] as unknown[]).filter((x): x is string => typeof x === "string")
       : undefined;
   const dt = str("destinationType");
+  const rawLabel = str("labelSource");
+  const lbl: LabelSource | undefined =
+    rawLabel === "declared" || rawLabel === "assumed" || rawLabel === "default"
+      ? rawLabel
+      : undefined;
   return {
     ...(typeof r.seq === "number" ? { seq: r.seq } : {}),
     // `rv` and `correlationId` are copied EXPLICITLY because this literal
@@ -160,6 +173,10 @@ function view(r: Record<string, unknown>): BoundaryReceiptView | null {
       : {}),
     reason: str("reason") ?? "",
     ...(str("recipeName") ? { recipeName: str("recipeName") } : {}),
+    // Validated against the union, not copied as any string: this reader hands
+    // rows to a formatter, and an arbitrary on-disk value reaching a caller
+    // typed as `LabelSource` would be a lie the type system then propagates.
+    ...(lbl ? { labelSource: lbl } : {}),
     ...(str("workspaceId") ? { workspaceId: str("workspaceId") } : {}),
   };
 }

--- a/src/privacy/shadowLog.ts
+++ b/src/privacy/shadowLog.ts
@@ -55,17 +55,30 @@ export const PATH_LABELS: Record<ShadowPath, string> = {
 };
 
 /**
- * Whether the classification on a row was DECLARED by an operator or ASSUMED
- * by the runtime.
+ * Where the classification on a row CAME FROM.
  *
  * This is the difference between a measurement and a claim about intent.
- * `orchestrator-task` has no declared-policy channel at all (ADR-0021), so
- * every one of its rows is assumed — and a recipe step with no `data_policy`
- * is assumed too, since `internal` there is a default and not a declaration.
- * Merging the two would let a report say an operator classified something they
- * never labelled.
+ *
+ * - `declared` — the dispatch itself carried a `data_policy`. An operator
+ *   classified THIS step.
+ * - `assumed` — nothing was declared and nothing configured; the runtime fell
+ *   back to `internal`. Nobody said anything, and the row must not pretend
+ *   otherwise. A recipe step with no `data_policy` is assumed, since `internal`
+ *   there is a default and not a declaration.
+ * - `default` — an operator configured a workspace-level classification for the
+ *   whole PATH (`privacy.orchestrator`, ADR-0021 2026-08-30 amendment). A real
+ *   operator statement, but about the channel rather than about this dispatch's
+ *   contents, so it is neither of the other two.
+ *
+ * Three values rather than two because ADR-0021 makes the distinction the
+ * PRECONDITION for enforcing the orchestrator path: "a workspace-level default
+ * that is recorded honestly as a default rather than as a declaration". Folding
+ * `default` into `declared` would let a report claim an operator classified a
+ * free-form prompt they never saw; folding it into `assumed` would erase the
+ * only operator statement on that path and make the enforcement look like the
+ * runtime helping itself to a label.
  */
-export type LabelSource = "declared" | "assumed";
+export type LabelSource = "declared" | "assumed" | "default";
 
 /** @deprecated kept so older rows still render; use PATH_LABELS. */
 export const OBSERVED_PATH = PATH_LABELS["recipe-agent-step"];
@@ -215,6 +228,18 @@ export interface PrivacyShadowSummary {
    * to explain the remainder.
    */
   assumedUnattributed: number;
+  /**
+   * Rows whose classification came from a PATH-LEVEL operator default
+   * (`labelSource: "default"`), not from the dispatch and not from the runtime.
+   *
+   * Counted separately from `assumed` rather than folded into it. An assumed
+   * row is outstanding work — the remedy is to declare a `data_policy`. A
+   * defaulted row is a decision an operator already made, and listing it as
+   * work to do would send them to re-make it. It is reported rather than left
+   * silent because a value that appears in the ledger and in no summary is
+   * indistinguishable, to a reader, from one that never occurs.
+   */
+  defaulted: number;
   observedPath: string;
   unobservedPaths: readonly string[];
 }
@@ -237,6 +262,7 @@ export function summarisePrivacyShadow(
     assumed: 0,
     assumedByRecipe: {},
     assumedUnattributed: 0,
+    defaulted: 0,
     observedPath: OBSERVED_PATH,
     unobservedPaths: UNOBSERVED_PATHS,
   };
@@ -281,6 +307,7 @@ export function summarisePrivacyShadow(
         summary.assumedUnattributed += 1;
       }
     }
+    if (row.labelSource === "default") summary.defaulted += 1;
     if (row.enforcing) summary.enforcingObservations += 1;
     summary.byDecision[row.decision] =
       (summary.byDecision[row.decision] ?? 0) + 1;
@@ -368,6 +395,16 @@ export function formatPrivacyShadow(s: PrivacyShadowSummary): string {
         `    ${String(s.assumedUnattributed).padStart(5)}  (not attributed to a recipe — orchestrator dispatches and rows written before attribution)`,
       );
     }
+  }
+  if (s.defaulted > 0) {
+    // Distinct line, distinct wording. These rows are NOT on the to-do list
+    // above: a path-level default is an operator decision already taken, and
+    // listing it as unlabelled work would send them to make it twice. Reported
+    // rather than silent, because a label that appears in the ledger and in no
+    // summary reads to the operator as one that never occurs.
+    L.push(
+      `  defaulted:  ${s.defaulted} of ${s.observed} row(s) classified by a PATH-LEVEL operator default (not per-dispatch)`,
+    );
   }
   if (s.enforcingObservations > 0) {
     L.push(

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -78,6 +78,13 @@ export interface AgentExecutorDeps {
     classification: string;
     categories?: string[];
     redactCategories?: string[];
+    /**
+     * Where `classification` came from. The shadow ledger has distinguished
+     * declared from assumed since #1397; the RECEIPT did not, so the enforced
+     * ledger — the one that says what actually happened — could not tell an
+     * operator's label from the runtime's fallback.
+     */
+    labelSource?: "declared" | "assumed" | "default";
   }) => void;
   /**
    * CANDIDATE policy for shadow mode (ADR-0021), deliberately a SEPARATE
@@ -96,7 +103,7 @@ export interface AgentExecutorDeps {
     destinationType: "local" | "remote";
     classification: Classification;
     path?: "recipe-agent-step" | "orchestrator-task";
-    labelSource?: "declared" | "assumed";
+    labelSource?: "declared" | "assumed" | "default";
     categories?: string[];
     redactCategories?: string[];
     enforcing: boolean;
@@ -531,6 +538,10 @@ export async function executeAgent(
       destinationId: boundary.destination.id,
       destinationType: boundary.destination.type,
       classification: boundary.classification,
+      // Same expression as the shadow observation above, deliberately: the two
+      // ledgers describing one dispatch must not disagree about where its label
+      // came from.
+      labelSource: input.boundary?.dataPolicy ? "declared" : "assumed",
       ...(boundary.categories && { categories: boundary.categories }),
       ...(boundary.redactCategories && {
         redactCategories: boundary.redactCategories,
@@ -582,6 +593,7 @@ export async function executeAgent(
       destinationId: boundary.destination.id,
       destinationType: boundary.destination.type,
       classification: boundary.classification,
+      labelSource: input.boundary?.dataPolicy ? "declared" : "assumed",
       ...(boundary.categories && { categories: boundary.categories }),
     });
   }

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -118,7 +118,10 @@ import { evaluateWhen } from "./whenGuard.js";
 import { resolveWorkspaceRoot } from "./workspaceRoot.js";
 import "./tools/index.js";
 import { patchworkPath } from "../patchworkHome.js";
-import { BoundaryReceiptLog } from "../privacy/boundaryReceiptLog.js";
+import {
+  type BoundaryReceiptLog,
+  sharedBoundaryReceiptLog,
+} from "../privacy/boundaryReceiptLog.js";
 import type {
   BoundaryDecision as BoundaryDecisionValue,
   Classification as ClassificationValue,
@@ -3634,7 +3637,7 @@ function toAgentResult(v: string | AgentResult): AgentResult {
  * the same per-instance-counter-on-a-shared-file defect that made 142 of 145
  * run-log seqs collide (#1324).
  */
-const _boundaryReceiptLogs = new Map<string, BoundaryReceiptLog>();
+
 /**
  * Short id of the workspace this process is operating in, for evidence
  * attribution (`src/workspaceId.ts`). Resolved per call rather than captured:
@@ -3674,25 +3677,10 @@ function evidenceWorkspaceId(startDir?: string): string | undefined {
 }
 
 function boundaryReceiptLog(): BoundaryReceiptLog {
-  // Keyed BY RESOLVED DIRECTORY, not a single instance.
-  //
-  // A plain singleton captures whichever home existed at first use and ignores
-  // PATCHWORK_HOME afterwards — the same frozen-at-first-use defect as the
-  // module-level RECIPES_DIR (#1265) and the OAuth redirect URI (#1266),
-  // reintroduced by the fix for it. Caught because an end-to-end test set a
-  // fresh home and its receipts went to the previous one.
-  //
-  // Still one instance PER DIRECTORY, which is the property that matters: a
-  // per-call instance would restart `seq` at 1 on every dispatch, the
-  // counter-on-a-shared-file bug that collided 142 of 145 run-log seqs
-  // (#1324).
-  const dir = patchworkPath();
-  let log = _boundaryReceiptLogs.get(dir);
-  if (!log) {
-    log = new BoundaryReceiptLog({ dir });
-    _boundaryReceiptLogs.set(dir, log);
-  }
-  return log;
+  // Delegates to the shared per-directory instance in `boundaryReceiptLog.ts`.
+  // It used to live here; the orchestrator path now writes receipts too, and
+  // two independent instances over one file restart `seq` against each other.
+  return sharedBoundaryReceiptLog();
 }
 
 function buildAgentExecutorDeps(
@@ -3800,6 +3788,12 @@ function buildAgentExecutorDeps(
           destinationId: r.destinationId,
           destinationType: r.destinationType,
           reason: r.reason,
+          // Carried from the executor, which already computes it for the shadow
+          // row. Both ledgers describe the same dispatch, so a receipt that
+          // omitted this would leave the ENFORCING log unable to say what the
+          // observing one could — the same asymmetry #1469 left behind for
+          // `recipeName`.
+          ...(r.labelSource && { labelSource: r.labelSource }),
           ...(r.categories && { categories: r.categories }),
           ...(r.redactCategories && { redactCategories: r.redactCategories }),
         });


### PR DESCRIPTION
ADR-0021 left orchestrator dispatch ungoverned and named its own precondition: *"a per-task label, or a workspace-level default that is recorded honestly as a default rather than as a declaration"*, with the receipt shape obliged to distinguish `declared` from `assumed`. It then deliberately declined to choose between the two options, on the grounds that the choice was being made from zero measurements and the volume should make it.

## The volume made it

Measured on `privacy_shadow.jsonl`, 19–30 August: **10 orchestrator dispatches against 288 recipe agent steps** — ~3% of observed traffic.

At that share a per-task label is the wrong instrument. An optional field on a free-form prompt goes unfilled, and a declaration channel that is mostly empty is worse than none: it manufactures rows that look like operator intent and are not.

## What changed

- **`privacy.orchestrator.classification`** — a path-level default. Its presence is the opt-in to enforcement; absent, the path stays observed-and-ungoverned exactly as since #1397, so no existing install changes behaviour by upgrading.
- **`labelSource` gains a third value, `default`** — not a synonym. `declared` = an operator classified THIS dispatch. `assumed` = nobody said anything and the runtime fell back. `default` = an operator classified the CHANNEL. Folding `default` into `declared` asserts intent about a prompt no operator saw, which is the claim ADR-0021 refused to make and the reason this path stayed open.
- **`labelSource` now reaches the RECEIPT**, not only the shadow row. It was observe-only from #1397, so the *enforcing* ledger could not tell an operator's label from the runtime's fallback — this ADR's own receipt-shape precondition, unmet on the path that already enforced. Three edits, not one: writer type, `record()` constructor copy, reader whitelist. That is the trio `workspaceId` was dropped by and `forbid` was dropped by on read (#1517); each leg is mutation-checked.
- **A refused dispatch fails the task** with `InformationBoundaryRefusal` — an `error` with a named cause, not a new lifecycle state (a `refused` status reaches persistence, the dashboard and five MCP tools for a distinction the message already carries).
- **The receipt log moved to `boundaryReceiptLog.ts` and is shared.** Two writers each holding their own instance is the per-instance-counter-on-a-shared-file defect that collided 142 of 145 run-log seqs; copying the helper into the orchestrator would have reproduced the bug its own comment warns about.

## Deliberately unchanged

No detection. No per-field labels, redaction or purpose — still deferred behind the same undecided recipe-schema prerequisite. `ALLOW_REDACTED` still refuses. `REQUIRE_APPROVAL` is still unreachable. Two independent opt-ins are still required: a registered destination **and** the orchestrator key.

## Two failure directions, chosen opposite ways

A malformed `classification` fails **open**, and a test asserts it so nobody quietly "fixes" it: failing closed on a typo would refuse every orchestrator task on the machine, automation hooks included, with nothing in the symptom pointing at the cause. A receipt that cannot be **written** does not reopen the boundary — the record is wrapped, the refusal sits outside the wrapper.

## Verification

`src/privacy/__tests__/orchestratorBoundary.test.ts` drives a real `ClaudeOrchestrator` with a spy driver; every assertion turns on **whether the driver was reached**, not on a status string. It carries a control (the same dispatch, permitted, must run) — without it the refusal test passes just as happily against an orchestrator that refuses everything.

Mutation-checked rather than assumed. Removing the refusal, mislabelling `default` as `declared`, dropping the reader whitelist line, and dropping the writer constructor copy each turn the suite red.

`boundaryScope.test.ts` is **inverted, not deleted** — deleting it would unpin the path in both directions. Its ordering assertion was wrong on the first attempt: it compared the two function *declarations*, which sit in the opposite order and never move, and passed against a deliberately swapped call site. Found by making the swap and watching it stay green.

Full suite: 10537 passed. All audit gates pass except `audit-companion-pins`, which is red on `main` and is what #1551 exists to fix — untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)