### PR TITLE
fix(privacy): "approvable" can be set, and never asked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,6 +594,18 @@ worker may DO; this answers what a destination may RECEIVE.
   presenting as total enforcement.
 - **Precedence `privacy → capability → cost`**, not negotiable by later stages.
   A cheaper or more capable model does not become authorised by being cheaper.
+- **`approvable: true` on a remote destination is a DEAD KNOB on the recommended
+  config shape**, and the claim that `REQUIRE_APPROVAL` is *unreachable* is
+  WRONG — it was carried in handoff notes and repeated three times before anyone
+  checked. It fires whenever no local destination accepts the classification.
+  What is true is narrower and worse: rule 1 tests `LOCAL_ONLY` BEFORE
+  `approvable`, so with a permissive local destination (which is what the
+  reference machine runs) the flag can never fire, and the operator who asked to
+  be asked is REFUSED instead — `LOCAL_ONLY` declines rather than rerouting.
+  Reported by `patchwork privacy destinations`, deliberately NOT fixed by
+  reordering: `narrowest()` ranks `REQUIRE_APPROVAL` stricter than `LOCAL_ONLY`
+  while the runtime behaves the opposite way, so reordering makes live traffic
+  newly approvable and needs a decision rather than a patch.
 - **Five decisions**: `ALLOW` · `ALLOW_REDACTED` · `LOCAL_ONLY` ·
   `REQUIRE_APPROVAL` · `DENY`. Pure function of (declared classification,
   destination policy) — no model in the loop. `narrowest()` enforces never-widen.

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -86,6 +86,13 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   repo, so it cannot run in CI, and it only sees a staged diff). Digit requirement in the
   Slack pattern is load-bearing — without it the gate fires on COMPLETED / CONSEQUENCE /
   CONVERSION, which occur legitimately nine times. — PR pending
+- 2026-08-30 `fix/approvable-is-a-dead-knob` — `approvable: true` can be set on a remote
+  destination and never fire. Rule 1 tests `LOCAL_ONLY` before `approvable`, so with a
+  permissive local destination (the recommended shape) the operator who asked to be asked is
+  REFUSED instead — `LOCAL_ONLY` declines rather than rerouting. Reported by `privacy
+  destinations`, deliberately NOT fixed by reordering, which would make live traffic newly
+  approvable. Also corrects a claim repeated three times from handoff notes without checking:
+  `REQUIRE_APPROVAL` is NOT unreachable. — PR pending
 
 - 2026-08-28 `fix/pr-outcomes-swallows-the-real-error` — `gh repo view` ran with stderr
   ignored, so an expired credential, a missing gh and a missing remote all reported the same

--- a/src/privacy/__tests__/approvableIsInert.test.ts
+++ b/src/privacy/__tests__/approvableIsInert.test.ts
@@ -1,0 +1,163 @@
+/**
+ * `approvable: true` can be set and never asked (ADR-0021).
+ *
+ * The claim carried in the handoff notes — and repeated into ADR-0024 — was that
+ * `REQUIRE_APPROVAL` is *unreachable*, because rule 1 returns `LOCAL_ONLY`
+ * before `approvable` is tested. That is not quite right, and the difference
+ * matters enough to pin:
+ *
+ *   - `REQUIRE_APPROVAL` IS reachable. It fires whenever an uncleared
+ *     destination is `approvable` and no local destination accepts the
+ *     classification.
+ *   - What is true is narrower and worse: on a registry with a permissive
+ *     LOCAL destination — which is the shape the docs recommend and the shape
+ *     the reference machine runs — the `approvable` flag on a remote
+ *     destination can NEVER fire. `localDestinationAccepts` is then always
+ *     true, so rule 1 short-circuits every time.
+ *
+ * So an operator sets `approvable: true`, expecting to be asked, and is never
+ * asked. They are refused instead, because `LOCAL_ONLY` does not reroute — it
+ * declines with a suggestion. A config knob that silently does nothing is worse
+ * than an absent one: it reads as a control that is in place.
+ *
+ * These tests describe the CURRENT behaviour deliberately. They are not a
+ * demand that the ordering change — see the report guard below for why that is
+ * a separate decision — they exist so the ordering cannot change by accident,
+ * in either direction, without someone reading this.
+ */
+import { describe, expect, it } from "vitest";
+
+import { type Destination, decideBoundary, narrowest } from "../dataPolicy.js";
+import {
+  describeDestinations,
+  formatDestinationsReport,
+} from "../describeDestinations.js";
+
+const REMOTE_APPROVABLE: Destination = {
+  id: "hosted",
+  type: "remote",
+  classifications: ["public", "internal"],
+  approvable: true,
+};
+
+describe("approvable on a remote destination", () => {
+  it("is INERT when a local destination accepts the classification", () => {
+    // The reference-machine shape: a local destination cleared for everything.
+    const outcome = decideBoundary(
+      { classification: "personal" },
+      REMOTE_APPROVABLE,
+      { localDestinationAccepts: true },
+    );
+    // Not REQUIRE_APPROVAL. The operator asked to be asked and will not be.
+    expect(outcome.decision).toBe("LOCAL_ONLY");
+    // And the reason does not mention approval at all, so the report gives no
+    // hint that the flag they set was passed over.
+    expect(outcome.reason).not.toMatch(/approv/i);
+  });
+
+  it("DOES fire when no local destination accepts it", () => {
+    // The control. Without it the assertion above would pass equally against a
+    // build where REQUIRE_APPROVAL had been deleted outright, which is the
+    // stronger claim the handoff note actually made.
+    const outcome = decideBoundary(
+      { classification: "personal" },
+      REMOTE_APPROVABLE,
+      { localDestinationAccepts: false },
+    );
+    expect(outcome.decision).toBe("REQUIRE_APPROVAL");
+  });
+
+  it("rule 1 returns the LESS restrictive of the two candidates", () => {
+    // Recorded because it is the part that looks like a defect and is not
+    // obviously one. `narrowest()` in this same module exists to stop a later
+    // stage widening an earlier decision, and ranks REQUIRE_APPROVAL (3) as
+    // stricter than LOCAL_ONLY (2) — yet rule 1 hands back LOCAL_ONLY first.
+    //
+    // Whether that ranking is right is genuinely unclear, which is why nothing
+    // is being changed here: in EFFECT today LOCAL_ONLY is the stricter of the
+    // two, because it refuses outright and no approval unlocks it, while
+    // REQUIRE_APPROVAL can be unlocked by a human. The ranking describes
+    // intent; the runtime describes behaviour; they disagree. Reordering rule 1
+    // to match the ranking would make live traffic newly approvable — an
+    // enforcement change, not a tidy-up.
+    const localOnly = decideBoundary(
+      { classification: "personal" },
+      REMOTE_APPROVABLE,
+      { localDestinationAccepts: true },
+    );
+    const requireApproval = decideBoundary(
+      { classification: "personal" },
+      REMOTE_APPROVABLE,
+      { localDestinationAccepts: false },
+    );
+    // narrowest() would pick REQUIRE_APPROVAL; rule 1 picked LOCAL_ONLY.
+    expect(narrowest(localOnly, requireApproval).decision).toBe(
+      "REQUIRE_APPROVAL",
+    );
+    expect(localOnly.decision).toBe("LOCAL_ONLY");
+  });
+});
+
+describe("the report says so, since the runtime will not", () => {
+  const LOCAL_PERMISSIVE: Destination = {
+    id: "local-models",
+    type: "local",
+    classifications: [
+      "public",
+      "internal",
+      "personal",
+      "confidential",
+      "restricted",
+    ],
+  };
+
+  it("flags an approvable remote destination that can never be asked", () => {
+    const described = describeDestinations(
+      [LOCAL_PERMISSIVE, REMOTE_APPROVABLE],
+      new Map(),
+    );
+    const hosted = described.find((d) => d.id === "hosted");
+    expect(hosted?.approvable).toBe(true);
+    expect(hosted?.approvalUnreachable).toBe(true);
+    const report = formatDestinationsReport(described);
+    expect(report).toMatch(/can NEVER fire/);
+    // It must say what happens INSTEAD. "Your flag is inert" leaves an operator
+    // guessing whether they are protected more or less than they thought.
+    expect(report).toMatch(/REFUSED, not asked/);
+  });
+
+  it("does NOT flag it when approval is genuinely reachable", () => {
+    // The control. Same remote destination, but the local one is cleared for
+    // nothing it refuses, so rule 1 cannot short-circuit and `approvable` does
+    // real work. Without this the assertion above passes against a build that
+    // flags every approvable destination unconditionally.
+    const narrowLocal: Destination = {
+      id: "local-models",
+      type: "local",
+      classifications: ["public"],
+    };
+    const described = describeDestinations(
+      [narrowLocal, REMOTE_APPROVABLE],
+      new Map(),
+    );
+    expect(described.find((d) => d.id === "hosted")?.approvalUnreachable).toBe(
+      false,
+    );
+    expect(formatDestinationsReport(described)).not.toMatch(/can NEVER fire/);
+  });
+
+  it("does NOT flag a destination that never set approvable", () => {
+    const plain: Destination = {
+      id: "hosted",
+      type: "remote",
+      classifications: ["public", "internal"],
+    };
+    const described = describeDestinations(
+      [LOCAL_PERMISSIVE, plain],
+      new Map(),
+    );
+    expect(described.find((d) => d.id === "hosted")?.approvalUnreachable).toBe(
+      false,
+    );
+  });
+});

--- a/src/privacy/dataPolicy.ts
+++ b/src/privacy/dataPolicy.ts
@@ -115,6 +115,30 @@ export interface BoundaryOutcome {
  * Rule 1 runs FIRST and is not reachable past. A destination cannot become
  * cleared by redacting a category, because the classification is a property of
  * the step as a whole — dropping a tag does not declassify what remains.
+ *
+ * ## The LOCAL_ONLY / REQUIRE_APPROVAL ordering inside rule 1
+ *
+ * The `LOCAL_ONLY` branch is tested BEFORE `approvable`, so on a registry with
+ * a permissive local destination — the shape the docs recommend — an
+ * `approvable: true` remote destination is never asked about for any
+ * classification it refuses. The operator set a control expecting to be asked
+ * and is REFUSED instead, because `LOCAL_ONLY` declines rather than rerouting.
+ *
+ * This is NOT the same as "REQUIRE_APPROVAL is unreachable", which is the
+ * stronger claim that has been written down elsewhere and is wrong: it fires
+ * whenever no local destination accepts the classification. Pinned in
+ * `__tests__/approvableIsInert.test.ts`, in both directions.
+ *
+ * Deliberately NOT reordered here. Note that `narrowest()` below ranks
+ * `REQUIRE_APPROVAL` (3) as stricter than `LOCAL_ONLY` (2), so rule 1 returns
+ * the LESS restrictive of its two candidates — which looks like a defect and
+ * may not be one. In EFFECT today `LOCAL_ONLY` is the stricter of the two,
+ * because it refuses outright and no approval unlocks it, while
+ * `REQUIRE_APPROVAL` can be unlocked by a human. The ranking describes intent,
+ * the runtime describes behaviour, and they disagree. Reordering would make
+ * live traffic newly approvable — an enforcement change, not a tidy-up — so it
+ * needs a decision, not a patch. `patchwork privacy destinations` reports the
+ * dead flag in the meantime.
  */
 export function decideBoundary(
   policy: DataPolicy,

--- a/src/privacy/describeDestinations.ts
+++ b/src/privacy/describeDestinations.ts
@@ -60,6 +60,27 @@ export interface DescribedDestination {
    * the one that sends data an operator may not expect to leave the machine.
    */
   sendsSensitiveOffMachine: boolean;
+  /** The operator set `approvable: true` on this destination. */
+  approvable: boolean;
+  /**
+   * True when `approvable` is set and can NEVER fire.
+   *
+   * `decideBoundary` rule 1 short-circuits to `LOCAL_ONLY` before it tests
+   * `approvable`, whenever some registered LOCAL destination is cleared for the
+   * classification in question. So on a registry with a permissive local
+   * destination — the shape the docs recommend — an `approvable` remote
+   * destination is never asked about for ANY classification it refuses.
+   *
+   * Reported rather than fixed. The operator set a control expecting to be
+   * asked, and is refused instead, because `LOCAL_ONLY` declines rather than
+   * rerouting. A knob that silently does nothing is worse than an absent one:
+   * it reads as a control that is in place.
+   *
+   * Computed with the SAME predicate the runtime uses (`some local destination
+   * is cleared for this classification`), not a re-derivation — two notions of
+   * reachability would drift, and the drift would be silent and reassuring.
+   */
+  approvalUnreachable: boolean;
   note?: string;
   noteReviewedOn?: string;
   /** True when a note exists but carries no reviewed date, or an unparseable one. */
@@ -93,12 +114,28 @@ export function describeDestinations(
     const dated =
       note?.noteReviewedOn !== undefined &&
       !Number.isNaN(Date.parse(note.noteReviewedOn));
+    // Every classification this destination would REFUSE. If a local
+    // destination accepts all of them, rule 1 short-circuits every time and the
+    // `approvable` flag is dead.
+    const refused = ALL_CLASSIFICATIONS.filter(
+      (c) => !d.classifications.includes(c),
+    );
+    const localAcceptsAllRefused =
+      refused.length > 0 &&
+      refused.every((c) =>
+        destinations.some(
+          (x) => x.type === "local" && x.classifications.includes(c),
+        ),
+      );
     out.push({
       id: d.id,
       type: d.type,
       cleared,
       drivers: driversFor.get(d.id) ?? [],
       sendsSensitiveOffMachine: d.type === "remote" && sensitive,
+      approvable: d.approvable === true,
+      approvalUnreachable:
+        d.approvable === true && d.type === "remote" && localAcceptsAllRefused,
       ...(note?.note !== undefined && { note: note.note }),
       ...(note?.noteReviewedOn !== undefined && {
         noteReviewedOn: note.noteReviewedOn,
@@ -165,6 +202,21 @@ export function formatDestinationsReport(
       );
       L.push(`        own choice, and the one that sends personal data to a`);
       L.push(`        third party's servers.`);
+    }
+    if (d.approvalUnreachable) {
+      // Louder than a note, because the operator believes a control is in
+      // place. Says what will happen INSTEAD — being refused is not what
+      // "approvable" led them to expect, and `LOCAL_ONLY` declines rather than
+      // rerouting, so nothing asks and nothing reaches the local destination
+      // either.
+      L.push(`      ⚠ "approvable" is set here and can NEVER fire: a local`);
+      L.push(
+        `        destination accepts every classification this one refuses,`,
+      );
+      L.push(
+        `        so the decision short-circuits to LOCAL_ONLY first. You will`,
+      );
+      L.push(`        be REFUSED, not asked.`);
     }
     if (d.note !== undefined) {
       L.push(`      note: ${d.note}`);


### PR DESCRIPTION
An operator who sets `approvable: true` on a remote destination is telling the boundary to ask a human before refusing. **On the config shape the docs recommend, they are never asked.**

`decideBoundary` rule 1 tests the `LOCAL_ONLY` branch before it tests `approvable`, and `localDestinationAccepts` is true for every classification whenever a permissive local destination is registered — which is exactly what the reference machine runs. The flag is dead, silently.

Worse than dead: `LOCAL_ONLY` **declines rather than rerouting**. So the operator who asked to be asked is refused instead, and nothing reaches the local destination either. A knob that silently does nothing is worse than an absent one, because it reads as a control that is in place.

## It also corrects a claim I repeated three times without checking

The handoff notes said *"`REQUIRE_APPROVAL` has no consumer and is unreachable (rule 1 returns `LOCAL_ONLY` before testing `approvable`)"*. I restated that in two summaries and wrote it into a drafted ADR before running it.

**It is wrong.** `REQUIRE_APPROVAL` fires whenever an uncleared destination is `approvable` and no local destination accepts the classification. The zero in the receipts ledger has a simpler cause: **no destination on this machine sets `approvable` at all.**

The difference is the whole fix. "Unreachable" suggests deleting or reworking a decision; what is actually wrong is one config shape silently shadowing a flag. ADR-0024 (#1555) is corrected in the same push.

## Reported, not reordered

`patchwork privacy destinations` now says the flag can never fire **and says what happens instead** — "you will be REFUSED, not asked". An operator told only that their flag is inert cannot tell whether they are protected more or less than they thought.

Reordering rule 1 would make live traffic newly approvable: an enforcement change, not a tidy-up, and yours to call.

## The ordering question, recorded because it is genuinely unclear

`narrowest()` ranks `REQUIRE_APPROVAL` (3) as stricter than `LOCAL_ONLY` (2) — so rule 1 returns the **less** restrictive of its two candidates, in a module whose never-widen helper exists to prevent exactly that.

It may still be right. In *effect* today `LOCAL_ONLY` is the stricter of the two, because it refuses outright and nothing unlocks it, while `REQUIRE_APPROVAL` can be unlocked by a human. The ranking describes intent; the runtime describes behaviour; they disagree. That needs a decision rather than a patch, so nothing is changed here.

## Verification

The reachability predicate is **the runtime's own** (`some local destination is cleared for this classification`), not a re-derivation — two notions of reachability would drift, and the drift would be silent and reassuring.

Tests pin the behaviour in both directions, with a control proving `REQUIRE_APPROVAL` still fires when it should — without it, the inert-flag assertion would pass equally against a build with the decision deleted, which is the stronger claim the handoff note actually made.

Mutation-checked: forcing the flag always-on and always-off each turns the suite red, so the guard cannot pass by flagging everything or nothing. New test file confirmed present in the full run by `vitest list` (6 of 10538), not inferred from a green summary.

Full suite: 10538 passed. Doc, CLI, drift, business-content and in-flight gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)