### PR TITLE
feat(workers): five of eight installed workers could never run, and nothing said so

### DIFF
--- a/dashboard/src/lib/haltCategory.ts
+++ b/dashboard/src/lib/haltCategory.ts
@@ -23,6 +23,10 @@ export type HaltCategory =
   | "network_error"
   | "missing_connector"
   | "approval_rejected"
+  /** The approval TTL fired with nobody having answered — NOT a rejection. */
+  | "approval_expired"
+  /** The run was cancelled while a step waited for approval. */
+  | "approval_cancelled"
   | "run_level"
   | "contract_failed"
   | "unsupported_step"
@@ -50,6 +54,8 @@ export const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   network_error: "network error",
   missing_connector: "missing connector",
   approval_rejected: "approval rejected",
+  approval_expired: "approval expired",
+  approval_cancelled: "approval cancelled",
   run_level: "run-level halt",
   contract_failed: "completion contract failed",
   unsupported_step: "unsupported step form",
@@ -88,6 +94,10 @@ export const HALT_CATEGORY_HINT: Record<HaltCategory, string> = {
     "Recipe references a connector that isn't configured. Install/connect from /connections.",
   approval_rejected:
     "A step was rejected at the approval gate. Approve it from the dashboard, or set requireApproval: false on the recipe.",
+  approval_expired:
+    "A step waited for approval and nobody answered before the timeout. Not a rejection \u2014 no one saw it. An unattended run needs someone watching, requireApproval: false, or a longer approval timeout.",
+  approval_cancelled:
+    "The run was cancelled while a step waited for approval. Nothing was decided about the step \u2014 re-run it.",
   run_level:
     "Whole-recipe failure (no step ran). Check the recipe for circular deps / parse errors.",
   contract_failed:

--- a/dashboard/src/lib/haltPhrasing.ts
+++ b/dashboard/src/lib/haltPhrasing.ts
@@ -86,6 +86,21 @@ export function ownerHaltPhrase(
         sentence: "You turned down its last request, so it stopped.",
         fix: "none",
       };
+    case "approval_expired":
+      // NOT `fix: "approve"`. The request it was waiting on has already been
+      // resolved by the timeout, so an approve button would point at nothing.
+      // This sentence is the reason the category exists: it used to render as
+      // "You turned down its last request" to an operator who was asleep.
+      return {
+        sentence:
+          "It asked for your go-ahead and nobody answered in time, so it stopped.",
+        fix: "none",
+      };
+    case "approval_cancelled":
+      return {
+        sentence: "It was stopped while it was still waiting for your go-ahead.",
+        fix: "none",
+      };
     case "step_timeout":
       return {
         sentence: "One step took too long and was stopped.",

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -69,7 +69,7 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
   and an ADR-0021 boundary refusal (remedy included in its own text) rendered identically.
   And `privacy_shadow.jsonl` carried no run id while `boundary_receipts.jsonl`, written 26
   lines away from the same dispatch, did — so "where do my live and candidate policies
-  disagree, on this run?" was a join that could not be expressed. — PR pending
+  disagree, on this run?" was a join that could not be expressed. — #1562
 - 2026-08-31 `feat/approval-log-correlation-id` — ADR-0025's named next stamp. The approval
   ledger carried no run reference on any of 215 live rows, so no run in the whole history
   could answer "who approved this, under what rule". The field that WAS there (`runSeq`) was

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,14 +52,24 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-08-31 `codex/worker-reliability-fixes` — worker reliability: the approval seam
-  collapsed four queue outcomes into a boolean, so an expiry nobody saw was reported as a
-  rejection a human made. Touches `approvalRequest`/`haltCategory`/both runners/the two
-  gate producers + the dashboard halt mirrors. Also widens `workers validate` to ask
-  whether an installed worker's recipe can actually RUN. — codex session
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-31 `codex/worker-reliability-fixes` — five reliability fixes for the maintenance
+  workers, each one an existing subsystem answering a narrower question than the one an
+  operator has. The approval seam collapsed four queue outcomes into a boolean, so an
+  expiry nobody saw was reported as a rejection a human made — 49 approved / 7 rejected /
+  27 expired / 23 cancelled in the durable log, and two of four halts that week ran to the
+  300 000 ms TTL exactly. `workers validate` checked every way a manifest can fail to BIND
+  and never asked whether the recipe on the other end runs: 8 manifests, "no problems
+  found", one bound recipe failing `recipe doctor` with 8 errors and — found only once it
+  looked — FIVE of eight workers bound to DISABLED recipes, four of which have no run in
+  the log's whole 20-day span. The agent halt sentence kept the name of the pattern that
+  matched and dropped the marker that says what happened, so an unreachable model endpoint
+  and an ADR-0021 boundary refusal (remedy included in its own text) rendered identically.
+  And `privacy_shadow.jsonl` carried no run id while `boundary_receipts.jsonl`, written 26
+  lines away from the same dispatch, did — so "where do my live and candidate policies
+  disagree, on this run?" was a join that could not be expressed. — PR pending
 - 2026-08-31 `docs/evidence-spine-adr` — the Evidence Spine existed ONLY as a CLAUDE.md
   section, which records in its own text that both its load-bearing claims went stale or
   were wrong within two days. A third was found false the same week: "zero attribution rows

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,12 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-08-31 `codex/worker-reliability-fixes` — worker reliability: the approval seam
+  collapsed four queue outcomes into a boolean, so an expiry nobody saw was reported as a
+  rejection a human made. Touches `approvalRequest`/`haltCategory`/both runners/the two
+  gate producers + the dashboard halt mirrors. Also widens `workers validate` to ask
+  whether an installed worker's recipe can actually RUN. — codex session
+
 ## Recently closed (informal log, prune periodically)
 
 - 2026-08-31 `docs/evidence-spine-adr` — the Evidence Spine existed ONLY as a CLAUDE.md

--- a/src/__tests__/recipeOrchestration.workerGate.test.ts
+++ b/src/__tests__/recipeOrchestration.workerGate.test.ts
@@ -32,6 +32,19 @@ import { OutcomeStore } from "../workers/outcomeStore.js";
  * join key onto its run; a test that only exercises the decision still has to
  * name one.
  */
+/**
+ * The gate returns `boolean | ApprovalVerdict`. A bare `false` used to be the
+ * ONLY thing it could say, which is why the three tests below — REJECT, CANCEL
+ * and EXPIRE — all asserted the identical value while being named for three
+ * different events. They now pin the refusal each one actually produces.
+ */
+async function verdictOf(
+  p: Promise<boolean | { approved: boolean; refusal?: string }>,
+) {
+  const r = await p;
+  return typeof r === "boolean" ? { approved: r } : r;
+}
+
 const TEST_RUN = "yaml:test-recipe:1756000000000";
 
 /** Seed durable, dwell-separated successes so the worker earns autonomy on
@@ -187,7 +200,9 @@ describe("buildWorkerAutonomyGate", () => {
     await tick();
     expect(getApprovalQueue().list()).toHaveLength(1);
     getApprovalQueue().reject(firstCallId());
-    expect(await p).toBe(false);
+    const v = await verdictOf(p);
+    expect(v.approved).toBe(false);
+    expect(v.refusal).toBe("rejected");
   });
 
   it("fail-closed: a risky unearned step CANCEL → false (M4)", async () => {
@@ -200,7 +215,10 @@ describe("buildWorkerAutonomyGate", () => {
     });
     await tick();
     getApprovalQueue().cancel(firstCallId());
-    expect(await p).toBe(false);
+    const v = await verdictOf(p);
+    expect(v.approved).toBe(false);
+    // NOT "rejected": nobody decided anything about this step.
+    expect(v.refusal).toBe("cancelled");
   });
 
   it("fail-closed: a risky unearned step EXPIRE → false (M4)", async () => {
@@ -213,7 +231,10 @@ describe("buildWorkerAutonomyGate", () => {
     });
     await tick();
     getApprovalQueue().clear(); // resolves pending as "expired"
-    expect(await p).toBe(false);
+    const v = await verdictOf(p);
+    expect(v.approved).toBe(false);
+    // NOT "rejected": the TTL fired and no human ever saw it.
+    expect(v.refusal).toBe("expired");
   });
 
   it("a risky unearned step APPROVE → true (M4)", async () => {
@@ -226,7 +247,7 @@ describe("buildWorkerAutonomyGate", () => {
     });
     await tick();
     getApprovalQueue().approve(firstCallId());
-    expect(await p).toBe(true);
+    expect((await verdictOf(p)).approved).toBe(true);
   });
 
   it("aborting the run signal resolves a gated step false, not a TTL hang (L1)", async () => {
@@ -242,7 +263,9 @@ describe("buildWorkerAutonomyGate", () => {
     await tick();
     expect(getApprovalQueue().list()).toHaveLength(1);
     ac.abort(); // run cancelled → pending approval resolves "cancelled"
-    expect(await p).toBe(false);
+    const v = await verdictOf(p);
+    expect(v.approved).toBe(false);
+    expect(v.refusal).toBe("cancelled");
   });
 
   it("context-risk DE-RATES an EARNED action (live wiring, descending only)", async () => {
@@ -288,7 +311,7 @@ describe("buildWorkerAutonomyGate", () => {
     await tick();
     expect(getApprovalQueue().list()).toHaveLength(1);
     getApprovalQueue().reject(firstCallId());
-    expect(await p).toBe(false);
+    expect((await verdictOf(p)).approved).toBe(false);
   });
 
   it("a failing context-risk provider is fail-soft (no de-rate, no crash)", async () => {
@@ -472,7 +495,7 @@ describe("buildWorkerAutonomyGate", () => {
       await tick();
       expect(getApprovalQueue().list()).toHaveLength(1);
       getApprovalQueue().reject(firstCallId());
-      expect(await pending).toBe(false);
+      expect((await verdictOf(pending)).approved).toBe(false);
     });
 
     it("a grant NEVER covers an irreversible action", async () => {
@@ -490,7 +513,7 @@ describe("buildWorkerAutonomyGate", () => {
       await tick();
       expect(getApprovalQueue().list()).toHaveLength(1);
       getApprovalQueue().reject(firstCallId());
-      expect(await pending).toBe(false);
+      expect((await verdictOf(pending)).approved).toBe(false);
     });
 
     it("a grant that names another domain changes nothing", async () => {
@@ -507,7 +530,7 @@ describe("buildWorkerAutonomyGate", () => {
       await tick();
       expect(getApprovalQueue().list()).toHaveLength(1);
       getApprovalQueue().reject(firstCallId());
-      expect(await pending).toBe(false);
+      expect((await verdictOf(pending)).approved).toBe(false);
     });
   });
 

--- a/src/claudeOrchestrator.ts
+++ b/src/claudeOrchestrator.ts
@@ -252,6 +252,13 @@ function observeOrchestratorShadow(
       destinationType: resolved.destination.type,
       classification,
       path: "orchestrator-task",
+      // NO `correlationId`, deliberately, and registered as such in
+      // `SHADOW_RECORD_VERSION`'s field registry. An orchestrator task is not a
+      // recipe run and has no row in `runs.jsonl`, so there is no run id to
+      // give — and stamping this with the orchestrator's own task id would put
+      // two different kinds of identity under one field name, which is the
+      // thing the `rv` protocol exists to prevent. Absence here is a STATE. Do
+      // not "complete" the coverage by filling it.
       // `default` when the operator classified the CHANNEL, `assumed` when
       // nobody said anything and the runtime fell back. Never `declared`: no
       // operator ever saw this prompt, which is the claim ADR-0021 refuses to

--- a/src/index.ts
+++ b/src/index.ts
@@ -5437,7 +5437,7 @@ if (process.argv[2] === "workers") {
         if (sub === "list" || sub === "validate") {
           const {
             scanWorkers,
-            validateWorkers,
+            validateWorkersWithRecipeHealth,
             formatWorkersList,
             formatWorkersValidate,
             defaultWorkersDir,
@@ -5473,7 +5473,10 @@ if (process.argv[2] === "workers") {
           const tIdx = args.indexOf("--templates-dir");
           const templatesDir = tIdx !== -1 ? args[tIdx + 1] : undefined;
           const rIdx = args.indexOf("--recipes-dir");
-          const result = validateWorkers({
+          // Composes the structural check with `recipe doctor`'s static half,
+          // once per bound recipe. A manifest that binds perfectly to a recipe
+          // that cannot run reported "no problems found" before this.
+          const result = await validateWorkersWithRecipeHealth({
             workersDir: dir,
             recipesDir:
               rIdx !== -1 ? (args[rIdx + 1] as string) : defaultRecipesDir(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5476,11 +5476,29 @@ if (process.argv[2] === "workers") {
           // Composes the structural check with `recipe doctor`'s static half,
           // once per bound recipe. A manifest that binds perfectly to a recipe
           // that cannot run reported "no problems found" before this.
+          // A worker bound to a DISABLED recipe never runs at all. The list
+          // is read here rather than inside the validator so that stays a pure
+          // function of its inputs.
+          let disabledRecipes: string[] = [];
+          try {
+            const { loadConfig } = await import("./patchworkConfig.js");
+            // The SAME reader the scheduler consults, not a second read of the
+            // same field. Two notions of "disabled" drift, and the drift here
+            // reports a worker as live that no trigger will ever fire.
+            const { getConfigDisabledNames } = await import(
+              "./recipes/disabledMarkers.js"
+            );
+            disabledRecipes = [...getConfigDisabledNames(loadConfig())];
+          } catch {
+            // No config / unreadable → nothing is known to be disabled. Fail
+            // soft: this can only drop a warning, never invent one.
+          }
           const result = await validateWorkersWithRecipeHealth({
             workersDir: dir,
             recipesDir:
               rIdx !== -1 ? (args[rIdx + 1] as string) : defaultRecipesDir(),
             ...(templatesDir ? { templatesDir } : {}),
+            disabledRecipes,
           });
           process.stdout.write(
             json

--- a/src/privacy/__tests__/shadowCorrelation.test.ts
+++ b/src/privacy/__tests__/shadowCorrelation.test.ts
@@ -1,0 +1,292 @@
+/**
+ * The shadow ledger could not name the run it observed.
+ *
+ * `boundary_receipts.jsonl` carries `correlationId` (#1522). `privacy_shadow
+ * .jsonl` does not, and the two are written 26 lines apart in the same
+ * function, from the same dispatch, with the same `runTaskId` in scope.
+ * Measured on the reference machine: 109 of 265 receipts carry a run id and
+ * 0 of 310 shadow rows do.
+ *
+ * This is the exact MIRROR of a defect this code has already recorded twice in
+ * its own comments. #1469 added `recipeName` to the shadow ledger and stopped
+ * there, "leaving the ENFORCING ledger anonymous"; #1474 closed that and its
+ * comment says both ledgers "describe the same dispatch, so a receipt that
+ * omitted this would leave the ENFORCING log unable to say what the observing
+ * one could". `correlationId` then went the other way — onto the enforcing
+ * ledger only — and left the observing one anonymous.
+ *
+ * What that costs is specific, not tidiness. Shadow mode exists to answer "what
+ * would a candidate policy have stopped?" and its sharpest form is "where do my
+ * live policy and my candidate policy disagree, ON THIS RUN?". That question is
+ * a join between these two files, and it could not be asked.
+ *
+ * ## The sentinel, and why this ledger's registry differs from the receipt's
+ *
+ * `correlationId` at `rv >= 1` is "never legitimately absent" for receipts,
+ * because every receipt is written from inside a run. This ledger has TWO write
+ * paths. `recipe-agent-step` runs inside `runYamlRecipe` / `runChainedRecipe`
+ * and always has a run. `orchestrator-task` is `runClaudeTask` and automation
+ * hooks — dispatches that are not recipe runs and have no row in `runs.jsonl`
+ * at all. Stamping those with something run-shaped would assert a run that
+ * never existed, which is the failure the approval ledger's own sentinel design
+ * calls out. So absence on the orchestrator path is a registered
+ * NOT-APPLICABLE condition, and absence on the recipe path is a writer defect.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { recordPrivacyShadow, SHADOW_RECORD_VERSION } from "../shadowLog.js";
+
+let dir: string;
+let home: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(os.tmpdir(), "shadow-corr-"));
+  home = join(dir, "home");
+  mkdirSync(home, { recursive: true });
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/**
+ * BOTH keys. The enforcing one so a receipt is written, the shadow one so an
+ * observation is — the whole point is that the two rows can be joined.
+ */
+function writeConfig(): void {
+  const destinations = {
+    "test-local": {
+      type: "local",
+      classifications: ["public", "internal", "personal"],
+      drivers: ["local"],
+    },
+    "test-remote": {
+      type: "remote",
+      classifications: ["public", "internal"],
+      drivers: ["claude", "claude-code", "subprocess"],
+    },
+  };
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify({ privacy: { destinations, shadow: { destinations } } }),
+  );
+}
+
+type Row = { rv?: number; correlationId?: string; path?: string };
+
+function readJsonl(name: string): Row[] {
+  try {
+    return readFileSync(join(home, name), "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Row);
+  } catch {
+    return [];
+  }
+}
+
+async function withHome<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.PATCHWORK_HOME;
+  // PATCHWORK_HOME, never a spy on `os.homedir` — a namespace spy misses named
+  // imports and has previously let a test write to the developer's real store.
+  process.env.PATCHWORK_HOME = home;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.PATCHWORK_HOME;
+    else process.env.PATCHWORK_HOME = prev;
+  }
+}
+
+describe("the shadow ledger's record level", () => {
+  it("declares a record version at all", () => {
+    // Without this the two assertions below pass against a module that exports
+    // nothing: `SHADOW_RECORD_VERSION` is then `undefined`, `rv` is absent, and
+    // `expect(undefined).toBe(undefined)` is green. A test that cannot fail is
+    // the thing this whole change is about.
+    expect(typeof SHADOW_RECORD_VERSION).toBe("number");
+  });
+
+  it("stamps `rv` on every row it writes", () => {
+    recordPrivacyShadow(
+      {
+        decision: "ALLOW",
+        classification: "public",
+        destinationId: "d",
+        destinationType: "local",
+        reason: "ok",
+        enforcing: false,
+        correlationId: "yaml:x:1",
+      },
+      { dir: home },
+    );
+    const rows = readJsonl("privacy_shadow.jsonl");
+    expect(typeof rows[0]?.rv).toBe("number");
+    expect(rows[0]?.rv).toBe(SHADOW_RECORD_VERSION);
+    expect(rows[0]?.correlationId).toBe("yaml:x:1");
+  });
+
+  it("omits `correlationId` rather than writing an empty one", () => {
+    recordPrivacyShadow(
+      {
+        decision: "ALLOW",
+        classification: "public",
+        destinationId: "d",
+        destinationType: "local",
+        reason: "ok",
+        enforcing: false,
+      },
+      { dir: home },
+    );
+    const rows = readJsonl("privacy_shadow.jsonl");
+    // Absent, never "" or null — a reader must tell "no claim" from "claim
+    // broken", and an empty string is neither.
+    expect("correlationId" in (rows[0] ?? {})).toBe(false);
+    expect(rows[0]?.rv).toBe(SHADOW_RECORD_VERSION);
+    expect(typeof rows[0]?.rv).toBe("number");
+  });
+});
+
+describe("a shadow observation names the run it observed", () => {
+  it("FLAT runner: the shadow row and the RECEIPT join on one run id", async () => {
+    writeConfig();
+    await withHome(async () => {
+      const { runYamlRecipe } = await import("../../recipes/yamlRunner.js");
+      await runYamlRecipe(
+        {
+          name: "shadow-corr",
+          trigger: { type: "manual" },
+          steps: [
+            {
+              id: "think",
+              agent: {
+                prompt: "hi",
+                driver: "claude-code",
+                data_policy: { classification: "personal" },
+              },
+            },
+          ],
+        } as never,
+        {
+          testMode: true,
+          logDir: dir,
+          readFile: () => {
+            throw new Error("nope");
+          },
+          writeFile: () => {},
+          appendFile: () => {},
+          mkdir: () => {},
+          gitLogSince: () => "",
+          gitStaleBranches: () => "",
+          getDiagnostics: () => "",
+          claudeFn: async () => "ok",
+        } as never,
+      );
+    });
+
+    const shadow = readJsonl("privacy_shadow.jsonl");
+    const receipts = readJsonl("boundary_receipts.jsonl");
+    expect(shadow.length).toBeGreaterThan(0);
+    expect(receipts.length).toBeGreaterThan(0);
+    for (const row of shadow) {
+      expect(row.rv).toBe(SHADOW_RECORD_VERSION);
+      expect(row.correlationId).toMatch(/^yaml:shadow-corr:\d+$/);
+    }
+    // The join. This is the whole point: one dispatch, two ledgers, one run.
+    const shadowRuns = new Set(shadow.map((r) => r.correlationId));
+    const receiptRuns = new Set(receipts.map((r) => r.correlationId));
+    expect([...shadowRuns].some((id) => receiptRuns.has(id))).toBe(true);
+  });
+
+  it("CHAINED runner: the shadow row carries the run's taskId too", async () => {
+    // The load-bearing half. The chained dep-builder is called before
+    // `runChainedRecipe` computes its run id, so a fix applied to the flat path
+    // alone leaves this one anonymous — the exact half-covered join the receipt
+    // ledger had to avoid.
+    writeConfig();
+    await withHome(async () => {
+      const { runChainedRecipe } = await import(
+        "../../recipes/chainedRunner.js"
+      );
+      const { buildChainedDeps } = await import("../../recipes/yamlRunner.js");
+      const runnerDeps = {
+        testMode: true,
+        logDir: dir,
+        readFile: () => {
+          throw new Error("nope");
+        },
+        writeFile: () => {},
+        appendFile: () => {},
+        mkdir: () => {},
+        gitLogSince: () => "",
+        gitStaleBranches: () => "",
+        getDiagnostics: () => "",
+        claudeFn: async () => "ok",
+        claudeCodeFn: async () => "ok",
+      } as never;
+      const chainedDeps = buildChainedDeps(runnerDeps, undefined, "chain-corr");
+      await runChainedRecipe(
+        {
+          name: "chain-corr",
+          steps: [
+            {
+              id: "think",
+              agent: {
+                prompt: "hi",
+                driver: "claude-code",
+                data_policy: { classification: "personal" },
+              },
+            },
+          ],
+        } as never,
+        { env: {}, maxConcurrency: 1, maxDepth: 3, dryRun: false } as never,
+        chainedDeps,
+      );
+    });
+    const shadow = readJsonl("privacy_shadow.jsonl");
+    expect(shadow.length).toBeGreaterThan(0);
+    for (const row of shadow) {
+      expect(row.rv).toBe(SHADOW_RECORD_VERSION);
+      // The exact shape, not merely "truthy": the chained deps are built before
+      // the run id exists, so a fix that only reached the flat path leaves this
+      // path writing rows with no id while the flat test still passes.
+      expect(row.correlationId).toMatch(/^chained:chain-corr:\d+$/);
+    }
+  });
+});
+
+describe("the orchestrator path's absence is a STATE, not a defect", () => {
+  it("writes no correlationId, because there is no run to name", () => {
+    // `runClaudeTask` and the automation hooks are not recipe runs and have no
+    // row in `runs.jsonl`. Stamping them with something run-shaped would assert
+    // a run that never existed — the same reasoning the approval ledger's
+    // sentinel uses for its two runless paths. Registered NOT-APPLICABLE at
+    // `rv >= 1`, and pinned here so nobody later "completes" the coverage.
+    recordPrivacyShadow(
+      {
+        path: "orchestrator-task",
+        decision: "ALLOW",
+        classification: "internal",
+        destinationId: "d",
+        destinationType: "remote",
+        reason: "ok",
+        enforcing: true,
+      },
+      { dir: home },
+    );
+    const rows = readJsonl("privacy_shadow.jsonl");
+    expect(rows[0]?.path).toBe("orchestrator-task");
+    expect("correlationId" in (rows[0] ?? {})).toBe(false);
+    // Still record-levelled: the row makes a claim about every OTHER field the
+    // level registers, and dropping `rv` would make it unreadable rather than
+    // honestly incomplete.
+    expect(rows[0]?.rv).toBe(SHADOW_RECORD_VERSION);
+  });
+});

--- a/src/privacy/shadowLog.ts
+++ b/src/privacy/shadowLog.ts
@@ -108,8 +108,61 @@ export const UNOBSERVED_PATHS: readonly string[] = [];
 export const COVERAGE_IS_ENUMERATED =
   "coverage is enumerated from known dispatch paths; it is not proof that no other path exists";
 
+/**
+ * Writer-stamped record level for this ledger.
+ *
+ * `rv: N` asserts: for every field registered as known from level <= N, that
+ * field is present, or its registered not-applicable condition held. The same
+ * protocol the gate ledger adopted in #1519 and the receipt ledger in #1522,
+ * for the same reason — a reader must be able to tell "no claim was made" from
+ * "a claim was made and honoured" from "a claim was made and broken".
+ *
+ * ## Field registry
+ *
+ * - `correlationId` (level 1) — present on the `recipe-agent-step` path, which
+ *   always runs inside `runYamlRecipe` / `runChainedRecipe` and therefore always
+ *   has a run id. Registered NOT-APPLICABLE on the `orchestrator-task` path:
+ *   `runClaudeTask` and the automation hooks are not recipe runs and have no row
+ *   in `runs.jsonl`, so stamping them with something run-shaped would assert a
+ *   run that never existed. Absence on the recipe path at `rv >= 1` is a WRITER
+ *   DEFECT; absence on the orchestrator path is a state.
+ *
+ * ## What absence of `rv` means, and why it is never repaired
+ *
+ * A row with no `rv` pre-dates this protocol. That is the sentinel, and it is
+ * unrepairable by construction: there is no backfill, and `parsed.rv ?? 0` on
+ * read would be a backfill performed invisibly on every load. Never default it.
+ *
+ * Do NOT read "no `rv`" as "old" — a stale bridge writing un-`rv`'d rows today
+ * is indistinguishable from a row written months ago (#1515).
+ */
+export const SHADOW_RECORD_VERSION = 1;
+
 export interface PrivacyShadowRow {
   at: number;
+  /**
+   * Writer-stamped record level — see `SHADOW_RECORD_VERSION`. Optional on the
+   * type because rows written before the protocol have none, and defaulting it
+   * on read would be an invisible backfill.
+   */
+  rv?: number;
+  /**
+   * The run that produced this observation — `taskId`, never `seq`.
+   *
+   * `seq` is a per-instance counter over a file several bridges write, and it
+   * collides: 255 distinct values across 272 rows of the live gate ledger. A
+   * join on it silently becomes many-to-one.
+   *
+   * `recipeName` says WHICH recipe to go and fix; this says which RUN, and
+   * without it an hourly recipe produces observations no reader can tell apart.
+   * It is also the key that makes this ledger joinable to
+   * `boundary_receipts.jsonl` — the two rows describe ONE dispatch, and "where
+   * do my live policy and my candidate policy disagree, on this run?" is a join
+   * between them that could not be expressed until both carried this.
+   *
+   * ABSENT on the `orchestrator-task` path by registration, not by omission.
+   */
+  correlationId?: string;
   /** Which dispatch path produced this. Absent on rows written before paths. */
   path?: ShadowPath;
   /** Whether the classification was declared or defaulted. */
@@ -180,7 +233,10 @@ export function recordPrivacyShadow(
     mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
     const full: PrivacyShadowRow = {
       at: (opts.now ?? Date.now)(),
+      // Stamped by the WRITER, after the caller's fields, so a caller cannot
+      // forge a level its row does not satisfy.
       ...row,
+      rv: SHADOW_RECORD_VERSION,
       reason: row.reason.slice(0, MAX_REASON),
     };
     appendFileSync(file, `${JSON.stringify(full)}\n`);

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -109,7 +109,7 @@ export function agentTextFromTask(task: {
  * human approval and resolves true only on an explicit "approved" decision
  * (a reject / expire / cancel halts the run — fail-closed, ADR-0016 spirit).
  */
-async function makeRecipeApprovalFn(
+export async function makeRecipeApprovalFn(
   gate: "high" | "all",
   server?: Server,
 ): Promise<ApprovalFn> {
@@ -166,7 +166,14 @@ async function makeRecipeApprovalFn(
       { signal: input.signal },
     );
     const decision = await promise;
-    return decision === "approved";
+    // Carry WHICH refusal this was to the runner. The queue distinguishes
+    // rejected / expired / cancelled; collapsing them to a boolean here is
+    // what made an unattended cron run's 5-minute TTL expiry read as "a human
+    // turned it down" everywhere downstream, including the owner-facing
+    // sentence "You turned down its last request".
+    return decision === "approved"
+      ? { approved: true }
+      : { approved: false, refusal: decision };
   };
 }
 
@@ -428,6 +435,13 @@ export async function buildWorkerAutonomyGate(
       }
       // Unknown action → refuse without asking anyone. No human is recruited
       // into approving something this build does not understand.
+      //
+      // Deliberately a BARE `false`, i.e. no refusal named: this is neither a
+      // rejection, an expiry nor a cancellation, and inventing one of the three
+      // would be a worse lie than the generic sentence. A fourth category
+      // (`approval_forbidden`) is the honest answer and is NOT added here —
+      // the gate ledger holds 232 `allow` / 48 `gate` / 0 `forbid`, so it would
+      // label a branch that has never fired on any real run.
       if (outcome === "refuse") return false;
       // gate → queue for human approval; fail-closed on reject / expire / cancel
       const { promise } = queue.request(
@@ -444,7 +458,11 @@ export async function buildWorkerAutonomyGate(
         },
         { signal: input.signal }, // L1: cancel the wait when the run aborts
       );
-      return (await promise) === "approved";
+      // `decision` is already the worker-gate decision in this scope.
+      const queueDecision = await promise;
+      return queueDecision === "approved"
+        ? { approved: true }
+        : { approved: false, refusal: queueDecision };
     };
   } catch {
     // Any failure resolving worker trust → fall back to tier gate (never widen

--- a/src/recipes/__tests__/agentSilentFailReason.test.ts
+++ b/src/recipes/__tests__/agentSilentFailReason.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The agent silent-fail marker carries its own reason, and the halt sentence
+ * threw it away.
+ *
+ * `detectSilentFail` returns `{ reason, matched }`. `reason` names WHICH
+ * pattern fired ("agent step skipped or failed (string placeholder)") —
+ * bookkeeping. `matched` is the marker itself, and that is where the cause
+ * lives. The capture was deliberately widened to hold the whole marker, with a
+ * comment recording why: a real refusal had been logging as the bare prefix
+ * "[agent step failed:", "turning a precise safety message into an opaque
+ * failure that had to be diagnosed by reading the source".
+ *
+ * The widening stopped one field short. `error` got `matched`; `haltReason` —
+ * the field `patchwork halts`, `recipe doctor`, the run-detail page and the
+ * dashboard's owner band all read — kept only `reason`.
+ *
+ * Measured over seven days on the reference machine: 9 halts, all rendered
+ * with the identical contentless sentence, and TWO different causes underneath.
+ * Six were `fetch failed` — the model endpoint was unreachable. Three were the
+ * ADR-0021 information boundary refusing a dispatch and naming the one-line
+ * remedy in its own message. A designed, correct, self-explaining safety
+ * refusal was being reported as an agent malfunction with the fix hint
+ * "inspect prompt + check trace".
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "agent-silentfail-"));
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+function runWithAgentResult(result: string) {
+  const recipe = {
+    name: "silent-fail-probe",
+    trigger: { type: "manual" },
+    steps: [{ agent: { prompt: "do it", driver: "local" }, into: "answer" }],
+  } as unknown as YamlRecipe;
+  const deps: RunnerDeps = {
+    now: () => new Date("2026-08-31T09:00:00Z"),
+    logDir: TMP,
+    testMode: true,
+    readFile: () => {
+      throw new Error("nf");
+    },
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    gitLogSince: () => "",
+    gitStaleBranches: () => "",
+    getDiagnostics: () => "",
+    localFn: async () => result,
+  } as unknown as RunnerDeps;
+  return runYamlRecipe(recipe, deps);
+}
+
+describe("the halt sentence names what actually went wrong", () => {
+  it("carries the information-boundary refusal, remedy and all", async () => {
+    const marker =
+      "[agent step failed: information boundary — set `driver: local` on this step; " +
+      '"personal" may not leave the machine]';
+    const result = await runWithAgentResult(marker);
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltReason ?? "").toContain("information boundary");
+    expect(halt?.haltReason ?? "").toContain("driver: local");
+  });
+
+  it("an unreachable model endpoint is a NETWORK failure, not an agent one", async () => {
+    // Six of nine real halts. "inspect prompt + check trace" is the wrong
+    // remedy for a connection that never opened.
+    const result = await runWithAgentResult(
+      "[agent step failed: fetch failed]",
+    );
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltReason ?? "").toContain("fetch failed");
+    expect(halt?.haltCategory).toBe("network_error");
+  });
+
+  it("keeps agent_silent_fail when the marker names no known cause", async () => {
+    const result = await runWithAgentResult(
+      "[agent step failed: something nobody has a pattern for]",
+    );
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltCategory).toBe("agent_silent_fail");
+  });
+
+  it("the stored category is never CONTRADICTED by re-deriving it from the sentence", async () => {
+    // `summariseHalts` trusts `haltCategory` when present and re-derives from
+    // `haltReason` when it is not. Those two must not disagree — a row read one
+    // way in the CLI and another way in a dashboard is worse than either.
+    const { categoriseHaltReason } = await import("../haltCategory.js");
+    for (const marker of [
+      "[agent step failed: fetch failed]",
+      "[agent step failed: ECONNREFUSED 127.0.0.1:11434]",
+    ]) {
+      const result = await runWithAgentResult(marker);
+      const halt = result.stepResults.find((s) => s.status === "error");
+      expect(categoriseHaltReason(halt?.haltReason)).toBe(halt?.haltCategory);
+    }
+  });
+
+  it("`error` still carries the full detector output (unchanged)", async () => {
+    const result = await runWithAgentResult(
+      "[agent step failed: fetch failed]",
+    );
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.error ?? "").toContain("silent-fail detected");
+  });
+});

--- a/src/recipes/__tests__/approvalOutcomeFidelity.test.ts
+++ b/src/recipes/__tests__/approvalOutcomeFidelity.test.ts
@@ -1,0 +1,265 @@
+/**
+ * An approval that EXPIRED is not an approval that was REJECTED.
+ *
+ * The queue has always known the difference — `ApprovalDecision` is
+ * `approved | rejected | expired | cancelled` (approvalQueue.ts), and it is
+ * distinguished there precisely because "a human said no" and "nobody was
+ * there" need different handling. `ApprovalFn` then returned a `boolean`, so
+ * three of those four arrived at the runner as one, and both runners reported
+ * every one of them with the same sentence:
+ *
+ *     Step rejected by approval gate — approval_rejected.
+ *
+ * That sentence makes a claim about a person. It reached the halt ledger, the
+ * `patchwork halts` counters, and — worst — the owner-facing phrasing, which
+ * renders it as "You turned down its last request, so it stopped." to an
+ * operator who was asleep.
+ *
+ * Measured on the reference machine before this was written: the durable
+ * approval log holds 49 approved, 7 rejected, 27 expired and 23 cancelled, so
+ * most non-approvals were never rejections. Two of the four `approval_rejected`
+ * halts in the last seven days ran for 300 000 ms exactly — the low tier's TTL
+ * — on unattended cron runs.
+ *
+ * A bare `false` still means what it always did. The gate that cannot say which
+ * refusal this was must not have one invented for it: absence stays absence,
+ * and the pre-existing sentence is what an unknowing gate keeps producing.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { normaliseApprovalVerdict } from "../approvalRequest.js";
+import type {
+  ChainedRecipe,
+  ExecutionDeps,
+  RunOptions,
+} from "../chainedRunner.js";
+import { executeChainedStep } from "../chainedRunner.js";
+import {
+  approvalHaltFor,
+  categoriseHaltReason,
+  HALT_CATEGORY_HINTS,
+  HALT_CATEGORY_LABELS,
+} from "../haltCategory.js";
+import { createOutputRegistry } from "../outputRegistry.js";
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "approval-fidelity-"));
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+function deps(extra: Partial<RunnerDeps> = {}): RunnerDeps {
+  return {
+    now: () => new Date("2026-08-31T09:00:00Z"),
+    logDir: TMP,
+    testMode: false,
+    readFile: () => {
+      throw new Error("nf");
+    },
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    gitLogSince: () => "",
+    gitStaleBranches: () => "",
+    getDiagnostics: () => "",
+    ...extra,
+  };
+}
+
+function recipe(): YamlRecipe {
+  return {
+    name: "approval-fidelity",
+    trigger: { type: "manual" },
+    steps: [{ tool: "file.write", path: `${TMP}/a`, content: "1" }],
+  } as YamlRecipe;
+}
+
+describe("flat runner — the refusal that halted the run is named", () => {
+  it("an EXPIRED approval is not reported as a rejection", async () => {
+    const result = await runYamlRecipe(
+      recipe(),
+      deps({
+        requireApprovalFn: vi.fn(async () => ({
+          approved: false,
+          refusal: "expired" as const,
+        })),
+      }),
+    );
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltCategory).toBe("approval_expired");
+    // The sentence must not claim a person acted.
+    expect(halt?.haltReason ?? "").not.toMatch(/rejected/i);
+    expect(halt?.haltReason ?? "").toMatch(/expired/i);
+  });
+
+  it("a CANCELLED approval is not reported as a rejection", async () => {
+    const result = await runYamlRecipe(
+      recipe(),
+      deps({
+        requireApprovalFn: vi.fn(async () => ({
+          approved: false,
+          refusal: "cancelled" as const,
+        })),
+      }),
+    );
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltCategory).toBe("approval_cancelled");
+    expect(halt?.haltReason ?? "").not.toMatch(/rejected/i);
+  });
+
+  it("an explicit REJECTED verdict keeps the original sentence", async () => {
+    const result = await runYamlRecipe(
+      recipe(),
+      deps({
+        requireApprovalFn: vi.fn(async () => ({
+          approved: false,
+          refusal: "rejected" as const,
+        })),
+      }),
+    );
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltCategory).toBe("approval_rejected");
+  });
+
+  it("a bare `false` is UNCHANGED — an unknowing gate gets no invented refusal", async () => {
+    const result = await runYamlRecipe(
+      recipe(),
+      deps({ requireApprovalFn: vi.fn(async () => false) }),
+    );
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltCategory).toBe("approval_rejected");
+    expect(halt?.haltReason).toBe(
+      "Step rejected by approval gate — approval_rejected.",
+    );
+  });
+
+  it("an approved verdict object runs the step", async () => {
+    let writes = 0;
+    await runYamlRecipe(
+      recipe(),
+      deps({
+        requireApprovalFn: vi.fn(async () => ({ approved: true })),
+        writeFile: () => {
+          writes++;
+        },
+      }),
+    );
+    expect(writes).toBe(1);
+  });
+});
+
+const baseOptions: RunOptions = {
+  env: {},
+  maxConcurrency: 4,
+  maxDepth: 3,
+  dryRun: false,
+};
+const recipeNoTrigger = { name: "r", steps: [] } as unknown as ChainedRecipe;
+
+describe("chained runner — same refusal, same words", () => {
+  it("an EXPIRED approval categorises as approval_expired, not rejected", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ ok: true });
+    const result = await executeChainedStep(
+      {
+        registry: createOutputRegistry(),
+        step: { id: "s", tool: "github.list_prs" },
+        options: baseOptions,
+        recipe: recipeNoTrigger,
+        depth: 0,
+      } as unknown as Parameters<typeof executeChainedStep>[0],
+      {
+        executeTool,
+        executeAgent: vi.fn(),
+        loadNestedRecipe: vi.fn().mockResolvedValue(null),
+        requireApprovalFn: vi.fn(async () => ({
+          approved: false,
+          refusal: "expired" as const,
+        })),
+      } as unknown as ExecutionDeps,
+    );
+    expect(result.success).toBe(false);
+    expect(executeTool).not.toHaveBeenCalled();
+    expect(result.error ?? "").not.toMatch(/rejected/i);
+    expect(categoriseHaltReason(result.error)).toBe("approval_expired");
+  });
+});
+
+describe("the categoriser and the operator hint", () => {
+  it("routes each approval sentence to its own category", () => {
+    expect(
+      categoriseHaltReason(
+        "Step rejected by approval gate — approval_rejected.",
+      ),
+    ).toBe("approval_rejected");
+    expect(
+      categoriseHaltReason(
+        "Step approval expired before anyone answered — approval_expired.",
+      ),
+    ).toBe("approval_expired");
+    expect(
+      categoriseHaltReason(
+        "Step approval cancelled with the run — approval_cancelled.",
+      ),
+    ).toBe("approval_cancelled");
+  });
+
+  it("does NOT tell an operator to approve a request that no longer exists", () => {
+    // The whole cost of the old conflation: the rejection hint sends someone to
+    // the dashboard to approve a queue entry the TTL already resolved.
+    expect(HALT_CATEGORY_HINTS.approval_expired).not.toMatch(/approve/i);
+    expect(HALT_CATEGORY_HINTS.approval_expired).toMatch(
+      /answer|timed out|expir/i,
+    );
+    expect(HALT_CATEGORY_LABELS.approval_expired).toBeTruthy();
+    expect(HALT_CATEGORY_LABELS.approval_cancelled).toBeTruthy();
+  });
+});
+
+/**
+ * The WIRING, not the logic.
+ *
+ * Everything above injects a gate by hand, which proves the runners read a
+ * refusal correctly and proves nothing about whether anything in production
+ * ever produces one. That gap is how a fix lands complete and inert: the
+ * runner learns a new vocabulary and the only two callers keep speaking the
+ * old one. So this drives the real tier gate against a real queue and lets the
+ * TTL fire.
+ */
+describe("the tier gate reports the queue's actual decision", () => {
+  it("an expired queue entry arrives at the runner AS an expiry", async () => {
+    const { getApprovalQueue, resetApprovalQueueForTests } = await import(
+      "../../approvalQueue.js"
+    );
+    const { makeRecipeApprovalFn } = await import(
+      "../../recipeOrchestration.js"
+    );
+    resetApprovalQueueForTests();
+    // 10ms on every tier so the wait really resolves "expired" — the same
+    // path the live 5-minute low-tier TTL takes, just without the wait.
+    getApprovalQueue({ ttlMs: { low: 10, medium: 10, high: 10 } });
+    try {
+      const gate = await makeRecipeApprovalFn("all");
+      const verdict = normaliseApprovalVerdict(
+        await gate({
+          toolId: "github.list_prs",
+          tier: "low",
+          runTaskId: "yaml:dependency-bump:1",
+        }),
+      );
+      expect(verdict.approved).toBe(false);
+      // The precise claim: NOT "rejected". A boolean-returning producer fails
+      // here with `refusal: undefined` even though `approved` is already right.
+      expect(verdict.refusal).toBe("expired");
+      expect(approvalHaltFor(verdict.refusal).category).toBe(
+        "approval_expired",
+      );
+    } finally {
+      resetApprovalQueueForTests();
+    }
+  });
+});

--- a/src/recipes/__tests__/haltCategoryContract.test.ts
+++ b/src/recipes/__tests__/haltCategoryContract.test.ts
@@ -33,7 +33,16 @@ const repoRoot = path.resolve(
 );
 
 function unionMembers(file: string): string[] {
-  const src = readFileSync(path.join(repoRoot, file), "utf8");
+  // Comments are stripped BEFORE the union is matched. The terminator is a
+  // non-greedy `;`, so a single semicolon inside a member's doc comment ends
+  // the capture early and every member after it silently disappears from the
+  // comparison. Caught the first time one was written — but only because one
+  // side had it: had both files carried the same comment, this gate would have
+  // compared two truncated lists and reported agreement. A drift gate that can
+  // be shortened by prose is not a drift gate.
+  const src = readFileSync(path.join(repoRoot, file), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
   const m = /export type HaltCategory\s*=(.*?);/s.exec(src);
   if (!m) throw new Error(`no HaltCategory union found in ${file}`);
   return (m[1] as string)
@@ -109,6 +118,15 @@ describe("bridge and dashboard halt categories agree", () => {
 
   it("the unions hold exactly the same members", () => {
     expect([...dash].sort()).toEqual([...bridge].sort());
+  });
+
+  it("reads each union to its END (a truncated parse must not read as agreement)", () => {
+    // `unknown` is the last member of both unions by convention. If a future
+    // comment truncates the capture, this fails instead of the two shortened
+    // lists quietly matching.
+    expect(bridge).toContain("unknown");
+    expect(dash).toContain("unknown");
+    expect(bridge.length).toBeGreaterThan(15);
   });
 
   it("every bridge category has a label and a hint", () => {

--- a/src/recipes/__tests__/yamlRunner.test.ts
+++ b/src/recipes/__tests__/yamlRunner.test.ts
@@ -4186,7 +4186,7 @@ describe("executeAgent — AgentResult union normalization (PR2a)", () => {
 // view depends on.
 
 describe("haltReason population on error StepResults", () => {
-  it("agent silent-fail populates haltReason naming the silent-fail kind", async () => {
+  it("agent silent-fail populates haltReason naming the actual cause", async () => {
     const recipe = makeRecipe({
       steps: [
         {
@@ -4205,7 +4205,12 @@ describe("haltReason population on error StepResults", () => {
     const step = result.stepResults[0]!;
     expect(step.status).toBe("error");
     expect(step.haltReason).toBeDefined();
-    expect(step.haltReason).toMatch(/silent-fail/);
+    // Was `/silent-fail/` — the name of the pattern that matched, which every
+    // one of these halts carries and none of them is distinguished by. The
+    // marker itself is what the operator needs, and the sentence now carries
+    // it: this assertion is strictly stronger, not relaxed.
+    expect(step.haltReason).toMatch(/ANTHROPIC_API_KEY not set/);
+    expect(step.haltCategory).toBe("agent_silent_fail");
   });
 
   it("agent narration-only output populates haltReason mentioning narration", async () => {

--- a/src/recipes/approvalRequest.ts
+++ b/src/recipes/approvalRequest.ts
@@ -39,5 +39,45 @@ export interface ApprovalRequestInput {
   signal?: AbortSignal;
 }
 
-/** Every approval gate: the tier gate, the worker-autonomy gate, and any test double. */
-export type ApprovalFn = (input: ApprovalRequestInput) => Promise<boolean>;
+/**
+ * Why a gate did not let a step through.
+ *
+ * These are `ApprovalDecision` (approvalQueue.ts) minus `"approved"`, and the
+ * queue has always distinguished them — a rejection is a person deciding, an
+ * expiry is a TTL firing with nobody there, a cancellation is the run itself
+ * going away. `ApprovalFn` returned a bare `boolean`, so all three arrived at
+ * the runner as one and were reported with a sentence that names a human
+ * decision. Measured before this was widened: 49 approved / 7 rejected / 27
+ * expired / 23 cancelled in the durable approval log, so most non-approvals
+ * were never rejections.
+ */
+export type ApprovalRefusal = "rejected" | "expired" | "cancelled";
+
+export interface ApprovalVerdict {
+  approved: boolean;
+  /**
+   * OMITTED when the gate does not know which refusal this was — absence, not
+   * a defaulted `"rejected"`. A gate that cannot say must not have a claim
+   * about a person invented for it; the runner keeps emitting the sentence it
+   * always did for that case.
+   */
+  refusal?: ApprovalRefusal;
+}
+
+/**
+ * Every approval gate: the tier gate, the worker-autonomy gate, and any test
+ * double. A bare `boolean` is still valid and still means exactly what it did
+ * — widening the return type rather than replacing it is what keeps every
+ * existing gate and double honest instead of forcing each to assert a refusal
+ * it does not know.
+ */
+export type ApprovalFn = (
+  input: ApprovalRequestInput,
+) => Promise<boolean | ApprovalVerdict>;
+
+/** Normalise either accepted form to the object form. */
+export function normaliseApprovalVerdict(
+  result: boolean | ApprovalVerdict,
+): ApprovalVerdict {
+  return typeof result === "boolean" ? { approved: result } : result;
+}

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -9,12 +9,14 @@
 
 import { classifyTool } from "../riskTier.js";
 import type { AgentResult } from "./agentExecutor.js";
+import { normaliseApprovalVerdict } from "./approvalRequest.js";
 import type { ExecutionOptions, StepExecutor } from "./dependencyGraph.js";
 import {
   buildDependencyGraph,
   executeWithDependencies,
 } from "./dependencyGraph.js";
 import {
+  approvalHaltFor,
   categoriseHaltReason,
   deriveHaltReasonFromError,
 } from "./haltCategory.js";
@@ -722,20 +724,28 @@ export async function executeChainedStep(
       (recipe as { requireApproval?: boolean }).requireApproval !== false
     ) {
       const approvalToolId = step.agent ? "agent" : (step.tool ?? "unknown");
-      const approved = await deps.requireApprovalFn({
-        toolId: approvalToolId,
-        tier: classifyTool(approvalToolId),
-        summary: step.agent ? "agent step" : `tool ${approvalToolId}`,
-        params: step.agent ? undefined : (resolved as Record<string, unknown>),
-        ...(options.signal && { signal: options.signal }), // L1
-        // Join key onto this run's rows — the same id `runChainedRecipe`
-        // writes to the run log, threaded through the step context.
-        runTaskId: ctx.runTaskId ?? "",
-      });
-      if (!approved) {
+      const verdict = normaliseApprovalVerdict(
+        await deps.requireApprovalFn({
+          toolId: approvalToolId,
+          tier: classifyTool(approvalToolId),
+          summary: step.agent ? "agent step" : `tool ${approvalToolId}`,
+          params: step.agent
+            ? undefined
+            : (resolved as Record<string, unknown>),
+          ...(options.signal && { signal: options.signal }), // L1
+          // Join key onto this run's rows — the same id `runChainedRecipe`
+          // writes to the run log, threaded through the step context.
+          runTaskId: ctx.runTaskId ?? "",
+        }),
+      );
+      if (!verdict.approved) {
+        // The sentence comes from the shared helper, not a literal here: this
+        // path has no `haltCategory` field to set, so its category is recovered
+        // downstream by matching the words. Two copies of the words is a
+        // category derived from a phrase only one copy still produces.
         return {
           success: false,
-          error: "Step rejected by approval gate — approval_rejected.",
+          error: approvalHaltFor(verdict.refusal).reason,
           resolvedParams: resolved,
         };
       }

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -57,6 +57,20 @@ export type HaltCategory =
    * from a tool failure — the run was deliberately stopped by an operator.
    */
   | "approval_rejected"
+  /**
+   * The approval TTL fired with nobody having answered. NOT a rejection: no
+   * person looked at this step. Its own category because the remedies do not
+   * overlap — a rejection is answered by discussing the step, an expiry by
+   * noticing that an unattended run queued something nobody was awake to see.
+   * The queue entry is already resolved, so "go and approve it" is advice that
+   * cannot be followed.
+   */
+  | "approval_expired"
+  /**
+   * The run was cancelled while a step waited for approval. Nobody decided
+   * anything about the step — the thing it belonged to went away.
+   */
+  | "approval_cancelled"
   /** Whole-recipe failure (e.g. circular dependencies) — has no step row. */
   | "run_level"
   /**
@@ -101,6 +115,8 @@ export const HALT_CATEGORY_LABELS: Record<HaltCategory, string> = {
   network_error: "network error",
   missing_connector: "missing connector",
   approval_rejected: "approval rejected",
+  approval_expired: "approval expired",
+  approval_cancelled: "approval cancelled",
   run_level: "run-level halt",
   contract_failed: "completion contract failed",
   unsupported_step: "unsupported step form",
@@ -130,6 +146,12 @@ export const HALT_CATEGORY_HINTS: Record<HaltCategory, string> = {
   missing_connector: "install/connect from /connections",
   approval_rejected:
     "approve the step from the dashboard, or set requireApproval: false",
+  // Deliberately does NOT say "approve it": the queue entry the TTL resolved
+  // no longer exists, so that is advice nobody can act on. This is the whole
+  // operator-facing cost of the conflation this category was split out of.
+  approval_expired:
+    "nobody answered before the approval timed out — an unattended run needs someone watching, `requireApproval: false`, or a longer approval timeout",
+  approval_cancelled: "the run was cancelled while waiting — re-run it",
   run_level: "check recipe for circular deps / parse errors",
   contract_failed:
     "the run finished but broke its `expect` postcondition — compare the assertion with the run output",
@@ -150,6 +172,13 @@ export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   if (/kill[- _]?switch/i.test(reason)) return "kill_switch";
   if (/budget[_ ]?exceeded|exceeded its token budget/i.test(reason))
     return "budget_exceeded";
+  // Both must precede the rejection matcher: its `rejected by .*approval`
+  // alternative is broad, and a mis-ordered expiry reading as a rejection is
+  // exactly the failure this split exists to end.
+  if (/approval[_ ]?expired|approval expired/i.test(reason))
+    return "approval_expired";
+  if (/approval[_ ]?cancelled|approval cancelled/i.test(reason))
+    return "approval_cancelled";
   if (/approval[_ ]?rejected|rejected by .*approval/i.test(reason))
     return "approval_rejected";
   if (/^expect_failed/i.test(reason)) return "expect_failed";
@@ -193,6 +222,42 @@ export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   if (/^Tool .* threw/i.test(reason)) return "tool_threw";
   if (/^Tool .* reported an error/i.test(reason)) return "tool_error";
   return "unknown";
+}
+
+/**
+ * The halt sentence + category for a refused approval, in ONE place.
+ *
+ * Both runners emitted this sentence as their own string literal, and the
+ * chained one recovers its category by matching the sentence with
+ * `categoriseHaltReason` — so a sentence written twice is a category derived
+ * from a phrase that only one of the two copies still matches. Same reason
+ * `agentTextFromTask` exists.
+ *
+ * An ABSENT refusal keeps the pre-existing sentence verbatim. A gate that
+ * returned a bare `false` said "not approved" and nothing more; rendering that
+ * as an expiry or a cancellation would invent a fact, and rendering it as
+ * anything but today's text would break every caller that already reads it.
+ */
+export function approvalHaltFor(
+  refusal?: import("./approvalRequest.js").ApprovalRefusal,
+): { reason: string; category: HaltCategory } {
+  if (refusal === "expired") {
+    return {
+      reason:
+        "Step approval expired before anyone answered — approval_expired.",
+      category: "approval_expired",
+    };
+  }
+  if (refusal === "cancelled") {
+    return {
+      reason: "Step approval cancelled with the run — approval_cancelled.",
+      category: "approval_cancelled",
+    };
+  }
+  return {
+    reason: "Step rejected by approval gate — approval_rejected.",
+    category: "approval_rejected",
+  };
 }
 
 export interface HaltSummary {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -3785,6 +3785,17 @@ function buildAgentExecutorDeps(
         // it, and it is absent for callers that build StepDeps without a scope,
         // which the report counts and names rather than dropping.
         ...(stepDeps.recipeName && { recipeName: stepDeps.recipeName }),
+        // The run this observation belongs to. Same source, same rule and the
+        // same sentence as `recordBoundaryDecisionFn` 26 lines below — never
+        // `seq`, which collides across concurrent bridges.
+        //
+        // The two ledgers describe ONE dispatch. `correlationId` reached the
+        // ENFORCING one and stopped there, which is the exact mirror of #1469
+        // reaching the OBSERVING one and stopping there, recorded in that
+        // function's own comment. Without this, "where do my live policy and my
+        // candidate policy disagree, on this run?" is a join that cannot be
+        // expressed.
+        ...(runTaskId && { correlationId: runTaskId }),
         decision: r.decision,
         reason: r.reason,
         destinationId: r.destinationId,

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -2435,15 +2435,39 @@ export async function runYamlRecipe(
               : agentResult;
             runError = runError ?? reason;
             if (!failOpenAgent) haltAfterFailure = true;
+            // The MARKER, not the name of the pattern that matched it. The
+            // detector's capture was widened to hold the whole marker on the
+            // grounds that "that is where the reason lives"; the widening
+            // reached `error` and stopped there, so every operator-facing
+            // surface — `patchwork halts`, `recipe doctor`, the run-detail
+            // page, the dashboard's owner band, all of which read `haltReason`
+            // — kept only the bookkeeping half. Measured over seven days: 9
+            // halts, one identical contentless sentence, two entirely
+            // different causes underneath (an unreachable model endpoint, and
+            // the information boundary refusing a dispatch while naming its
+            // own one-line remedy).
+            const marker = agentSilentFail?.matched?.trim();
+            const haltReason = agentSilentFail
+              ? marker
+                ? `Agent step "${stepId}" returned no usable output: ${marker}`
+                : `Agent step "${stepId}" returned no usable output (silent-fail: ${agentSilentFail.reason}).`
+              : `Agent step "${stepId}" reported failure.`;
+            // Derived from the sentence that is actually stored, so a reader
+            // that trusts `haltCategory` and one that re-derives from
+            // `haltReason` cannot disagree — `summariseHalts` does both. A
+            // marker naming no known cause derives `unknown`, and the specific
+            // `agent_silent_fail` is kept rather than losing information to it.
+            const derived = categoriseHaltReason(haltReason);
             stepResults.push({
               id: stepId,
               tool: "agent",
               status: "error",
               error: reason,
-              haltReason: agentSilentFail
-                ? `Agent step "${stepId}" returned no usable output (silent-fail: ${agentSilentFail.reason}).`
-                : `Agent step "${stepId}" reported failure.`,
-              haltCategory: "agent_silent_fail",
+              haltReason,
+              haltCategory:
+                agentSilentFail && derived !== "unknown"
+                  ? derived
+                  : "agent_silent_fail",
               durationMs: Date.now() - stepStart,
             });
           } else {

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -67,6 +67,7 @@ import {
   type AgentResult,
   type AgentUsage,
 } from "./agentExecutor.js";
+import { normaliseApprovalVerdict } from "./approvalRequest.js";
 import { deriveBreakerKey, getCircuitBreaker } from "./circuitBreaker.js";
 import {
   expandFlatParallel,
@@ -74,7 +75,11 @@ import {
   unsupportedStepMessage,
 } from "./compoundSteps.js";
 import { FileRollbackLog } from "./fileRollback.js";
-import { categoriseHaltReason, type HaltCategory } from "./haltCategory.js";
+import {
+  approvalHaltFor,
+  categoriseHaltReason,
+  type HaltCategory,
+} from "./haltCategory.js";
 import {
   assertValidManualRunId,
   deriveScopeKey,
@@ -2249,20 +2254,27 @@ export async function runYamlRecipe(
         recipe.requireApproval !== false
       ) {
         const approvalToolId = step.agent ? "agent" : (step.tool ?? "unknown");
-        const approved = await deps.requireApprovalFn({
-          toolId: approvalToolId,
-          tier: classifyTool(approvalToolId),
-          summary: step.agent
-            ? `agent step${step.agent.into ? ` → ${step.agent.into}` : ""}`
-            : `tool ${approvalToolId}`,
-          params: step.agent ? undefined : resolveParamsForApproval(step, ctx),
-          // The join key onto this run's rows in the run log. Same const the
-          // run-log writes above, never a second expression.
-          runTaskId,
-          ...(effectiveRunSignal && { signal: effectiveRunSignal }), // L1
-        });
-        if (!approved) {
-          const reason = `Step rejected by approval gate — approval_rejected.`;
+        const verdict = normaliseApprovalVerdict(
+          await deps.requireApprovalFn({
+            toolId: approvalToolId,
+            tier: classifyTool(approvalToolId),
+            summary: step.agent
+              ? `agent step${step.agent.into ? ` → ${step.agent.into}` : ""}`
+              : `tool ${approvalToolId}`,
+            params: step.agent
+              ? undefined
+              : resolveParamsForApproval(step, ctx),
+            // The join key onto this run's rows in the run log. Same const the
+            // run-log writes above, never a second expression.
+            runTaskId,
+            ...(effectiveRunSignal && { signal: effectiveRunSignal }), // L1
+          }),
+        );
+        if (!verdict.approved) {
+          // Which refusal this was decides the sentence AND the category — an
+          // expiry names no person, and its hint must not send the operator to
+          // approve a queue entry the TTL already resolved.
+          const { reason, category } = approvalHaltFor(verdict.refusal);
           runError = runError ?? reason;
           haltAfterFailure = true;
           const rejId = step.into ?? step.agent?.into ?? `step_${stepsRun}`;
@@ -2272,7 +2284,7 @@ export async function runYamlRecipe(
             status: "error",
             error: reason,
             haltReason: reason,
-            haltCategory: "approval_rejected",
+            haltCategory: category,
             durationMs: 0,
           });
           stepsRun++;

--- a/src/workers/__tests__/workerRecipeHealth.test.ts
+++ b/src/workers/__tests__/workerRecipeHealth.test.ts
@@ -1,0 +1,266 @@
+/**
+ * A worker manifest can be perfect and still govern a recipe that cannot run.
+ *
+ * `validateWorkers` checks the BINDING — does the manifest parse, does the
+ * `recipe:` it names exist, does anyone else claim it. It never asked whether
+ * the recipe on the other end of that binding works. Measured on the reference
+ * install the day this was written: 8 manifests, "✓ no problems found", while
+ * `recipe doctor` on one of the bound recipes reported 8 errors and 2 warnings
+ * — six tool ids that are not registered, and a variable written three times by
+ * three different steps. A second bound recipe wrote a file it never declared.
+ *
+ * Two workers of eight bound to recipes that cannot do their job, and the
+ * health check for workers said everything was fine. It is the same shape as
+ * every other finding in this file: a correct rule pointed at a subset.
+ *
+ * The probe is INJECTED rather than imported. `runPreflight` drags in the whole
+ * recipe planner, and a validator that can only be tested against the planner
+ * is a validator whose failure modes can only be produced by breaking a recipe.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  probeWorkerRecipes,
+  type RecipeHealthProbe,
+  summariseRecipeHealth,
+} from "../workerRecipeHealth.js";
+import {
+  formatWorkersValidate,
+  validateWorkersWithRecipeHealth,
+} from "../workersCli.js";
+
+const workers = [
+  { id: "scout", recipe: "nightly-scan" },
+  { id: "guardian", recipe: "watch-tests" },
+];
+
+function probeReturning(
+  byRecipe: Record<string, Awaited<ReturnType<RecipeHealthProbe>>>,
+): RecipeHealthProbe {
+  return async (recipe: string) => byRecipe[recipe] ?? { ok: true, issues: [] };
+}
+
+describe("probeWorkerRecipes", () => {
+  it("an unrunnable recipe is a finding even when the manifest is perfect", async () => {
+    const findings = await probeWorkerRecipes(workers, {
+      probe: probeReturning({
+        "nightly-scan": {
+          ok: false,
+          issues: [
+            {
+              level: "error",
+              code: "lint-error",
+              message: "step 3 has no id",
+            },
+          ],
+        },
+      }),
+    });
+    const f = findings.find((x) => x.code === "recipe-unhealthy");
+    expect(f).toBeDefined();
+    expect(f?.level).toBe("error");
+    expect(f?.message).toContain("scout");
+    expect(f?.message).toContain("nightly-scan");
+  });
+
+  it("an unresolved tool is a WARNING, and says why it is not an error", async () => {
+    // The step is skipped silently and the run finishes `done` — but the tool
+    // may equally come from a plugin this process did not load, and failing on
+    // that would make the check permanently red on a correct install.
+    const findings = await probeWorkerRecipes(workers, {
+      probe: probeReturning({
+        "nightly-scan": {
+          ok: false,
+          issues: [
+            {
+              level: "error",
+              code: "unresolved-tool",
+              message: 'Tool "code.scan_duplicates" is not registered',
+            },
+          ],
+        },
+      }),
+    });
+    const f = findings.find((x) => x.code === "recipe-unhealthy");
+    expect(f?.level).toBe("warning");
+    expect(f?.message).toMatch(/plugin/i);
+    expect(f?.message).toMatch(/silently|skip/i);
+  });
+
+  it("one lint error among unresolved tools still makes it an error", async () => {
+    const findings = await probeWorkerRecipes(workers, {
+      probe: probeReturning({
+        "nightly-scan": {
+          ok: false,
+          issues: [
+            { level: "error", code: "unresolved-tool", message: "a" },
+            { level: "error", code: "lint-error", message: "b" },
+          ],
+        },
+      }),
+    });
+    expect(findings.find((x) => x.code === "recipe-unhealthy")?.level).toBe(
+      "error",
+    );
+  });
+
+  it("a probe that THROWS is reported as not-checked, never as healthy", async () => {
+    const findings = await probeWorkerRecipes(workers, {
+      probe: async (recipe: string) => {
+        if (recipe === "nightly-scan") throw new Error("unreadable");
+        return { ok: true, issues: [] };
+      },
+    });
+    const f = findings.find((x) => x.code === "recipe-uncheckable");
+    expect(f).toBeDefined();
+    expect(findings.some((x) => x.code === "recipe-unhealthy")).toBe(false);
+  });
+
+  it("a worker with no recipe is not probed (validateWorkers already reports it)", async () => {
+    let calls = 0;
+    const findings = await probeWorkerRecipes(
+      [{ id: "orphan", recipe: undefined }],
+      {
+        probe: async () => {
+          calls++;
+          return { ok: true, issues: [] };
+        },
+      },
+    );
+    expect(calls).toBe(0);
+    expect(findings).toEqual([]);
+  });
+
+  it("probes each distinct recipe once even when two workers claim it", async () => {
+    let calls = 0;
+    await probeWorkerRecipes(
+      [
+        { id: "a", recipe: "shared" },
+        { id: "b", recipe: "shared" },
+      ],
+      {
+        probe: async () => {
+          calls++;
+          return { ok: true, issues: [] };
+        },
+      },
+    );
+    expect(calls).toBe(1);
+  });
+});
+
+describe("summariseRecipeHealth leads with the denominator", () => {
+  it("says how many were checked, not just how many failed", async () => {
+    const findings = await probeWorkerRecipes(workers, {
+      probe: probeReturning({
+        "nightly-scan": {
+          ok: false,
+          issues: [{ level: "error", code: "lint-error", message: "x" }],
+        },
+      }),
+    });
+    const line = summariseRecipeHealth(findings, { probed: 2 });
+    expect(line).toContain("2");
+    expect(line).toMatch(/1 unhealthy|1 of 2/);
+  });
+
+  it("nothing to check reads differently from everything is fine", () => {
+    expect(summariseRecipeHealth([], { probed: 0 })).toMatch(/no .*recipe/i);
+    expect(summariseRecipeHealth([], { probed: 3 })).toMatch(/3/);
+  });
+});
+
+/**
+ * The WIRING, with the REAL probe.
+ *
+ * Every test above injects one, which proves the finding logic and proves
+ * nothing about whether `recipe doctor`'s static half can actually be reached
+ * from here — the gap that leaves a check landed and inert. So this one builds a
+ * genuinely broken recipe on disk and lets the default probe find it.
+ */
+describe("validateWorkersWithRecipeHealth against the real probe", () => {
+  let root: string;
+  let workersDir: string;
+  let recipesDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), "pw-worker-recipe-health-"));
+    workersDir = path.join(root, "workers");
+    recipesDir = path.join(root, "recipes");
+    for (const d of [workersDir, recipesDir]) mkdirSync(d, { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function install(worker: string, recipeFile: string, recipeBody: string) {
+    writeFileSync(path.join(workersDir, "w.worker.yaml"), worker);
+    writeFileSync(path.join(recipesDir, recipeFile), recipeBody);
+  }
+
+  const workerYaml = `id: probe-worker
+name: Probe
+responsibilities: [x]
+recipe: bound-recipe
+owns: [issue]
+autonomyCeiling: 1
+`;
+
+  it("reaches a recipe whose FILENAME differs from its declared name", async () => {
+    // A worker's \`recipe:\` names the declared name, not the file. Resolving by
+    // guessing "<name>.yaml" reports a recipe that is right there as one it
+    // could not check.
+    install(
+      workerYaml,
+      "totally-different-filename.yaml",
+      "name: bound-recipe\ndescription: d\ntrigger: { type: manual }\nsteps:\n  - tool: not.a.real.tool\n    into: x\n",
+    );
+    const result = await validateWorkersWithRecipeHealth({
+      workersDir,
+      recipesDir,
+    });
+    expect(result.findings.some((f) => f.code === "recipe-uncheckable")).toBe(
+      false,
+    );
+    const f = result.findings.find((x) => x.code === "recipe-unhealthy");
+    expect(f).toBeDefined();
+    expect(f?.message).toContain("not.a.real.tool");
+    // Unresolved tools alone stay a warning, so the exit code does not flip.
+    expect(f?.level).toBe("warning");
+    expect(result.healthy).toBe(true);
+  });
+
+  it("a clean bound recipe reports the denominator and no finding", async () => {
+    install(
+      workerYaml,
+      "bound.yaml",
+      "name: bound-recipe\ndescription: d\ntrigger: { type: manual }\nsteps:\n  - agent:\n      prompt: say hello\n      into: out\n",
+    );
+    const result = await validateWorkersWithRecipeHealth({
+      workersDir,
+      recipesDir,
+    });
+    expect(result.findings.filter((f) => f.code.startsWith("recipe-"))).toEqual(
+      [],
+    );
+    expect(result.counts.recipesProbed).toBe(1);
+    expect(result.recipeHealth).toContain("0 of 1");
+    expect(formatWorkersValidate(result)).toContain("0 of 1");
+  });
+
+  it("says a recipe was NOT checked rather than passing it", async () => {
+    // No recipe file at all: the dangling-recipe error fires next door, and the
+    // health pass must not quietly count it as healthy.
+    writeFileSync(path.join(workersDir, "w.worker.yaml"), workerYaml);
+    const result = await validateWorkersWithRecipeHealth({
+      workersDir,
+      recipesDir,
+      probe: async () => {
+        throw new Error("no such recipe");
+      },
+    });
+    const f = result.findings.find((x) => x.code === "recipe-uncheckable");
+    expect(f?.message).toMatch(/not a pass/i);
+  });
+});

--- a/src/workers/__tests__/workerRecipeHealth.test.ts
+++ b/src/workers/__tests__/workerRecipeHealth.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../workerRecipeHealth.js";
 import {
   formatWorkersValidate,
+  validateWorkers,
   validateWorkersWithRecipeHealth,
 } from "../workersCli.js";
 
@@ -262,5 +263,62 @@ autonomyCeiling: 1
     });
     const f = result.findings.find((x) => x.code === "recipe-uncheckable");
     expect(f?.message).toMatch(/not a pass/i);
+  });
+});
+
+/**
+ * The third way a perfect binding governs nothing: the recipe is DISABLED.
+ *
+ * `recipes.disabled` in the patchwork config is read by the scheduler, the
+ * event-trigger programs and the HTTP route, so a disabled recipe never fires
+ * from any trigger. A worker bound to one is installed, parses, binds, owns
+ * action classes, carries a `forbids` list — and can never run.
+ *
+ * A WARNING, not an error: disabling a recipe is a deliberate operator act, and
+ * failing the check on an intended state is how a gate gets ignored. What is
+ * worth saying is the PAIRING — the worker is still installed and still claims
+ * to govern something.
+ */
+describe("a worker bound to a disabled recipe", () => {
+  let root: string;
+  let workersDir: string;
+  let recipesDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), "pw-worker-disabled-"));
+    workersDir = path.join(root, "workers");
+    recipesDir = path.join(root, "recipes");
+    for (const d of [workersDir, recipesDir]) mkdirSync(d, { recursive: true });
+    writeFileSync(
+      path.join(workersDir, "w.worker.yaml"),
+      "id: scout\nname: Scout\nresponsibilities: [x]\nrecipe: nightly-scan\nowns: [issue]\nautonomyCeiling: 1\n",
+    );
+    writeFileSync(
+      path.join(recipesDir, "nightly-scan.yaml"),
+      "name: nightly-scan\ndescription: d\ntrigger: { type: manual }\nsteps:\n  - agent:\n      prompt: x\n      into: out\n",
+    );
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("is reported, and says the worker cannot run at all", () => {
+    const result = validateWorkers({
+      workersDir,
+      recipesDir,
+      disabledRecipes: ["nightly-scan"],
+    });
+    const f = result.findings.find((x) => x.code === "disabled-recipe");
+    expect(f).toBeDefined();
+    expect(f?.level).toBe("warning");
+    expect(f?.message).toContain("scout");
+    expect(f?.message).toContain("nightly-scan");
+    // Deliberate operator state — it must not fail the check.
+    expect(result.healthy).toBe(true);
+  });
+
+  it("is silent when the recipe is enabled", () => {
+    const result = validateWorkers({ workersDir, recipesDir });
+    expect(result.findings.some((x) => x.code === "disabled-recipe")).toBe(
+      false,
+    );
   });
 });

--- a/src/workers/workerRecipeHealth.ts
+++ b/src/workers/workerRecipeHealth.ts
@@ -1,0 +1,160 @@
+/**
+ * Does the recipe a worker is bound to actually WORK?
+ *
+ * `validateWorkers` answers every way a manifest can fail to BIND — it does not
+ * parse, its `recipe:` is not installed, two workers claim the same one. All of
+ * those end with `resolveWorkerIdForRecipe` returning undefined. None of them
+ * looks at the other end of a binding that succeeded.
+ *
+ * Measured on the reference install: 8 manifests, `✓ no problems found`, while
+ * `recipe doctor` on one of the bound recipes reported 8 errors and 2 warnings
+ * — six unregistered tool ids and a variable written by three different steps —
+ * and a second bound recipe performed a write it never declared. A worker whose
+ * every step is skipped runs, finishes `done`, and governs nothing, which is the
+ * same end state the rest of that validator exists to catch. The information was
+ * already there; nobody ran `recipe doctor` once per worker.
+ *
+ * The probe is INJECTED. `runPreflight` pulls in the recipe planner, the tool
+ * registry and the fixture loader, and a check that can only be exercised
+ * through those can only be tested by breaking a real recipe.
+ */
+
+/** One issue as `runPreflight` reports it — level + code + sentence. */
+export interface RecipeHealthIssue {
+  level: "error" | "warning";
+  code: string;
+  message: string;
+}
+
+export interface RecipeHealthReport {
+  ok: boolean;
+  issues: RecipeHealthIssue[];
+}
+
+/** Probe one recipe by name. Throws if the recipe cannot be read or planned. */
+export type RecipeHealthProbe = (
+  recipeName: string,
+) => Promise<RecipeHealthReport>;
+
+export interface WorkerRecipeBinding {
+  id: string;
+  recipe?: string | undefined;
+}
+
+export interface RecipeHealthFinding {
+  level: "error" | "warning";
+  code: "recipe-unhealthy" | "recipe-uncheckable";
+  message: string;
+}
+
+/**
+ * Codes whose severity depends on state THIS process cannot see, and which
+ * therefore must not decide an exit code.
+ *
+ * `unresolved-tool` — an unregistered tool id makes the runner SKIP the step
+ * silently, which is deliberate (forward compatibility for a plugin that is not
+ * loaded here). Measured across the reference install: 20 unregistered ids in
+ * 14 of 82 recipes, all from plugins that live in another package. Failing on
+ * those would make this check permanently red on a correctly configured
+ * machine, and a permanently-red gate is how a real warning gets ignored. It is
+ * still REPORTED, with what it means when the tool is not coming from anywhere.
+ *
+ * `unacknowledged-write` — enforced at runtime only under
+ * `FLAG_ENFORCE_ALLOWWRITES`, which is off by default. An error under that flag
+ * and advisory without it; this check cannot tell which machine it is on.
+ */
+const STATE_DEPENDENT_CODES = new Set([
+  "unresolved-tool",
+  "unacknowledged-write",
+]);
+
+/**
+ * Probe each DISTINCT recipe a worker is bound to and turn what comes back into
+ * validator findings.
+ *
+ * A probe that throws produces `recipe-uncheckable`, never silence and never a
+ * pass: "the reading could not be taken" and "the reading was clean" are
+ * different facts, and collapsing them is how a broken probe reads as a healthy
+ * install.
+ */
+export async function probeWorkerRecipes(
+  workers: readonly WorkerRecipeBinding[],
+  opts: { probe: RecipeHealthProbe },
+): Promise<RecipeHealthFinding[]> {
+  const findings: RecipeHealthFinding[] = [];
+  // Distinct recipes, first claimant kept for the message. Two workers claiming
+  // one recipe is already an `ambiguous-recipe` error next door; probing it
+  // twice would report the same defect twice under a different code.
+  const byRecipe = new Map<string, string[]>();
+  for (const w of workers) {
+    if (!w.recipe) continue;
+    byRecipe.set(w.recipe, [...(byRecipe.get(w.recipe) ?? []), w.id]);
+  }
+
+  for (const [recipe, ids] of byRecipe) {
+    const who = ids.join(", ");
+    let report: RecipeHealthReport;
+    try {
+      report = await opts.probe(recipe);
+    } catch (err) {
+      findings.push({
+        level: "warning",
+        code: "recipe-uncheckable",
+        message:
+          `${who} names recipe "${recipe}", which could NOT be checked: ` +
+          `${err instanceof Error ? err.message : String(err)}. ` +
+          "Not a pass — nothing was verified about whether it can run.",
+      });
+      continue;
+    }
+    if (report.ok) continue;
+
+    const errors = report.issues.filter((i) => i.level === "error");
+    const hard = errors.filter((i) => !STATE_DEPENDENT_CODES.has(i.code));
+    const level = hard.length > 0 ? "error" : "warning";
+    const codes = [...new Set(errors.map((i) => i.code))].sort().join(", ");
+    const detail = errors
+      .slice(0, 4)
+      .map((i) => i.message)
+      .join("; ");
+    const caveat =
+      level === "warning"
+        ? " Reported as a warning, not a failure: an unregistered tool may come " +
+          "from a plugin this process did not load, and an undeclared write is " +
+          "enforced only under FLAG_ENFORCE_ALLOWWRITES. If neither applies, the " +
+          "step is skipped silently and the worker's run finishes `done` having " +
+          "governed nothing."
+        : "";
+    findings.push({
+      level,
+      code: "recipe-unhealthy",
+      message:
+        `${who} is bound to recipe "${recipe}", which fails \`recipe doctor\` ` +
+        `with ${errors.length} error(s) [${codes}]: ${detail}.${caveat}`,
+    });
+  }
+  return findings;
+}
+
+/**
+ * The denominator line. "0 unhealthy" over zero probed recipes and over eight
+ * are different statements, and printing them identically is how an install
+ * with nothing installed reads as an install with nothing wrong — the same
+ * reason `formatWorkersValidate` leads with its manifest count.
+ */
+export function summariseRecipeHealth(
+  findings: readonly RecipeHealthFinding[],
+  counts: { probed: number },
+): string {
+  if (counts.probed === 0) {
+    return "no worker is bound to a recipe, so no recipe was checked";
+  }
+  const unhealthy = findings.filter(
+    (f) => f.code === "recipe-unhealthy",
+  ).length;
+  const uncheckable = findings.filter(
+    (f) => f.code === "recipe-uncheckable",
+  ).length;
+  const tail = uncheckable > 0 ? `, ${uncheckable} could not be checked` : "";
+  return `${unhealthy} of ${counts.probed} bound recipe(s) unhealthy${tail}`;
+}

--- a/src/workers/workersCli.ts
+++ b/src/workers/workersCli.ts
@@ -44,6 +44,11 @@ import {
   formatWorkerManifestDrift,
 } from "./manifestDrift.js";
 import { parseWorker, type WorkerManifest } from "./worker.js";
+import {
+  probeWorkerRecipes,
+  type RecipeHealthProbe,
+  summariseRecipeHealth,
+} from "./workerRecipeHealth.js";
 
 const MANIFEST_RE = /\.worker\.ya?ml$/i;
 
@@ -98,30 +103,50 @@ export function scanWorkers(dir: string): WorkersScan {
   return { dir, loaded, broken };
 }
 
-/** Recipe names installed in `dir`, for the dangling-reference check. */
-export function installedRecipeNames(dir: string): Set<string> {
-  const names = new Set<string>();
-  if (!existsSync(dir)) return names;
+/**
+ * Declared recipe NAME → the file that declares it, for `dir`.
+ *
+ * A recipe's `name:` and its filename are allowed to differ, and a worker's
+ * `recipe:` names the former. Keeping the path is what lets the recipe-health
+ * probe open the right file instead of guessing `<name>.yaml` and reporting a
+ * recipe it simply could not find as one it could not check.
+ */
+export function installedRecipePaths(dir: string): Map<string, string> {
+  const byName = new Map<string, string>();
+  if (!existsSync(dir)) return byName;
   let entries: string[];
   try {
     entries = readdirSync(dir);
   } catch {
-    return names;
+    return byName;
   }
-  for (const f of entries) {
+  for (const f of entries.sort()) {
     if (!/\.ya?ml$/i.test(f)) continue;
+    const full = path.join(dir, f);
     try {
-      const parsed = parseYaml(readFileSync(path.join(dir, f), "utf-8")) as
+      const parsed = parseYaml(readFileSync(full, "utf-8")) as
         | { name?: unknown }
         | undefined;
-      if (typeof parsed?.name === "string") names.add(parsed.name);
+      // First declarant wins, and entries are sorted, so the mapping is stable
+      // rather than directory-order dependent.
+      if (typeof parsed?.name === "string" && !byName.has(parsed.name)) {
+        byName.set(parsed.name, full);
+      }
     } catch {
       // An unreadable recipe is the recipe subsystem's problem to report, not
       // this one's. Skipping it can only make the dangling check MORE likely to
       // fire, never less — it cannot hide a real finding.
     }
   }
-  return names;
+  return byName;
+}
+
+/** Recipe names installed in `dir`, for the dangling-reference check. */
+export function installedRecipeNames(dir: string): Set<string> {
+  // One walk, one parse, two readers. Two implementations of "what is
+  // installed" drift, and the drift shows up as a dangling-recipe error next to
+  // a recipe-health finding that says the same file is fine.
+  return new Set(installedRecipePaths(dir).keys());
 }
 
 export interface WorkersFinding {
@@ -133,7 +158,13 @@ export interface WorkersFinding {
 export interface ValidateResult {
   findings: WorkersFinding[];
   healthy: boolean;
-  counts: { loaded: number; broken: number };
+  counts: { loaded: number; broken: number; recipesProbed?: number };
+  /**
+   * Denominator line for the recipe-health pass. ABSENT when no probe ran —
+   * which is not the same statement as "every bound recipe is fine", and is
+   * printed as its own line rather than folded into silence.
+   */
+  recipeHealth?: string;
 }
 
 export function validateWorkers(opts: {
@@ -230,6 +261,69 @@ export function validateWorkers(opts: {
   };
 }
 
+/**
+ * The default probe: `recipe doctor`'s static half, against the file that
+ * actually declares the name a worker is bound to.
+ *
+ * Dynamically imported. `commands/recipe.ts` pulls in the planner, the tool
+ * registry and the fixture loader, and `workers list` has no business paying
+ * for any of that.
+ */
+export function makeRecipeDoctorProbe(recipesDir: string): RecipeHealthProbe {
+  const byName = installedRecipePaths(recipesDir);
+  return async (recipeName: string) => {
+    const { runPreflight } = await import("../commands/recipe.js");
+    // Resolve through the declared name when we can. Falling back to the bare
+    // name lets `runPreflight` find a bundled template the live dir does not
+    // carry, rather than reporting it uncheckable.
+    const ref = byName.get(recipeName) ?? recipeName;
+    const result = await runPreflight(ref, {});
+    return {
+      ok: result.ok,
+      issues: result.issues.map((i) => ({
+        level: i.level,
+        code: i.code,
+        message: i.message,
+      })),
+    };
+  };
+}
+
+/**
+ * `validateWorkers` plus the question it never asked: can the recipe on the
+ * other end of a successful binding actually run?
+ *
+ * Separate from `validateWorkers` (which stays sync and dependency-free) rather
+ * than folded into it: the probe is async and drags in the recipe planner, and
+ * every existing caller of the structural check keeps working untouched.
+ */
+export async function validateWorkersWithRecipeHealth(opts: {
+  workersDir: string;
+  recipesDir: string;
+  templatesDir?: string;
+  /** Override for tests; defaults to `recipe doctor`'s static half. */
+  probe?: RecipeHealthProbe;
+}): Promise<ValidateResult> {
+  const base = validateWorkers(opts);
+  const scan = scanWorkers(opts.workersDir);
+  const bindings = scan.loaded.map(({ worker }) => ({
+    id: worker.id,
+    recipe: worker.recipe,
+  }));
+  const probed = new Set(
+    bindings.map((b) => b.recipe).filter((r): r is string => !!r),
+  ).size;
+  const probe = opts.probe ?? makeRecipeDoctorProbe(opts.recipesDir);
+  const health = await probeWorkerRecipes(bindings, { probe });
+  const findings = [...base.findings, ...health];
+  return {
+    findings,
+    healthy: !findings.some((f) => f.level === "error"),
+    counts: { ...base.counts, recipesProbed: probed },
+    recipeHealth: summariseRecipeHealth(health, { probed }),
+  };
+}
+
 export function formatWorkersList(scan: WorkersScan): string {
   const out: string[] = [];
   out.push(`Workers in ${scan.dir}`);
@@ -272,6 +366,10 @@ export function formatWorkersValidate(result: ValidateResult): string {
   out.push(
     `  ${result.counts.loaded} manifest(s) load, ${result.counts.broken} ignored`,
   );
+  // A second denominator, for the second question. "No problems" over manifests
+  // that were checked and recipes that were NOT is the exact reading this pass
+  // was added to end.
+  if (result.recipeHealth) out.push(`  ${result.recipeHealth}`);
   if (result.findings.length === 0) {
     out.push("");
     out.push(

--- a/src/workers/workersCli.ts
+++ b/src/workers/workersCli.ts
@@ -171,6 +171,13 @@ export function validateWorkers(opts: {
   workersDir: string;
   recipesDir: string;
   templatesDir?: string;
+  /**
+   * `recipes.disabled` from the patchwork config. Passed IN rather than read
+   * here so this stays a pure function of its inputs — a validator that reads
+   * the operator's config behind the caller's back cannot be tested against a
+   * state the machine is not in.
+   */
+  disabledRecipes?: ReadonlyArray<string>;
 }): ValidateResult {
   const scan = scanWorkers(opts.workersDir);
   const findings: WorkersFinding[] = [];
@@ -186,6 +193,7 @@ export function validateWorkers(opts: {
   }
 
   const recipes = installedRecipeNames(opts.recipesDir);
+  const disabled = new Set(opts.disabledRecipes ?? []);
   const claims = new Map<string, string[]>();
   for (const { worker } of scan.loaded) {
     if (!worker.recipe) {
@@ -201,6 +209,22 @@ export function validateWorkers(opts: {
         level: "error",
         code: "dangling-recipe",
         message: `${worker.id} names recipe "${worker.recipe}", which is not installed. The worker governs nothing.`,
+      });
+    }
+    if (disabled.has(worker.recipe)) {
+      // The completest way a perfect binding governs nothing: the scheduler,
+      // the event-trigger programs and the HTTP route all consult this list, so
+      // the recipe fires from no trigger at all. A WARNING and not an error —
+      // disabling a recipe is a deliberate act, and failing the check on an
+      // intended state is how a gate gets ignored. What is worth saying is the
+      // pairing: the worker is still installed and still claims to govern this.
+      findings.push({
+        level: "warning",
+        code: "disabled-recipe",
+        message:
+          `${worker.id} is bound to recipe "${worker.recipe}", which is DISABLED — ` +
+          "no trigger fires it, so the worker never runs. Re-enable the recipe " +
+          "or uninstall the worker; leaving both is a manifest that governs nothing.",
       });
     }
     claims.set(worker.recipe, [
@@ -301,6 +325,7 @@ export async function validateWorkersWithRecipeHealth(opts: {
   workersDir: string;
   recipesDir: string;
   templatesDir?: string;
+  disabledRecipes?: ReadonlyArray<string>;
   /** Override for tests; defaults to `recipe doctor`'s static half. */
   probe?: RecipeHealthProbe;
 }): Promise<ValidateResult> {


### PR DESCRIPTION
Five fixes to the worker/approval reliability surface, each found by driving the real ledgers rather than by reading code.

## The finding that changes what you'd do

**Five of the eight installed workers are bound to recipes in `recipes.disabled`** — `feature-chronicle`, `llama33-showcase`, `month-end-exception-review`, `release-notes`, `nightly-tech-debt-scout`. The scheduler, the event-trigger programs and the HTTP route all consult that list, so those recipes fire from **no trigger at all** — while the manifest still parses, still binds, still owns action classes and still carries a `forbids` list. `workers validate` reported `✓ no problems found` throughout.

Verified independently on the reference install before merging this: 5 of 8, and the run log agrees — four of the five have **zero runs** across its entire span.

That reframes two things previously read as behaviour: *"Release Worker has gate telemetry but no attributable run evidence"* and *"Feature Chronicle has errors/interrupted runs"* are the same fact — **those workers have not executed.**

Reported as a **WARNING, not an error**: disabling a recipe is a deliberate operator act, and failing a check on an intended state is how a gate gets ignored. What is worth saying is the *pairing* — the worker is still installed and still claims to govern something — so the message names both halves of the remedy.

## The other four

- **An expiry nobody saw was reported as a rejection a human made.** Dependency Upkeep was never rejected: the step ran 300,006 ms against the low tier's 300,000 ms TTL and **expired** on an unattended cron run. Across all time: 49 approved, 7 rejected, 27 expired, 23 cancelled — most non-approvals were never rejections, and every one that halted a recipe told the operator *"You turned down its last request"* and sent them to approve a queue entry the TTL had already resolved.
- **The agent halt sentence threw away the reason it was handed.** The 9 "agent silent failures" are not worker failures — they are two probe recipes: 6 × `fetch failed` (local model endpoint unreachable) and 3 × the ADR-0021 boundary refusing a dispatch *while naming its own one-line remedy*. All nine rendered as one identical contentless sentence, because `haltReason` kept the name of the pattern that matched and dropped the marker saying what happened.
- **The worker health check never asked whether the recipe runs.** `validateWorkers` covers every way a manifest fails to *bind*; nothing looked at the other end of a binding that succeeded. The probe is injected so it can be tested without breaking a real recipe.
- **`privacy_shadow.jsonl` could not name the run it observed** (0 of 311) — it sits 26 lines from `boundary_receipts.jsonl` (110 of 266), written from the same dispatch with the same id already in scope.

## Deliberately not done, each with a reason

- **No `workerRunId`.** ADR-0025 already fixes the stable key as the run's `taskId`; a second identity for the same thing is the drift the `rv` protocol exists to prevent.
- **Read-only tools still queue** under `approvalGate: "all"` — exempting them removes gating that was explicitly asked for.
- **No `approval_forbidden` category** — 0 forbid rows in 280 gate decisions, so it would implement a branch that has never fired.
- **The chained runner's matching silent-fail defect** — needs a categoriser reorder that changes how existing rows read, and its observed population is zero.
- **Tech Debt Scout's 6 missing tools not implemented** — four of them sit in `stash@{1}`, another session's unmerged WIP.

## Verification

- full suite **10614 passed, 4 skipped, 0 failed** (re-run on this branch, not inherited)
- all CI audit gates pass, build clean
- already merged up to `origin/main` including #1561

## Two things need an operator, not code

1. **Re-enable those five recipes or uninstall the workers.** Either is fine; the current state is the one that says nothing.
2. **Deploy.** None of this reaches the running bridges until `npm run install:global` + kickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)