### PR TITLE
fix(privacy): real identifiers were shipping to every install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,17 @@ jobs:
       # accident, months later. Nothing was going to report it.
       - name: Audit real IP literals (gating)
         run: node scripts/audit-real-ips.mjs
+      # A real Slack channel id shipped three times in one example (labelled
+      # sales / marketing / engineering, all the same id) and a real workspace
+      # channel name sat in a shipped template. `templates/` is packed into npm
+      # wholesale, so both landed on every install as working configuration —
+      # published AND copied onto other people's machines. The private-identifier
+      # gate could not catch them: it matches an operator denylist that by design
+      # never enters the repo, so it cannot run here, and it only ever sees a
+      # staged diff. This one matches SHAPE, needs no secret, and therefore runs
+      # in CI.
+      - name: Audit real identifiers in shipped artifacts (gating)
+        run: node scripts/audit-shipped-identifiers.mjs
       # The README's hero block told a new user to run `patchwork connections
       # connect gmail`. There is no `connections` verb — the second command in
       # the 90-second start failed for everyone who followed it, and no gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,42 @@ It never prints the matched string — only which denylist entry number matched,
 and where. Echoing it would put the secret into scrollback, CI logs and
 screenshots, which is the same disclosure one layer over.
 
+## Shipped-artifact identifier gate
+
+`scripts/audit-shipped-identifiers.mjs` (CI-gating) scans `templates/` and
+`examples/` for real-world identifiers by SHAPE — Slack channel ids and
+`/Users/<name>` paths.
+
+It exists because those directories are **distributed**: `package.json`'s
+`files` includes `templates` wholesale, so a real identifier there is published
+AND copied onto every installer's machine as working configuration. Found by
+hand 2026-08-31 — a real Slack channel id shipped three times in one example
+(labelled sales / marketing / engineering, all the same id) and a real workspace
+channel name sat in a shipped template. Nothing was checking.
+
+**It is not a duplicate of the private-identifier gate.** That one matches an
+operator's denylist, which by design never enters the repo — so it cannot run in
+CI and only ever sees a staged diff, a branch name and a commit message. It
+could not have caught these: they were already committed. This one matches
+shape, needs no secret, and therefore runs in CI. Complements, not overlap.
+
+**The digit requirement in the Slack pattern is load-bearing.** `C` plus 8-10
+uppercase alphanumerics also matches ordinary English — `COMPLETED`,
+`CONSEQUENCE`, `CONVERSION` occur legitimately in nine places across shipped
+recipes. Requiring a digit separates a real id from a word; without it the gate
+fires on normal content and gets silenced.
+
+**It deliberately does NOT judge domains or emails.** Real-vs-placeholder is a
+knowledge question, not a shape one (`acme.test` and a genuine company differ by
+what you know, not by form), and a guessing gate would either miss the real ones
+or block legitimate placeholders. That half stays with the denylist gate and
+with reading the diff. Known carve-out: a recipe whose FUNCTION is to filter
+mail from a named service must name that service's sender address — the same
+exception CLAUDE.md already makes for connector product names.
+
+A scan of zero files FAILS rather than passing, so a moved or unreadable
+directory cannot report OK.
+
 ## Documentation
 
 Comply with all docs in `/documents/`. Consult before changes:

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -78,6 +78,14 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   DERIVING labels is now 0 of 74 — a figure CLAUDE.md was still quoting while work was scoped
   against it. The workable design is recorded rather than discarded, with a measurable trigger
   to reopen. — PR pending
+- 2026-08-31 `fix/real-identifiers-in-shipped-artifacts` — a real Slack channel id shipped
+  three times in one example and a real workspace channel name sat in a shipped template.
+  `templates/` is packed into npm wholesale, so both were published AND copied onto every
+  installer's machine as working configuration. Replaced with placeholders and gated by shape
+  in CI. The private-identifier gate could not have caught them (denylist never enters the
+  repo, so it cannot run in CI, and it only sees a staged diff). Digit requirement in the
+  Slack pattern is load-bearing — without it the gate fires on COMPLETED / CONSEQUENCE /
+  CONVERSION, which occur legitimately nine times. — PR pending
 
 - 2026-08-28 `fix/pr-outcomes-swallows-the-real-error` — `gh repo view` ran with stderr
   ignored, so an expired credential, a missing gh and a missing remote all reported the same

--- a/examples/recipes/google-meet-debrief.yaml
+++ b/examples/recipes/google-meet-debrief.yaml
@@ -58,9 +58,9 @@ steps:
     params:
       meetings: "{{meetings}}"
       team: "{{team}}"
-      slackChannelSales: "C0AUZEY8Y0Y"
-      slackChannelMarketing: "C0AUZEY8Y0Y"
-      slackChannelEngineering: "C0AUZEY8Y0Y"
+      slackChannelSales: "C0000000SALES"
+      slackChannelMarketing: "C0000000MKTG"
+      slackChannelEngineering: "C0000000ENGR"
       issues: "{{issues}}"
     into: meeting
 

--- a/scripts/audit-shipped-identifiers.mjs
+++ b/scripts/audit-shipped-identifiers.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Real-world identifiers must not ship.
+ *
+ * `templates/` and `examples/` are DISTRIBUTED — `package.json`'s `files`
+ * includes `templates` wholesale, so anything here is packed into npm and lands
+ * on every install. That makes them categorically worse than a doc: a real
+ * identifier in `docs/` is published, but one here is published AND copied onto
+ * other people's machines as working configuration.
+ *
+ * Found by scanning rather than by a gate, 2026-08-31: a real Slack channel id
+ * appeared three times in a shipped example (labelled sales / marketing /
+ * engineering, all the same id), and a real Slack workspace channel name sat in
+ * a shipped template. Neither was caught by anything.
+ *
+ * ## Why this is not the private-identifier gate
+ *
+ * `audit-private-identifiers.mjs` matches an operator's DENYLIST, which by
+ * design never enters the repository — so it cannot run in CI, and it only ever
+ * sees a staged diff, a branch name and a commit message. It could not have
+ * caught these: they were already committed, and CI has no denylist.
+ *
+ * This gate matches SHAPE instead, which needs no secret and therefore CAN run
+ * in CI. The two are complements, not duplicates.
+ *
+ * ## Shape, deliberately, and only where shape is unambiguous
+ *
+ * It checks two things and refuses to guess at a third:
+ *
+ *   - Slack channel ids. `C` + 8-10 uppercase alphanumerics AND at least one
+ *     digit. The digit requirement is load-bearing: without it the pattern
+ *     matches ordinary uppercase English — `COMPLETED`, `CONSEQUENCE`,
+ *     `CONVERSION` all appear legitimately in shipped recipes, in seven files.
+ *     A gate that fires on those is a gate someone silences.
+ *   - `/Users/<name>` absolute paths, which carry an operator's account name.
+ *
+ * It does NOT try to decide whether a domain or email is "real". That is not a
+ * shape question — `acme.test` and a genuine company differ by knowledge, not
+ * by form — and a gate that guesses would either miss the real ones or block
+ * legitimate placeholders. That half stays with the denylist gate and with
+ * reading the diff.
+ *
+ * Known and deliberate exception: a recipe whose FUNCTION is to filter mail
+ * from a named service must name that service's sender address (the reading
+ * capture example needs its two). That is the same carve-out CLAUDE.md already
+ * makes for connector product names, and it is why this gate does not read
+ * addresses at all.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const ROOTS = ["templates", "examples"];
+
+/** Slack channel id shape. The digit requirement excludes English words. */
+const SLACK_ID = /\bC(?=[A-Z0-9]{8,10}\b)(?=[A-Z0-9]*\d)[A-Z0-9]{8,10}\b/g;
+/** An operator's home directory, and so their account name. */
+const USER_PATH = /\/Users\/[A-Za-z0-9._-]+/g;
+
+/**
+ * Obvious placeholders, allowed. Written as all-zeros runs so that a real id
+ * cannot masquerade as one: a genuine Slack id with eight consecutive zeros is
+ * not a thing anyone will hit by accident.
+ */
+const PLACEHOLDER = /^C0{7,}[A-Z0-9]*$/;
+
+function walk(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = path.join(dir, e);
+    let st;
+    try {
+      st = statSync(p);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) walk(p, out);
+    else out.push(p);
+  }
+  return out;
+}
+
+const findings = [];
+let scanned = 0;
+
+for (const root of ROOTS) {
+  for (const file of walk(root)) {
+    let text;
+    try {
+      text = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    scanned += 1;
+    const lines = text.split("\n");
+    lines.forEach((line, i) => {
+      for (const m of line.match(SLACK_ID) ?? []) {
+        if (PLACEHOLDER.test(m)) continue;
+        findings.push({
+          file,
+          line: i + 1,
+          kind: "slack channel id",
+          value: m,
+        });
+      }
+      for (const m of line.match(USER_PATH) ?? []) {
+        findings.push({
+          file,
+          line: i + 1,
+          kind: "operator home path",
+          value: m,
+        });
+      }
+    });
+  }
+}
+
+if (scanned === 0) {
+  // An empty scan must never read as a pass. Same rule the privacy verbs
+  // follow: nothing observed and nothing to observe are different facts.
+  console.error(
+    "[shipped-ids] FAIL — scanned 0 files. templates/ and examples/ are missing or unreadable, so this gate verified NOTHING.",
+  );
+  process.exit(1);
+}
+
+if (findings.length === 0) {
+  console.log(
+    `[shipped-ids] OK — ${scanned} shipped file(s) carry no real-world identifier.`,
+  );
+  process.exit(0);
+}
+
+// The value IS printed here, unlike the denylist gate. These are not secrets
+// drawn from a private list — they are strings already committed to a public
+// repository, and an operator cannot fix "something somewhere" without knowing
+// which string to replace.
+console.error(
+  `[shipped-ids] FAIL — ${findings.length} real-world identifier(s) in shipped artifacts:`,
+);
+for (const f of findings) {
+  console.error(`  ${f.file}:${f.line}  ${f.kind}: ${f.value}`);
+}
+console.error(
+  "\n  templates/ and examples/ are packed into npm and land on every install.",
+);
+console.error("  Replace with a placeholder (e.g. C00000000000, ~/ or $HOME).");
+process.exit(1);

--- a/templates/recipes/morning-brief-slack.yaml
+++ b/templates/recipes/morning-brief-slack.yaml
@@ -89,7 +89,7 @@ steps:
 
       {{brief}}
   - tool: slack.post_message
-    channel: all-massappealdesigns
+    channel: your-channel-name
     text: |
       *Morning Brief — {{date}}*
 


### PR DESCRIPTION
A real Slack channel id sat in a shipped example three times — labelled sales, marketing and engineering, all the same id — and a real Slack workspace channel name sat in a shipped template.

**These are not docs.** `package.json`'s `files` includes `templates` wholesale, so both were published *and* packed into npm and copied onto every installer's machine as working configuration. A real identifier in `docs/` is disclosed once; one here is disclosed and then distributed.

Replaced with placeholders. The example is incidentally a better example now: three distinct channel constants, where it previously used one real id for three supposedly different channels.

## The gate is the point

Nothing was checking, and `audit-private-identifiers.mjs` structurally could not: it matches an operator's denylist, which **by design never enters the repository**, so it cannot run in CI and only ever sees a staged diff, a branch name and a commit message. These were already committed months ago.

`scripts/audit-shipped-identifiers.mjs` matches **shape** instead — Slack channel ids and `/Users/<name>` paths — needs no secret, and therefore runs in CI. Complements the denylist gate rather than overlapping it.

### The digit requirement is load-bearing

`C` + 8–10 uppercase alphanumerics also matches ordinary English. `COMPLETED`, `CONSEQUENCE` and `CONVERSION` occur legitimately in **nine places across seven shipped recipes**. Requiring a digit separates an id from a word.

Without it the gate fires on normal content, and a gate that fires on normal content is one somebody silences. This is the second time in two days an unbounded identifier pattern matched an English word in this work — the demo-repo version matched "replaceable", in a repo whose own tagline is *"The AI vendor is replaceable."*

### What it deliberately will not do

It does not judge domains or emails. Real-versus-placeholder is a knowledge question, not a shape one — `acme.test` and a genuine company differ by what you know, not by form — and a guessing gate would either miss the real ones or block valid placeholders. That half stays with the denylist gate and with reading the diff.

Known carve-out, left alone: a recipe whose *function* is to filter mail from a named service must name that service's sender address. Same exception CLAUDE.md already makes for connector product names.

A scan of zero files **FAILS** rather than passing, so a moved or unreadable directory cannot report OK.

## Verification

Mutation-checked, not inferred from a green run:

| mutation | result |
|---|---|
| restore the original id | FAILS, naming file and line |
| add an operator home path | FAILS |
| run where the directories don't exist | FAILS (zero-scan guard) |
| the nine English-word occurrences | stays green |

Full suite 10532 passed. Every audit gate passes except `audit-companion-pins`, which is red on `main` already and is what #1551 fixes — untouched here.

Neither identifier appears in the commit message or this PR body; commit text cannot be edited later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)