### PR TITLE
feat(gate): the Decision Record said why, and had no stable name for which rule

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,19 +50,22 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-31 `feat/gate-rule-id` — the Decision Record said WHY in prose and had no stable key
-  for WHICH RULE decided. A receipt citing a rule, an operator filtering on one, and any later
-  grouping all need something that survives rewording, so `reason` (prose, expected to change)
-  and `ruleId` (stable) become separate fields. Nine terminal branches, nine ids, required on
-  the decision so a new branch is a compile error until it names its rule. `rv` 1 → 2, where 2
-  means "this row carries a ruleId" — `correlationOf` does not skip unknown versions, so the
-  bump adds a guarantee without stranding a reader. Names a rule the ENGINE applied, never a
-  customer policy id: a curated pack is control-plane by ADR-0019.
-
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-31 `feat/gate-rule-id` — the Decision Record said WHY in prose and had no stable
+  key for WHICH RULE decided, so a receipt, an operator filter or any grouping had to key on
+  a sentence. `reason` and `ruleId` split into two fields with two jobs; nine terminal
+  branches, nine ids, REQUIRED on the decision so a new branch is a compile error until it
+  names its rule. `rv` 1 → 2, cumulative: 1 promises `correlationId`, 2 promises `ruleId`,
+  and the bump strands no reader because `correlationOf` does not skip unknown versions.
+  `ruleOf` keeps the middle state honest — a pre-rule row is `unversioned`, never "no rule
+  applied". Names a rule the ENGINE applied, never a customer policy id (ADR-0019 reserves
+  curated packs for the control plane). `record()` dropped it on the way to disk, the THIRD
+  field that literal has had to be told about after `correlationId` and `workspaceId`, and
+  its own comment already documents the trap. — #1563
 
 - 2026-08-31 `codex/worker-reliability-fixes` — five reliability fixes for the maintenance
   workers, each one an existing subsystem answering a narrower question than the one an

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,6 +50,15 @@ verified (which is how this line came to be written).
 
 ## Active
 
+- 2026-08-31 `feat/gate-rule-id` — the Decision Record said WHY in prose and had no stable key
+  for WHICH RULE decided. A receipt citing a rule, an operator filtering on one, and any later
+  grouping all need something that survives rewording, so `reason` (prose, expected to change)
+  and `ruleId` (stable) become separate fields. Nine terminal branches, nine ids, required on
+  the decision so a new branch is a compile error until it names its rule. `rv` 1 → 2, where 2
+  means "this row carries a ruleId" — `correlationOf` does not skip unknown versions, so the
+  bump adds a guarantee without stranding a reader. Names a rule the ENGINE applied, never a
+  customer policy id: a curated pack is control-plane by ADR-0019.
+
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 

--- a/src/__tests__/gateRuleState.test.ts
+++ b/src/__tests__/gateRuleState.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `ruleOf` — the same three-way honesty `correlationOf` has, one field over.
+ *
+ * The distinction that matters: a row written before rules were named is
+ * `unversioned`, NOT "no rule applied". A rule DID apply; nobody recorded
+ * which. Collapsing those two into one value is the absence-collapse ADR-0025
+ * exists to prevent, and it cannot be undone once readers depend on it.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  GATE_RECORD_VERSION,
+  ruleOf,
+  WorkerGateDecisionLog,
+} from "../workerGateDecisionLog.js";
+
+describe("ruleOf", () => {
+  it("reports a pre-rule row as unversioned, never as 'no rule'", () => {
+    expect(ruleOf({ rv: 1, correlationId: "t" } as never)).toEqual({
+      state: "unversioned",
+    });
+    expect(ruleOf({} as never)).toEqual({ state: "unversioned" });
+  });
+
+  it("names the rule when the row carries one at a version that guarantees it", () => {
+    expect(ruleOf({ rv: 2, ruleId: "gate.unearned-trust" } as never)).toEqual({
+      state: "named",
+      ruleId: "gate.unearned-trust",
+    });
+  });
+
+  it("reports a WRITER DEFECT when the level guarantees a rule and none is there", () => {
+    // Not "unversioned": the row claims rv>=2, which promises a ruleId. A
+    // reader must be able to tell a writer bug from an older writer.
+    expect(ruleOf({ rv: 2 } as never)).toEqual({ state: "defect", rv: 2 });
+    expect(ruleOf({ rv: 2, ruleId: "" } as never)).toEqual({
+      state: "defect",
+      rv: 2,
+    });
+  });
+});
+
+describe("the durable record carries the rule", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "pw-gate-rule-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("persists ruleId and stamps the version that guarantees it", () => {
+    const log = new WorkerGateDecisionLog({ dir });
+    log.record({
+      recipeName: "r",
+      correlationId: "yaml:r:1",
+      workerId: "w",
+      toolName: "gitPush",
+      action: "gate",
+      ruleId: "gate.unearned-trust",
+      classKey: "vcs-push:compensable:high",
+      domain: "vcs-push",
+      owned: true,
+      blastTier: "high",
+      reversibility: "compensable",
+      earnedLevel: 0,
+      autonomyCeiling: 4,
+      effectiveLevel: 0,
+      reason: "compensable + unearned — gated for approval",
+      gatePolicyVersion: "worker-ramp-v2",
+    } as never);
+
+    const rows = readFileSync(
+      path.join(dir, "worker_gate_decisions.jsonl"),
+      "utf8",
+    )
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ruleId).toBe("gate.unearned-trust");
+    expect(rows[0].rv).toBe(GATE_RECORD_VERSION);
+    expect(ruleOf(rows[0])).toEqual({
+      state: "named",
+      ruleId: "gate.unearned-trust",
+    });
+  });
+
+  it("GATE_RECORD_VERSION is at least 2 — the level that promises a rule id", () => {
+    // A ratchet: dropping back below 2 would make every new row read as
+    // `unversioned` while still carrying a ruleId, which is the quietest
+    // possible way to lose the field's meaning.
+    expect(GATE_RECORD_VERSION).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -350,6 +350,9 @@ export async function buildWorkerAutonomyGate(
           workerId: worker.id,
           toolName: input.toolId,
           action: decision.action,
+          // Which rule decided it. `reason` beside it is prose and may be
+          // reworded; this is the half a receipt cites (rv>=2 guarantees it).
+          ruleId: decision.ruleId,
           classKey: decision.classKey,
           domain: decision.domain,
           owned: decision.owned,

--- a/src/workerGateDecisionLog.ts
+++ b/src/workerGateDecisionLog.ts
@@ -106,6 +106,17 @@ export interface GateDecisionRecord {
    * express it falsely.
    */
   correlationId?: string;
+  /**
+   * Stable id of the rule that decided this — see `GateRuleId` in
+   * `workers/workerGate.ts`. The `reason` beside it is prose and may be
+   * reworded; this is the half a receipt cites and a reader groups by.
+   *
+   * At `rv >= 2` its absence is a WRITER DEFECT, not a state, for the same
+   * reason `correlationId`'s is at `rv >= 1`: every decision takes exactly one
+   * terminal branch, so "decided, and legitimately had no rule" cannot occur.
+   * Rows at `rv < 2` predate the field and are not backfilled.
+   */
+  ruleId?: string;
 
   /** Monotonic sequence id within the process — stable for pagination. */
   seq: number;
@@ -181,7 +192,17 @@ export interface GateDecisionRecord {
  * assertion about what level N meant when it was written, so widening level N
  * later falsifies rows nobody can go back and fix.
  */
-export const GATE_RECORD_VERSION = 1 as const;
+/**
+ * Row-schema version. What each level GUARANTEES, cumulatively:
+ *
+ *   1 — the row carries `correlationId` (the run's `taskId`).
+ *   2 — the row additionally carries `ruleId` (which rule decided it).
+ *
+ * Bumped only when a reader may newly RELY on a field being present, never for
+ * a merely additive one. `correlationOf` does not skip rows from an unknown
+ * version, so a bump adds a guarantee without stranding any existing reader.
+ */
+export const GATE_RECORD_VERSION = 2 as const;
 
 /**
  * `rv` is excluded, and that exclusion is load-bearing rather than tidy. If a
@@ -314,6 +335,36 @@ export function correlationOf(
   return { state: "defect", rv: rec.rv };
 }
 
+/**
+ * Which rule a row names, with the same three-way honesty as `correlationOf`.
+ *
+ *  - `unversioned` — written before rules were named. NOT "no rule applied":
+ *    one did, nobody recorded which. Never render it as "unknown rule".
+ *  - `named`       — the row names its rule.
+ *  - `defect`      — the row claims a level that guarantees a rule id and does
+ *    not carry one. A writer bug, not a state of the world.
+ *
+ * As with `correlationOf` there is deliberately NO "decided, legitimately had
+ * no rule": every decision takes exactly one terminal branch, so such a row
+ * would be a false claim.
+ */
+export type RuleState =
+  | { state: "unversioned" }
+  | { state: "named"; ruleId: string }
+  | { state: "defect"; rv: number };
+
+export function ruleOf(
+  rec: Pick<GateDecisionRecord, "rv" | "ruleId">,
+): RuleState {
+  if (typeof rec.rv !== "number" || !Number.isFinite(rec.rv) || rec.rv < 2) {
+    return { state: "unversioned" };
+  }
+  const id = rec.ruleId;
+  if (typeof id === "string" && id.length > 0)
+    return { state: "named", ruleId: id };
+  return { state: "defect", rv: rec.rv };
+}
+
 export class WorkerGateDecisionLog {
   private records: GateDecisionRecord[] = [];
   private seq = 0;
@@ -410,6 +461,11 @@ export class WorkerGateDecisionLog {
       // was wired end to end and thrown away by the last step.
       ...(input.correlationId && { correlationId: input.correlationId }),
       ...(input.workspaceId && { workspaceId: input.workspaceId }),
+      // `ruleId` is the third field this literal has had to be told about.
+      // Copied conditionally, like `correlationId`: the writer cannot force a
+      // caller to supply one, so an absent id at rv>=2 is surfaced by
+      // `ruleOf` as a DEFECT rather than silently written as nothing.
+      ...(input.ruleId && { ruleId: input.ruleId }),
       recipeName,
       workerId,
       toolName,
@@ -745,12 +801,30 @@ function attributionAbsenceReason(
   }
 }
 
+/**
+ * Render the rule for a human, preserving the three states `ruleOf` draws.
+ *
+ * A pre-rule row must NEVER read as "no rule applied" — one did, nobody
+ * recorded which — and a row that promises an id and lacks one must read as a
+ * writer bug rather than as an absence, or the defect is invisible in the one
+ * place an operator actually looks.
+ */
+function describeRule(rec: GateDecisionRecord): string {
+  const r = ruleOf(rec);
+  if (r.state === "named") return r.ruleId;
+  if (r.state === "defect") {
+    return `MISSING — the row claims rv ${r.rv}, which guarantees one (writer defect)`;
+  }
+  return "not recorded — this row predates named rules";
+}
+
 export function formatGateDecision(rec: GateDecisionRecord): string {
   const when = new Date(rec.decidedAt).toISOString();
   const verb = describeGateAction(rec.action);
   const lines: string[] = [
     `${when} — ${rec.workerId} → ${rec.toolName} (${rec.classKey})`,
     `  Result: ${verb}`,
+    `  Rule: ${describeRule(rec)}`,
     `  Owned by this worker: ${rec.owned ? "yes" : "no"}`,
     `  Earned trust level: L${rec.earnedLevel} (autonomy ceiling L${rec.autonomyCeiling})`,
   ];
@@ -808,6 +882,16 @@ const DIFF_FIELDS: Array<{
   read: (r: GateDecisionRecord) => string;
 }> = [
   { field: "action", read: (r) => r.action },
+  // The most consequential diff there is: the same worker on the same class
+  // decided by a DIFFERENT rule. Reads through `ruleOf` so an older row shows
+  // "—" rather than inventing an absence that looks like a rule change.
+  {
+    field: "ruleId",
+    read: (r) => {
+      const st = ruleOf(r);
+      return st.state === "named" ? st.ruleId : "—";
+    },
+  },
   { field: "owned", read: (r) => String(r.owned) },
   { field: "earnedLevel", read: (r) => `L${r.earnedLevel}` },
   { field: "autonomyCeiling", read: (r) => `L${r.autonomyCeiling}` },

--- a/src/workers/__tests__/gateRuleId.test.ts
+++ b/src/workers/__tests__/gateRuleId.test.ts
@@ -1,0 +1,167 @@
+/**
+ * WHICH RULE decided this — a stable id per terminal branch of the gate.
+ *
+ * `reason` is prose and is expected to be reworded; a receipt, an operator
+ * filter and any later grouping need a key that survives rewording. These
+ * tests pin one id per branch and, more importantly, pin the SET: the
+ * exhaustiveness map below is typed `Record<GateRuleId, ...>`, so adding a
+ * member to the union is a compile error until it is listed here, and then a
+ * test failure until a case actually produces it.
+ *
+ * Without that, a new branch silently inherits no id (or a neighbour's) and the
+ * ledger's rule column quietly stops meaning what it says — the same class of
+ * drift the `rv` protocol exists to prevent, one field over.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { GraduationConfig } from "../graduation.js";
+import { parseWorker } from "../worker.js";
+import { decideWorkerAction, type GateRuleId } from "../workerGate.js";
+import { WorkerLevelStore } from "../workerLevelStore.js";
+
+const CFG: GraduationConfig = {
+  dwellMs: 1000,
+  demoteCooldownMs: 5000,
+  minEvidenceForGraduation: 5,
+};
+
+function storeWithL4(workerId: string, toolName: string): WorkerLevelStore {
+  const store = new WorkerLevelStore();
+  for (let i = 0; i < 80; i++)
+    store.apply(workerId, { toolName, good: true, at: 0 }, { cfg: CFG });
+  for (const at of [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000])
+    store.apply(workerId, { toolName, good: true, at }, { cfg: CFG });
+  return store;
+}
+
+function storeWithL2(workerId: string, toolName: string): WorkerLevelStore {
+  const store = new WorkerLevelStore();
+  for (let i = 0; i < 10; i++)
+    store.apply(workerId, { toolName, good: true, at: 0 }, { cfg: CFG });
+  store.apply(workerId, { toolName, good: true, at: 1000 }, { cfg: CFG });
+  store.apply(workerId, { toolName, good: true, at: 2000 }, { cfg: CFG });
+  return store;
+}
+
+/** Every id the union declares, and how to make the gate emit it. */
+const CASES: Record<GateRuleId, () => GateRuleId> = {
+  "forbid.workspace-policy": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["fs-write"] }),
+      "editText",
+      {},
+      new WorkerLevelStore(),
+      { forbidRules: [{ match: "fs-write", reason: "read-only workspace" }] },
+    ).ruleId,
+
+  "allow.agent-step": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["fs-write"] }),
+      "agent",
+      {},
+      new WorkerLevelStore(),
+    ).ruleId,
+
+  "allow.reversible": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["fs-write"] }),
+      "getGitStatus",
+      {},
+      new WorkerLevelStore(),
+    ).ruleId,
+
+  "allow.earned-compensable": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["vcs-push"] }),
+      "gitPush",
+      {},
+      storeWithL2("w", "gitPush"),
+    ).ruleId,
+
+  "allow.earned-autonomous": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["messaging"] }),
+      "slackPostMessage",
+      {},
+      storeWithL4("w", "slackPostMessage"),
+    ).ruleId,
+
+  // Earned L4 AND a permissive ceiling, throttled only by the live situation —
+  // so the id must attribute it to context-risk and not to stale trust.
+  "gate.context-risk-throttle": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["messaging"] }),
+      "slackPostMessage",
+      {},
+      storeWithL4("w", "slackPostMessage"),
+      { contextRisk: { score: 1, reasons: ["huge uncommitted diff"] } },
+    ).ruleId,
+
+  "gate.unowned-class": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["fs-write"] }),
+      "gitPush",
+      {},
+      new WorkerLevelStore(),
+    ).ruleId,
+
+  "gate.ceiling-below-threshold": () =>
+    decideWorkerAction(
+      parseWorker({
+        id: "w",
+        name: "W",
+        owns: ["messaging"],
+        autonomyCeiling: 1,
+      }),
+      "slackPostMessage",
+      {},
+      storeWithL4("w", "slackPostMessage"),
+    ).ruleId,
+
+  "gate.unearned-trust": () =>
+    decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["vcs-push"] }),
+      "gitPush",
+      {},
+      new WorkerLevelStore(),
+    ).ruleId,
+};
+
+describe("every gate branch names its rule", () => {
+  for (const [expected, run] of Object.entries(CASES) as Array<
+    [GateRuleId, () => GateRuleId]
+  >) {
+    it(`emits ${expected}`, () => {
+      expect(run()).toBe(expected);
+    });
+  }
+
+  it("emits a DISTINCT id per branch — no two branches share one", () => {
+    const emitted = Object.values(CASES).map((run) => run());
+    expect(new Set(emitted).size).toBe(emitted.length);
+  });
+
+  it("covers every id the union declares", () => {
+    // `CASES` is typed Record<GateRuleId, …>, so this asserts the runtime set
+    // matches the type. A member added to the union without a case here fails
+    // to compile; one added to both without a branch that produces it fails
+    // the per-case test above.
+    const declared = Object.keys(CASES) as GateRuleId[];
+    const produced = new Set(declared.map((k) => CASES[k]()));
+    for (const id of declared) expect(produced.has(id)).toBe(true);
+  });
+});
+
+describe("ruleId is separate from reason, deliberately", () => {
+  it("carries prose AND a key, and the key is not the prose", () => {
+    const d = decideWorkerAction(
+      parseWorker({ id: "w", name: "W", owns: ["vcs-push"] }),
+      "gitPush",
+      {},
+      new WorkerLevelStore(),
+    );
+    expect(d.ruleId).toBe("gate.unearned-trust");
+    expect(d.reason).toContain("unearned");
+    expect(d.reason).not.toBe(d.ruleId);
+  });
+});

--- a/src/workers/workerGate.ts
+++ b/src/workers/workerGate.ts
@@ -165,6 +165,47 @@ export function resolveGateOutcome(
   };
 }
 
+/**
+ * WHICH RULE decided this action — a stable id for the branch of
+ * `decideWorkerAction` that fired, not a description of it.
+ *
+ * `reason` is prose for a human and is expected to be reworded; nothing may be
+ * keyed on it. This is the half a receipt cites, an operator filters on, and a
+ * later reader groups by, so it must survive rewording, translation and
+ * formatting. The two are deliberately separate fields rather than one string
+ * that tries to be both.
+ *
+ * It names a rule the ENGINE applied. It is NOT a customer's policy id: a
+ * curated policy pack is organisation-scoped and belongs in the control plane
+ * (ADR-0019), and one shipped from this MIT repository could not be withdrawn.
+ * The distinction is that every id below is derivable from this file alone.
+ *
+ * REQUIRED on `WorkerGateDecision`, not optional. Every terminal branch has
+ * exactly one, so an absent id could only mean a branch forgot to say — and an
+ * optional field is one that eventually is not passed (the same reasoning that
+ * made `ApprovalRequestInput.runTaskId` required). A new branch is a compile
+ * error until it names its rule.
+ */
+export type GateRuleId =
+  /** An explicit workspace `forbids` rule matched (ADR-0017). No approval unlocks it. */
+  | "forbid.workspace-policy"
+  /** Agent reasoning steps are not a gated action-class. */
+  | "allow.agent-step"
+  /** Reversible actions flow un-gated regardless of trust. */
+  | "allow.reversible"
+  /** Compensable class, earned autonomy at or above the compensable threshold. */
+  | "allow.earned-compensable"
+  /** Non-reversible class, earned full autonomy. */
+  | "allow.earned-autonomous"
+  /** Live context-risk was the BINDING constraint — the situation throttled it, not stale trust. */
+  | "gate.context-risk-throttle"
+  /** The action falls outside the worker's owned domain. */
+  | "gate.unowned-class"
+  /** The worker's declared autonomy ceiling sits below this class's threshold — always gated. */
+  | "gate.ceiling-below-threshold"
+  /** Owned and permitted in principle, but the trust is not yet earned. */
+  | "gate.unearned-trust";
+
 export interface WorkerGateDecision {
   action: WorkerGateAction;
   classKey: string;
@@ -186,6 +227,9 @@ export interface WorkerGateDecision {
   /** The descending ceiling imposed by live context-risk (4 = no de-rate).
    *  Present only when a contextRisk was supplied. Diagnostic / audit. */
   contextCeiling?: TrustLevel;
+  /** Stable id of the rule that decided this. See `GateRuleId`. */
+  ruleId: GateRuleId;
+  /** Human prose. Expected to be reworded — never key on it, use `ruleId`. */
   reason: string;
 }
 
@@ -325,6 +369,7 @@ export function decideWorkerAction(
     return {
       ...base,
       action: "forbid",
+      ruleId: "forbid.workspace-policy",
       reason: `forbidden by workspace policy (rule \`${forbidden.matchedBy}\`): ${forbidden.reason}`,
     };
   }
@@ -340,6 +385,7 @@ export function decideWorkerAction(
     return {
       ...base,
       action: "allow",
+      ruleId: "allow.agent-step",
       reason: "agent reasoning step — not a gated action-class",
     };
   }
@@ -349,6 +395,7 @@ export function decideWorkerAction(
     return {
       ...base,
       action: "allow",
+      ruleId: "allow.reversible",
       reason: `reversible (${ac.blastTier} blast) — undoable, flows un-gated`,
     };
   }
@@ -363,6 +410,7 @@ export function decideWorkerAction(
     return {
       ...base,
       action: "allow",
+      ruleId: "allow.earned-compensable",
       reason: `earned autonomy (L${effectiveLevel}) on compensable class — auto-allowed at L${COMPENSABLE_AUTONOMY_LEVEL}+`,
     };
   }
@@ -372,6 +420,7 @@ export function decideWorkerAction(
     return {
       ...base,
       action: "allow",
+      ruleId: "allow.earned-autonomous",
       reason: `earned autonomy (L4) on ${ac.reversibility} class`,
     };
   }
@@ -381,6 +430,7 @@ export function decideWorkerAction(
       ? COMPENSABLE_AUTONOMY_LEVEL
       : AUTONOMOUS_LEVEL;
   let reason: string;
+  let ruleId: GateRuleId;
   // Context-risk is the BINDING constraint when it dropped the effective level
   // below what earned trust + ceiling alone would have allowed. Attribute it so
   // the audit trail shows the situation throttled the action, not stale trust.
@@ -396,15 +446,19 @@ export function decideWorkerAction(
     const why = opts?.contextRisk?.reasons?.length
       ? ` (${opts.contextRisk.reasons.join(", ")})`
       : "";
+    ruleId = "gate.context-risk-throttle";
     reason = `${ac.reversibility} throttled by live context-risk (ceiling L${contextCeiling} < L${threshold})${why} — gated`;
   } else if (!owned) {
+    ruleId = "gate.unowned-class";
     reason = `${ac.reversibility} action outside the worker's owned domain — gated`;
   } else if (worker.autonomyCeiling < threshold) {
+    ruleId = "gate.ceiling-below-threshold";
     reason = `${ac.reversibility} class capped by autonomy ceiling (L${worker.autonomyCeiling} < L${threshold}) — always gated`;
   } else {
+    ruleId = "gate.unearned-trust";
     reason = `${ac.reversibility} + unearned (effective L${effectiveLevel} < L${threshold}) — gated for approval`;
   }
-  return { ...base, action: "gate", reason };
+  return { ...base, action: "gate", ruleId, reason };
 }
 
 /**


### PR DESCRIPTION
Fills the line the deck couldn't back: **"Rule applied: …"**.

## The gap

Every gate decision carried a `reason` — prose, written for a human, expected to be reworded. Nothing carried a key. A receipt citing the rule, an operator filtering on one, a dashboard grouping by one, any later analysis: all have to key on *something*, and the only candidate was a sentence.

`reason` and `ruleId` are now separate fields with separate jobs. Prose stays free to change; the key is what anything machine-read uses.

## Nine branches, nine ids

| | |
|---|---|
| `forbid.workspace-policy` | an explicit `forbids` rule matched — no approval unlocks it |
| `allow.agent-step` · `allow.reversible` | the two carve-outs |
| `allow.earned-compensable` · `allow.earned-autonomous` | trust was earned |
| `gate.context-risk-throttle` | the **situation** throttled it, not stale trust |
| `gate.unowned-class` · `gate.ceiling-below-threshold` · `gate.unearned-trust` | the three ways it gates |

**Required, not optional** on `WorkerGateDecision` — the same reasoning that made `ApprovalRequestInput.runTaskId` required. Every branch has exactly one, so an absent id could only mean a branch forgot to say, and an optional field is one that eventually is not passed. A new branch is a compile error until it names its rule; the test map is `Record<GateRuleId, …>`, so it is also a compile error until a case produces it.

## `rv` 1 → 2, and why that's safe

The level is cumulative and each step is a promise a reader may rely on: **1** guarantees `correlationId`, **2** additionally guarantees `ruleId`. `correlationOf` does not skip rows from an unknown version, so the bump adds a guarantee without stranding any existing reader.

`ruleOf` mirrors `correlationOf`'s three-way honesty, and the middle state is the whole point:

- **`unversioned`** — written before rules were named. **NOT "no rule applied"** — a rule *did* apply, nobody recorded which. Collapsing those two is the absence-collapse ADR-0025 exists to prevent, and it can't be undone once readers depend on it.
- **`named`** — the row names its rule.
- **`defect`** — claims rv≥2 and carries no id. A writer bug, not a state of the world.

## The licence line, stated in the code

It names a rule **the engine applied**, never a customer's policy id. A curated policy pack is organisation-scoped and belongs in the control plane (ADR-0019); one shipped from this MIT repo could not be withdrawn. The test of the distinction: every id here is derivable from `workerGate.ts` alone.

## `record()` dropped it — the third time

The field never reached disk. `record()` enumerates fields explicitly, and **its own comment already documents this trap**, naming `correlationId` and `workspaceId` as the previous two victims. `ruleId` is the third. Caught only because the test asserts on the **file**, not the return value.

That is now three instances of this exact pattern in one working session — `list()`, the approval restore path, and this. Worth a lint rule or a shared "copy every declared field" helper; noted, not done here.

## The reader landed with the writer

`formatGateDecision` renders the rule; `describeRule` preserves all three states so a pre-rule row never reads as "no rule" and a defect never reads as an absence; and `ruleId` joins the `--diff` fields — the same worker on the same class decided by a *different* rule is the most consequential diff there is.

## Verification

- full suite **10637 passed, 4 skipped, 0 failed**
- `typecheck`, `typecheck:tests:core`, `build`, biome all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)