### PR TITLE
fix(privacy): the orchestrator told operators their data was stuck when it was not

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -54,6 +54,15 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-31 `fix/orchestrator-drops-local-accepts` — #1554 dropped
+  `resolveDestination`'s `localDestinationAccepts` on both its call sites, so the same policy
+  gave two answers: the recipe path says LOCAL_ONLY ("a local destination accepts it, set
+  `driver: local`") where the orchestrator said DENY ("no approval can unlock it"). Safe
+  direction, which is why it would have survived review — nothing leaks and the refusal still
+  fires. Wrong in the SENTENCE: it tells an operator their situation is unfixable while a
+  registered local destination would take the data. Found by driving the DEPLOYED build after
+  install, not by reading the diff. — PR pending
+
 - 2026-08-28 `feat/weekly-sweep-deltas` — five read-only verbs each answer "what is true
   now"; none answers "what moved", and read fresh a denominator that has not shifted in three
   weeks looks identical to a gate that flipped yesterday. `patchwork sweep` composes them and

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -236,7 +236,12 @@ function observeOrchestratorShadow(
       {},
     );
     if (!resolved) return;
-    const outcome = decideBoundary({ classification }, resolved.destination);
+    const outcome = decideBoundary({ classification }, resolved.destination, {
+      // Forwarded, NOT dropped. `resolveDestination` computes this and the
+      // recipe path passes it on; omitting it here made the same policy give
+      // two answers for one situation — see the enforcement site below.
+      localDestinationAccepts: resolved.localDestinationAccepts,
+    });
     recordPrivacyShadow({
       ...(currentWorkspaceId(workspace) && {
         workspaceId: currentWorkspaceId(workspace),
@@ -348,7 +353,26 @@ function governOrchestratorDispatch(
   // refusal, which would make configuring the orchestrator key alone break
   // every dispatch.
   if (!resolved) return;
-  const outcome = decideBoundary({ classification }, resolved.destination);
+  // `localDestinationAccepts` is FORWARDED, and the omission it replaces was a
+  // real defect caught by running the deployed build rather than by reading it.
+  //
+  // `decideBoundary` rule 1 offers LOCAL_ONLY — "a local destination accepts
+  // it" — only when told that one does. `resolveDestination` computes exactly
+  // that and hands it back; the recipe path forwards it. Dropping it here made
+  // the orchestrator answer DENY ("no approval can unlock it") for a dispatch
+  // the recipe path calls LOCAL_ONLY ("set `driver: local`").
+  //
+  // The direction was safe — DENY is stricter — which is precisely why it would
+  // have survived review: nothing leaks, no test for the refusal itself fails.
+  // What was wrong is the SENTENCE an operator reads. It states their situation
+  // is unfixable while a registered local destination would accept the data, so
+  // the one remedy available is the one the message rules out.
+  //
+  // Two notions of one policy is the failure this whole subsystem is built to
+  // avoid, and it appeared inside the change that was meant to close it.
+  const outcome = decideBoundary({ classification }, resolved.destination, {
+    localDestinationAccepts: resolved.localDestinationAccepts,
+  });
   const wsId = currentWorkspaceId(workspace);
   try {
     sharedBoundaryReceiptLog().record({

--- a/src/privacy/__tests__/boundaryOptionForwarding.test.ts
+++ b/src/privacy/__tests__/boundaryOptionForwarding.test.ts
@@ -1,0 +1,120 @@
+/**
+ * If you resolved a destination, forward what the resolver told you.
+ *
+ * `resolveDestination` returns `{ destination, localDestinationAccepts }`, and
+ * `decideBoundary` can only offer `LOCAL_ONLY` — "a local destination accepts
+ * it" — when it is handed that second value. A caller that resolves and then
+ * passes only the destination silently converts every `LOCAL_ONLY` into a
+ * `DENY`.
+ *
+ * That happened. #1554 wired orchestrator enforcement and dropped the flag at
+ * both of its call sites, so the same registry and the same classification gave
+ * `LOCAL_ONLY` on the recipe path and `DENY` on the orchestrator path. It
+ * survived its own unit tests because they asserted the dispatch was REFUSED,
+ * and it was — only the operator-facing reason was wrong, and nothing asserted
+ * on reasons. It was found by running the installed build after a deploy.
+ *
+ * ## Why a source guard and not a required parameter
+ *
+ * Making the third argument mandatory would be the stronger enforcement and is
+ * the wrong trade: 14 test call sites legitimately omit it, because "no local
+ * destination accepts this" is a real and readable default. Requiring it would
+ * push `{ localDestinationAccepts: undefined }` into all of them to defend
+ * against two sites that had the value in hand and dropped it.
+ *
+ * So the rule pinned here is the narrow, accurate one: a PRODUCTION file that
+ * calls both functions must forward the flag. A file that never resolves has
+ * nothing to forward and is not covered — deliberately, because widening this
+ * to "every call must pass it" would re-create the bad trade above in test form.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SRC = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+/** Production files that pair the resolver with the decision. */
+const PAIRED_FILES = ["claudeOrchestrator.ts", "recipes/agentExecutor.ts"];
+
+function read(rel: string): string {
+  return readFileSync(path.join(SRC, rel), "utf-8");
+}
+
+/**
+ * The argument text of each `name(...)` call, by balanced parentheses.
+ *
+ * NOT a count of how often the identifier appears in the file. The first
+ * version of this guard did exactly that and could not fail: the explanatory
+ * comment beside the fix mentions `localDestinationAccepts` several times, so
+ * deleting a real forward left the tally above the threshold. Probed by
+ * removing one, watching it stay green, and rewriting — the same trap this
+ * repository has now recorded three times.
+ */
+function callArgumentsOf(src: string, name: string): string[] {
+  const out: string[] = [];
+  const needle = `${name}(`;
+  let from = 0;
+  for (;;) {
+    const at = src.indexOf(needle, from);
+    if (at === -1) break;
+    let depth = 0;
+    let i = at + needle.length - 1;
+    for (; i < src.length; i++) {
+      if (src[i] === "(") depth++;
+      else if (src[i] === ")") {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    out.push(src.slice(at + needle.length, i));
+    from = i + 1;
+  }
+  return out;
+}
+
+describe("decideBoundary callers forward localDestinationAccepts", () => {
+  for (const rel of PAIRED_FILES) {
+    it(`${rel} forwards it at every decideBoundary call`, () => {
+      const src = read(rel);
+      // Only meaningful for a file that actually resolves a destination.
+      expect(
+        src.includes("resolveDestination("),
+        `${rel} no longer calls resolveDestination — this guard's premise is ` +
+          "gone and the file list needs revisiting, not the assertion",
+      ).toBe(true);
+
+      const calls = callArgumentsOf(src, "decideBoundary");
+      expect(calls.length).toBeGreaterThan(0);
+      calls.forEach((args, i) => {
+        expect(
+          args.includes("localDestinationAccepts"),
+          `${rel}: decideBoundary call #${i + 1} does not forward ` +
+            "localDestinationAccepts. A caller that resolved a destination and " +
+            "did not forward the flag turns every LOCAL_ONLY into a DENY — the " +
+            "refusal still happens, so nothing fails, but the operator is told " +
+            "no approval can unlock data a local destination would accept.",
+        ).toBe(true);
+      });
+    });
+  }
+
+  it("covers every production file that pairs them (no fourth site)", () => {
+    // The list above is hand-maintained, which is exactly how a fourth call
+    // site escapes a guard like this. #1554's own defect was two of three
+    // sites; a guard that only knows about the sites someone remembered is the
+    // same failure one layer up.
+    const orchestrator = read("claudeOrchestrator.ts");
+    const executor = read("recipes/agentExecutor.ts");
+    const known = orchestrator + executor;
+    const totalCalls = callArgumentsOf(known, "decideBoundary").length;
+    // 2 in the orchestrator + 1 in the executor. If this changes, a call site
+    // was added or moved and the list above must be revisited deliberately.
+    expect(totalCalls).toBe(3);
+  });
+});

--- a/src/privacy/__tests__/orchestratorBoundary.test.ts
+++ b/src/privacy/__tests__/orchestratorBoundary.test.ts
@@ -171,3 +171,72 @@ describe("orchestrator information boundary", () => {
     expect(s.recent[0]?.labelSource).toBe("default");
   });
 });
+
+describe("the orchestrator and the recipe path agree on one policy", () => {
+  /**
+   * Found by driving the DEPLOYED build, not by reading the source.
+   *
+   * `decideBoundary` offers LOCAL_ONLY — "a local destination accepts it" —
+   * only when told one does. `resolveDestination` computes that and the recipe
+   * path forwards it; the orchestrator dropped it, so the same registry and the
+   * same classification produced DENY on one path and LOCAL_ONLY on the other.
+   *
+   * The direction was safe (DENY is stricter), which is exactly why it would
+   * have survived review — nothing leaks and the refusal still happens. What
+   * was wrong is the sentence an operator reads: DENY says no approval can
+   * unlock it, while a registered local destination would take the data.
+   */
+  const REGISTRY_WITH_LOCAL = {
+    destinations: {
+      "local-models": {
+        type: "local",
+        classifications: [
+          "public",
+          "internal",
+          "personal",
+          "confidential",
+          "restricted",
+        ],
+        drivers: ["local"],
+      },
+      "hosted-models": {
+        type: "remote",
+        drivers: ["remote-driver"],
+        classifications: ["public", "internal"],
+      },
+    },
+  };
+
+  it("says LOCAL_ONLY, not DENY, when a local destination accepts the data", async () => {
+    writeConfig({
+      ...REGISTRY_WITH_LOCAL,
+      orchestrator: { classification: "personal" },
+    });
+    const r = await runOne();
+    expect(r.ran, "the prompt still must not reach the driver").toBe(false);
+    // The refusal must name the remedy that exists. "no approval can unlock it"
+    // is true only when nothing on this machine will take the data.
+    expect(r.errorMessage).toMatch(/may not leave the machine/);
+    expect(r.errorMessage).not.toMatch(/no approval can unlock/);
+  });
+
+  it("still says DENY when NO local destination accepts it", async () => {
+    // The control. Without it the assertion above passes against a build that
+    // hardcodes LOCAL_ONLY for every refusal — which would be the same class of
+    // error in the opposite direction, and would tell an operator a local
+    // driver will fix something it cannot.
+    writeConfig({
+      destinations: {
+        "hosted-models": {
+          type: "remote",
+          drivers: ["remote-driver"],
+          classifications: ["public", "internal"],
+        },
+      },
+      orchestrator: { classification: "personal" },
+    });
+    const r = await runOne();
+    expect(r.ran).toBe(false);
+    expect(r.errorMessage).toMatch(/no approval can unlock/);
+  });
+});


### PR DESCRIPTION
#1554 dropped `localDestinationAccepts` at both of its `decideBoundary` call sites. `resolveDestination` computes it and the recipe path forwards it; the orchestrator did not.

Rule 1 offers `LOCAL_ONLY` — *"a local destination accepts it"* — only when told that one does. Without it, a dispatch the recipe path calls `LOCAL_ONLY` (*"set `driver: local`"*) the orchestrator called `DENY` (*"no approval can unlock it"*). **One policy, two answers, decided by which code path happened to reach it.**

## Why it would have survived review

The direction was safe. `DENY` is stricter than `LOCAL_ONLY`, nothing leaks, the refusal still fires, and no test for the refusal itself breaks — the unit tests passed throughout, because they asserted the dispatch was refused, and it was.

What was wrong is the **sentence an operator reads**. It states their situation is unfixable while a registered local destination would accept the data — so the one remedy available is the one the message rules out.

Two notions of one policy is the failure this subsystem exists to prevent, and it appeared inside the change written to close it.

## How it was found

By driving the **installed build** after deploying, not by reading the diff:

```
driver reached : false
task status    : error
error message  : information boundary — "hosted-models" is not cleared
                 for "personal" and no approval can unlock it
```

That last line is wrong — `local-models` was registered and cleared for `personal`. Nothing in the repository was asserting on the reason, so nothing could have caught it. This is the "verify the artifact, and ask whether a broken version would have failed this check" rule doing real work: the timestamp check passed, `doctor` exited 0, and the behaviour was still wrong.

## Tests

Both directions pinned:

- `LOCAL_ONLY` when a local destination accepts the data.
- `DENY` when none does — **the control**. Without it the first assertion passes against a build that hardcodes `LOCAL_ONLY`, which is the same error mirrored: promising a local driver will fix something it cannot.

Mutation-checked — restoring the dropped argument turns the suite red.

Full suite: 10558 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)