### PR TITLE
fix(gate): a recipe could switch off the machinery that governs it

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -55,6 +55,22 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-08-31 `fix/recipe-cannot-disable-worker-gate` — `requireApproval: false` (#995) was
+  DELIBERATELY preserved when worker autonomy arrived (#1027 lists "respects
+  requireApproval:false" as intended). Compatibility was kept, but the flag had been defined
+  against a gate that meant one thing and now sat in front of two — workspace tier policy AND
+  worker governance — and since the worker gate is injected AS `requireApprovalFn` with
+  `recordGateDecision` inside it, an opted-out recipe governed nothing AND recorded nothing.
+  An intentional narrowing of the flag's meaning, not the discovery of an accident. Invariant
+  now explicit: a recipe may opt out of the workspace TIER policy, never of WORKER governance.
+  Tier half applied by the caller (worker gate built with no tier fn — the seam already
+  returned true when absent); governance half by both runners via `gateAutomatedRuns`. Closed
+  on the chained path too, which receives the flat deps whole and had the same hole with no
+  signal. Parsed through `RecipeOrchestrator.loadRecipe` so the gate-build reading cannot
+  drift from the execution reading; an unloadable recipe fails the run there. INVERTS one
+  previously-pinned assertion that carried no rationale — flagged in the PR rather than
+  landed quietly. — #1565
+
 - 2026-08-31 `feat/evidence-field-roundtrip` — the evidence ledgers are copied field-by-field
   by hand (deliberately — a spread would let unvetted caller content reach disk), so a field
   can be declared, stamped by its producer, and dropped by a copy site nobody updated, with

--- a/src/__tests__/recipeOrchestration.test.ts
+++ b/src/__tests__/recipeOrchestration.test.ts
@@ -38,6 +38,16 @@ function makeServer() {
 function makeRecipeOrchestrator(overrides: Record<string, unknown> = {}) {
   return {
     fire: vi.fn().mockResolvedValue({ ok: true, taskId: "t1", name: "foo" }),
+    // `fireYamlRecipe` parses the recipe through the orchestrator's OWN loader
+    // before composing the approval gate, because whether the workspace tier
+    // policy applies is the recipe's `requireApproval`. A mock without this
+    // makes every fire fail — which is correct behaviour, not a test bug: a
+    // recipe that cannot be loaded must not run.
+    loadRecipe: vi.fn().mockReturnValue({
+      name: "foo",
+      trigger: { type: "manual" },
+      steps: [],
+    }),
     isInFlight: vi.fn().mockReturnValue(false),
     listInFlight: vi.fn().mockReturnValue([]),
     ...overrides,

--- a/src/recipeOrchestration.ts
+++ b/src/recipeOrchestration.ts
@@ -1673,8 +1673,37 @@ export class RecipeOrchestration {
     // cron/webhook runs never block mid-flight), so this injection does not
     // need to inspect the trigger type here.
     const approvalGate = this.deps.server?.approvalGate ?? "off";
+    // Parse the recipe HERE, through the orchestrator's own resolved loader —
+    // the identical path `fire()` uses — because whether the workspace tier
+    // policy applies is the recipe's own `requireApproval`, and the gate is
+    // composed before `fire()` ever sees the file. A second parser would let
+    // the gate-build reading drift from the execution reading.
+    //
+    // A recipe that will not load fails the run NOW rather than being treated
+    // as "approval enabled" and failing at dispatch a moment later: silently
+    // interpreting malformed configuration is the wrong direction for a
+    // governance decision, and `fire()` would reject it anyway.
+    let tierOptOut = false;
+    try {
+      tierOptOut =
+        (
+          this.deps.recipeOrchestrator.loadRecipe(opts.filePath) as {
+            requireApproval?: boolean;
+          }
+        ).requireApproval === false;
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+    // `requireApproval: false` suppresses the TIER gate and nothing else. The
+    // worker gate is composed over whatever this is — with no tier fn, a worker
+    // `allow` returns true immediately, while `gate` still queues and `forbid`
+    // still refuses. The runner enforces the other half: the flag cannot
+    // suppress the worker gate itself.
     const tierApprovalFn =
-      approvalGate === "off"
+      approvalGate === "off" || tierOptOut
         ? undefined
         : await makeRecipeApprovalFn(approvalGate, this.deps.server);
     // worker.autonomy flip (flag-gated, default off). When a worker owns this

--- a/src/recipes/RecipeOrchestrator.ts
+++ b/src/recipes/RecipeOrchestrator.ts
@@ -156,6 +156,21 @@ export class RecipeOrchestrator {
     return { ok: true, taskId, name };
   }
 
+  /**
+   * The RESOLVED recipe loader — the identical function `fire()` uses, test
+   * injection included.
+   *
+   * Exposed because a caller may need the recipe BEFORE `fire()` runs: the
+   * approval gate is composed first, and whether the workspace tier policy
+   * applies depends on the recipe's own `requireApproval`. Re-reading the YAML
+   * through a second parser would let the gate-build interpretation drift from
+   * the execution interpretation, which is the one divergence a governance
+   * decision must never have. Throws exactly as `fire()` would.
+   */
+  loadRecipe(filePath: string): YamlRecipe {
+    return this.fireDeps.loadYamlRecipe(filePath);
+  }
+
   isInFlight(name: string): boolean {
     return this.inFlight.has(name);
   }

--- a/src/recipes/__tests__/flatRunnerApproval.test.ts
+++ b/src/recipes/__tests__/flatRunnerApproval.test.ts
@@ -210,7 +210,24 @@ describe("flat-runner approval gate — gateAutomatedRuns (worker.autonomy)", ()
     expect(writes).toBe(2);
   });
 
-  it("respects requireApproval:false opt-out even with gateAutomatedRuns", async () => {
+  it("requireApproval:false does NOT suppress the gate when it is the WORKER gate", async () => {
+    // INVERTED deliberately, and the behaviour it pinned WAS deliberate —
+    // #1027's own notes list "respects requireApproval:false" as intended
+    // behaviour of the worker-autonomy flip, and #995 introduced the flag as an
+    // opt-out from the original flat-runner gate. This is a supersession, not
+    // the discovery of an accident.
+    //
+    // What changed is the flag's scope. It was defined against a gate that
+    // meant one thing; worker autonomy put a second thing behind the same
+    // gate, and preserving the flag's behaviour let a recipe-level setting
+    // aimed at the workspace tier suppress worker governance too. Since
+    // `recordGateDecision` lives inside the gate fn, it also stopped the
+    // evidence being written: no decision, no ruleId, no correlationId.
+    //
+    // The invariant now is: a recipe may opt out of the workspace TIER policy;
+    // it may never opt out of WORKER governance. The tier half is applied by
+    // the caller, which builds the worker gate with no tier fn.
+    // See `recipeCannotDisableWorkerGate.test.ts`.
     let writes = 0;
     const requireApprovalFn = vi.fn(async () => false);
     await runYamlRecipe(
@@ -223,8 +240,9 @@ describe("flat-runner approval gate — gateAutomatedRuns (worker.autonomy)", ()
         },
       }),
     );
-    expect(requireApprovalFn).not.toHaveBeenCalled();
-    expect(writes).toBe(2);
+    expect(requireApprovalFn).toHaveBeenCalled();
+    // and the refusal still bites — the opt-out cannot make it advisory
+    expect(writes).toBe(0);
   });
 });
 

--- a/src/recipes/__tests__/recipeCannotDisableWorkerGate.test.ts
+++ b/src/recipes/__tests__/recipeCannotDisableWorkerGate.test.ts
@@ -1,0 +1,173 @@
+/**
+ * A recipe may opt out of the workspace TIER approval policy.
+ * It may NEVER opt itself out of Worker governance.
+ *
+ * `requireApproval: false` is documented as a per-recipe opt-out of "the
+ * flat-runner approval gate", and it was written before the worker-autonomy
+ * gate existed. The two then composed in a way nobody chose: the worker gate is
+ * injected as `requireApprovalFn`, so the flag suppressed BOTH — and
+ * `recordGateDecision` lives inside that function.
+ *
+ * The consequence is worse than a missing approval. A recipe could switch off
+ * the governance machinery that exists to govern it, by setting one boolean in
+ * its own file, and the evidence simply stopped being written: no decision, no
+ * `ruleId`, no `correlationId`. A run that governed nothing looks exactly like
+ * a run that had nothing to govern.
+ *
+ * Found while trying to let two dogfood recipes accumulate unattended evidence:
+ * the opt-out that would have unblocked them would also have erased the thing
+ * being accumulated.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import type {
+  ChainedRecipe,
+  ExecutionDeps,
+  RunOptions,
+} from "../chainedRunner.js";
+import { executeChainedStep } from "../chainedRunner.js";
+import { createOutputRegistry } from "../outputRegistry.js";
+import {
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "opt-out-gate-"));
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+function deps(extra: Partial<RunnerDeps> = {}): RunnerDeps {
+  return {
+    now: () => new Date("2026-08-31T09:00:00Z"),
+    logDir: TMP,
+    testMode: false,
+    readFile: () => {
+      throw new Error("nf");
+    },
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    gitLogSince: () => "",
+    gitStaleBranches: () => "",
+    getDiagnostics: () => "",
+    ...extra,
+  };
+}
+
+/** `requireApproval: false` — the opt-out under test. */
+function optedOutRecipe(): YamlRecipe {
+  return {
+    name: "opted-out",
+    trigger: { type: "cron", at: "0 9 * * *" },
+    requireApproval: false,
+    steps: [{ tool: "file.write", path: `${TMP}/a`, content: "1" }],
+  } as unknown as YamlRecipe;
+}
+
+describe("a recipe cannot opt out of worker governance", () => {
+  it("STILL consults the gate when a worker owns the recipe", async () => {
+    // `gateAutomatedRuns` is set exactly when `buildWorkerAutonomyGate`
+    // returned a fn, so it is the runner's only signal that the injected
+    // approval fn IS the worker gate rather than the tier gate.
+    const gate = vi.fn(async () => true);
+    await runYamlRecipe(
+      optedOutRecipe(),
+      deps({ requireApprovalFn: gate, gateAutomatedRuns: true }),
+      {},
+    );
+    expect(
+      gate,
+      "the worker gate must run even though the recipe opted out",
+    ).toHaveBeenCalled();
+  });
+
+  it("still HALTS when the worker gate refuses, opt-out or not", async () => {
+    // The opt-out must not become a way to make a refusal advisory.
+    const gate = vi.fn(async () => false);
+    const result = await runYamlRecipe(
+      optedOutRecipe(),
+      deps({ requireApprovalFn: gate, gateAutomatedRuns: true }),
+      {},
+    );
+    expect(gate).toHaveBeenCalled();
+    expect(result.stepResults[0]?.status).toBe("error");
+  });
+
+  it("still SKIPS the tier gate when no worker owns the recipe", async () => {
+    // The original behaviour, and the whole point of the flag. A non-worker
+    // recipe opting out gets no approval prompt — unchanged.
+    const tier = vi.fn(async () => true);
+    await runYamlRecipe(
+      optedOutRecipe(),
+      deps({ requireApprovalFn: tier }), // no gateAutomatedRuns → tier only
+      {},
+    );
+    expect(
+      tier,
+      "a non-worker recipe's opt-out still suppresses the tier gate",
+    ).not.toHaveBeenCalled();
+  });
+
+  it("consults the gate normally when the recipe does NOT opt out", async () => {
+    const gate = vi.fn(async () => true);
+    const normal = {
+      ...optedOutRecipe(),
+      requireApproval: undefined,
+      trigger: { type: "manual" },
+    } as unknown as YamlRecipe;
+    await runYamlRecipe(normal, deps({ requireApprovalFn: gate }), {});
+    expect(gate).toHaveBeenCalled();
+  });
+});
+
+describe("the same invariant holds on the chained runner", () => {
+  // The chained path receives the flat runner's deps whole (`...runnerDeps`),
+  // so it gets the worker gate too — and honoured `requireApproval: false`
+  // unconditionally, with no signal that the injected fn was the worker gate.
+  // Fixing only the flat path would leave the invariant half-true, which is the
+  // "gate pointed at a subset" shape this repo has been bitten by before.
+  const options: RunOptions = {
+    env: {},
+    maxConcurrency: 4,
+    maxDepth: 3,
+    dryRun: false,
+  };
+  const optedOut = {
+    name: "chained-opted-out",
+    steps: [],
+    requireApproval: false,
+  } as unknown as ChainedRecipe;
+
+  function run(deps: Partial<ExecutionDeps>) {
+    return executeChainedStep(
+      {
+        registry: createOutputRegistry(),
+        step: { id: "s", tool: "github.list_prs" },
+        options,
+        recipe: optedOut,
+        depth: 0,
+      } as unknown as Parameters<typeof executeChainedStep>[0],
+      {
+        executeTool: vi.fn().mockResolvedValue({ ok: true }),
+        executeAgent: vi.fn(),
+        loadNestedRecipe: vi.fn().mockResolvedValue(null),
+        ...deps,
+      } as unknown as ExecutionDeps,
+    );
+  }
+
+  it("STILL consults the gate when the worker gate is the injected fn", async () => {
+    const gate = vi.fn(async () => true);
+    await run({ requireApprovalFn: gate, gateAutomatedRuns: true });
+    expect(gate).toHaveBeenCalled();
+  });
+
+  it("still SKIPS the tier gate when it is not the worker gate", async () => {
+    const tier = vi.fn(async () => true);
+    await run({ requireApprovalFn: tier });
+    expect(tier).not.toHaveBeenCalled();
+  });
+});

--- a/src/recipes/chainedRunner.ts
+++ b/src/recipes/chainedRunner.ts
@@ -297,9 +297,21 @@ export interface ExecutionDeps {
    * re-gated. The fn itself applies the gate threshold (high/all) against the
    * step's tier and returns `true` for steps that don't need sign-off, so the
    * runner only acts on an explicit rejection. Per-recipe opt-out via
-   * `requireApproval: false`.
+   * `requireApproval: false` — of the TIER policy only, never of worker
+   * governance (see `gateAutomatedRuns`).
    */
   requireApprovalFn?: import("./approvalRequest.js").ApprovalFn;
+  /**
+   * Set exactly when `buildWorkerAutonomyGate` returned a fn, i.e. when
+   * `requireApprovalFn` IS the worker gate rather than the tier gate. Spread in
+   * from the flat runner's deps, which the chained path already receives whole.
+   *
+   * Load-bearing for one reason: a recipe's own `requireApproval: false` must
+   * not be able to switch off the machinery that governs it. The flag suppresses
+   * the workspace tier policy (applied by the caller, which builds the worker
+   * gate with no tier fn) and nothing else.
+   */
+  gateAutomatedRuns?: boolean;
 }
 
 function nestedRecipeRef(step: ChainedStep): string | undefined {
@@ -721,7 +733,10 @@ export async function executeChainedStep(
       deps.requireApprovalFn &&
       depth === 0 &&
       (step.agent || step.tool) &&
-      (recipe as { requireApproval?: boolean }).requireApproval !== false
+      // Same invariant as the flat runner: the opt-out covers the tier policy,
+      // never worker governance.
+      ((recipe as { requireApproval?: boolean }).requireApproval !== false ||
+        deps.gateAutomatedRuns === true)
     ) {
       const approvalToolId = step.agent ? "agent" : (step.tool ?? "unknown");
       const verdict = normaliseApprovalVerdict(

--- a/src/recipes/yamlRunner.ts
+++ b/src/recipes/yamlRunner.ts
@@ -553,12 +553,29 @@ export interface YamlRecipe {
   /** PR2b — per-recipe token budget (see `BudgetPolicy` in schema.ts). */
   budget?: import("./schema.js").BudgetPolicy;
   /**
-   * M3 — per-recipe opt-out of the flat-runner approval gate. The gate is
+   * **Disables WORKSPACE/TIER approval for this recipe. It does NOT disable
+   * Worker governance.**
+   *
+   * M3 — per-recipe opt-out of the flat-runner approval gate. That gate is
    * safe-by-default: it only ever engages for `manual`-triggered runs (so
    * automated cron/webhook runs never block mid-flight) and only when the
-   * bridge injects a `requireApprovalFn` (i.e. approvalGate != "off"). Set
-   * `requireApproval: false` to disable the gate for this recipe even on a
-   * manual run.
+   * bridge injects a `requireApprovalFn` (i.e. approvalGate != "off").
+   *
+   * ## Scope, and why it narrowed
+   *
+   * When worker autonomy arrived (#1027) this flag's behaviour was
+   * deliberately preserved — the flip's own notes list "respects
+   * requireApproval:false" as intended. That kept compatibility, but the flag
+   * had been defined against a gate that meant one thing and now sat in front
+   * of two: the workspace tier policy AND worker governance. Because the worker
+   * gate is injected AS `requireApprovalFn`, and `recordGateDecision` lives
+   * inside it, an opted-out worker recipe governed nothing and recorded nothing.
+   *
+   * The meaning is therefore narrowed to what it was always for: the workspace
+   * tier policy. A worker `gate` still queues and a `forbid` still refuses,
+   * whatever this says. The tier half is applied by the caller, which builds
+   * the worker gate with no tier fn; the runners refuse to let this flag
+   * suppress the worker gate itself.
    */
   requireApproval?: boolean;
 }
@@ -2248,10 +2265,19 @@ export async function runYamlRecipe(
       // on automated triggers (that's how workers run), and `requireApprovalFn`
       // is the worker-aware fn — reversible actions pass, risky-unearned ones
       // queue. Off → manual-only, byte-identical to pre-flip behaviour.
+      // `requireApproval: false` opts out of the WORKSPACE TIER policy only.
+      // It may never opt a recipe out of WORKER governance: `gateAutomatedRuns`
+      // is set exactly when `buildWorkerAutonomyGate` returned a fn, so it is
+      // the signal that the injected fn IS the worker gate. Honouring the flag
+      // there would let a recipe switch off the machinery that governs it by
+      // setting one boolean in its own file — and since `recordGateDecision`
+      // lives inside that fn, it would also stop the evidence being written.
+      // The tier half of the opt-out is applied by the caller, which builds the
+      // worker gate with no tier fn (see `fireYamlRecipe`).
       if (
         deps.requireApprovalFn &&
         (recipeTriggerKind === "manual" || deps.gateAutomatedRuns) &&
-        recipe.requireApproval !== false
+        (recipe.requireApproval !== false || deps.gateAutomatedRuns === true)
       ) {
         const approvalToolId = step.agent ? "agent" : (step.tool ?? "unknown");
         const verdict = normaliseApprovalVerdict(


### PR DESCRIPTION
Narrows `requireApproval: false` to the scope it was always for: **a recipe may opt out of the workspace TIER approval policy; it may never opt itself out of WORKER governance.**

## History — a supersession, not an accident

`requireApproval: false` was introduced in **#995** as an opt-out from the original flat-runner approval gate. When worker autonomy arrived in **#1027**, that behaviour was **deliberately preserved** — the flip's own notes list *"respects requireApproval:false"* among its intended behaviours.

What changed underneath it is the **scope**. The flag was defined against a gate that meant one thing. Worker autonomy put a second, different thing behind the same gate: the worker gate is injected *as* `requireApprovalFn`, composed over the tier fn. So a setting aimed at the workspace tier policy also suppressed worker governance.

## Why that matters more than a skipped approval

**`recordGateDecision` lives inside the function the flag skips.** An opted-out recipe governed nothing *and recorded nothing* — no decision, no `ruleId`, no `correlationId`. A run that governed nothing is indistinguishable on disk from a run with nothing to govern.

Found while trying to let two dogfood recipes accumulate unattended evidence: the opt-out that would have unblocked them would also have erased the thing being accumulated. The failed run that exposed it is the proof — it wrote `git.log_since / allow / allow.reversible` precisely *because* the flag was not set.

## The fix, in two halves

**Tier half — the caller.** `fireYamlRecipe` builds the worker gate with **no tier fn** for an opted-out recipe. The composition seam already supported this: `return tierApprovalFn ? tierApprovalFn(input) : true`.

**Governance half — the runners.** `gateAutomatedRuns` is set exactly when the injected fn *is* the worker gate, so the flag cannot suppress it.

| Case | Behaviour |
|---|---|
| worker `allow` + tier enabled | tier policy still has final say (floor preserved) |
| worker `allow` + recipe opted out of tier | flows — **and the decision is still recorded** |
| worker `gate` | still queues, opt-out or not |
| worker `forbid` | still refused |
| non-worker + opt-out | unchanged — no tier approval |

## Closed on both runners

The chained path receives the flat runner's deps whole (`...runnerDeps`), so it had the identical hole and no signal to detect it. Fixing only the flat path would leave the invariant true of one execution path only.

## The parse

Done at gate-build time through **`RecipeOrchestrator.loadRecipe`** — the orchestrator's own *resolved* loader, test injection included — not a second parser. A gate-build reading that can drift from the execution reading is the one divergence a governance decision must not have. A recipe that will not load **fails the run there**, rather than being treated as "approval enabled".

## Discoverability

The author-facing definition now leads with the scope, **at the type itself**:

> Disables **workspace/tier** approval for this recipe. It does **not** disable Worker governance.

with the #1027 history recorded beneath it, so nobody reconstructs the old interpretation later.

## One inverted assertion

`flatRunnerApproval.test.ts` held *"respects requireApproval:false opt-out even with gateAutomatedRuns"*. It is inverted here, with #1027's intent recorded beside it — the old behaviour was chosen, and is being superseded on purpose rather than corrected as a mistake.

## Tests

Six new. The three governance ones are **mutation-checked**: restoring the old condition fails exactly those three, while the three preservation tests (non-worker opt-out still skips the tier gate; normal recipes unchanged) keep passing.

The `makeRecipeOrchestrator` mock now needs `loadRecipe` — seven tests failed because it lacked one. That is the invariant working: a fake orchestrator that cannot load a recipe *should* stop working, since governance now depends on reading the exact configuration first. Making the loader optional or fail-soft would have weakened the invariant to preserve tests.

## Verification

- full suite **10648 passed, 4 skipped, 0 failed**
- `typecheck`, `typecheck:tests:core`, `build`, biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)