### PR TITLE
feat(evidence): a missing link is not the same as a link that was never owed

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,19 +50,21 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- 2026-08-31 `feat/evidence-relationship-coverage` — Stage 1 of turning `patchwork evidence`
-  from "which ledgers overlap?" into "can the claimed relationships be traversed?". The flat
-  "does this row carry a correlationId?" reading gives WRONG answers on live data three ways:
-  6 approval requests and 7 privacy-shadow rows legitimately have no run (client-session MCP
-  calls; orchestrator dispatches), and `runs.jsonl` is an event log whose 974 rows are 505
-  runs. So the unit is a relationship with an expectation attached, classified
-  connected/legacy/not-applicable/unresolved/defect, with integrity = connected / (connected
-  + defect + unresolved). Found 7 real unresolved receipts on first run.
-
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-08-31 `feat/evidence-relationship-coverage` — Stage 1 of `patchwork evidence` becoming
+  a coverage instrument. The flat "does this row carry a correlationId?" reading is WRONG on
+  live data three ways: 6 approval requests (MCP client sessions) and 7 privacy-shadow rows
+  (orchestrator dispatches) legitimately have no run, and `runs.jsonl` is an event log whose
+  974 rows are 505 runs. Unit becomes a relationship with an expectation attached —
+  connected / legacy / not-applicable / unresolved / defect — with integrity = connected /
+  (connected + defect + unresolved), so history and rows that never owed a link stay out of
+  the denominator. Approvals traverse in two hops (decision --callId--> request
+  --correlationId--> run); the archive is read alongside the live run log. Found 7 genuinely
+  unresolved receipts on its first run. Stage 2 (`--check`) deliberately deferred. — #1566
 
 - 2026-08-31 `fix/recipe-cannot-disable-worker-gate` — `requireApproval: false` (#995) was
   DELIBERATELY preserved when worker autonomy arrived (#1027 lists "respects

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,6 +50,15 @@ verified (which is how this line came to be written).
 
 ## Active
 
+- 2026-08-31 `feat/evidence-relationship-coverage` — Stage 1 of turning `patchwork evidence`
+  from "which ledgers overlap?" into "can the claimed relationships be traversed?". The flat
+  "does this row carry a correlationId?" reading gives WRONG answers on live data three ways:
+  6 approval requests and 7 privacy-shadow rows legitimately have no run (client-session MCP
+  calls; orchestrator dispatches), and `runs.jsonl` is an event log whose 974 rows are 505
+  runs. So the unit is a relationship with an expectation attached, classified
+  connected/legacy/not-applicable/unresolved/defect, with integrity = connected / (connected
+  + defect + unresolved). Found 7 real unresolved receipts on first run.
+
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 

--- a/src/__tests__/evidenceRelationships.test.ts
+++ b/src/__tests__/evidenceRelationships.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Relationship coverage — the four rules the live ledgers forced.
+ *
+ * Each of these was a wrong answer the flat "does this row have a
+ * correlationId?" reading gave on real data, so each is pinned:
+ *
+ *  1. `runs.jsonl` is an EVENT log. 974 rows resolved to 505 runs on the
+ *     reference machine — a denominator over rows double-counts healthy runs.
+ *  2. An approval from an MCP client session never belonged to a run. Six such
+ *     rows read as broken until the source is consulted.
+ *  3. A `privacy_shadow` row from the orchestrator path is a task dispatch, not
+ *     a recipe step. Same shape, same wrong answer.
+ *  4. An approval decision reaches its run THROUGH its request. Scoring
+ *     decision rows for a run id directly marks every one of them broken.
+ *
+ * And one distinction that is not a rule but a doctrine: `unresolved` is not
+ * `defect`. "The writer never wrote a link" and "the link names a target that
+ * is gone" need different remedies, and folding them together is what makes an
+ * integrity number that nobody can act on.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { evidenceRelationships } from "../evidenceRelationships.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "pw-evidence-rel-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function write(file: string, rows: unknown[]): void {
+  writeFileSync(
+    path.join(dir, file),
+    `${rows.map((r) => JSON.stringify(r)).join("\n")}\n`,
+    "utf8",
+  );
+}
+const rel = (name: string) => {
+  const r = evidenceRelationships(dir).relationships.find(
+    (x) => x.name === name,
+  );
+  if (!r) throw new Error(`no relationship named ${name}`);
+  return r;
+};
+
+describe("runs are an event log, not a table", () => {
+  it("collapses repeated rows for one taskId to a single run", () => {
+    write("runs.jsonl", [
+      { taskId: "yaml:r:1", status: "running" },
+      { taskId: "yaml:r:1", status: "done" },
+      { taskId: "yaml:r:2", status: "running" },
+      { taskId: "yaml:r:2", status: "error" },
+    ]);
+    const r = evidenceRelationships(dir);
+    expect(r.runRows).toBe(4);
+    expect(r.distinctRuns).toBe(2);
+  });
+
+  it("reads the rotation archive alongside the live file", () => {
+    // A run can rotate out while evidence naming it is still current; ignoring
+    // the archive would report a healthy join as unresolved because the log grew.
+    write("runs.jsonl", [{ taskId: "yaml:new:1", status: "done" }]);
+    write("runs.jsonl.1", [{ taskId: "yaml:old:1", status: "done" }]);
+    write("boundary_receipts.jsonl", [
+      { rv: 1, correlationId: "yaml:old:1", decision: "ALLOW" },
+    ]);
+    expect(rel("boundary receipt → run").connected).toBe(1);
+    expect(rel("boundary receipt → run").unresolved).toBe(0);
+  });
+});
+
+describe("expectation is a property of the SOURCE, not the row shape", () => {
+  it("an MCP client-session approval is not-applicable, not a defect", () => {
+    write("runs.jsonl", [{ taskId: "yaml:r:1", status: "done" }]);
+    write("approval_log.jsonl", [
+      // client session — never belonged to a run
+      { kind: "request", callId: "a", rv: 1, sessionId: "7c7c272a-6946" },
+      // recipe session — a run IS expected
+      {
+        kind: "request",
+        callId: "b",
+        rv: 1,
+        sessionId: "recipe",
+        correlationId: "yaml:r:1",
+      },
+    ]);
+    const r = rel("approval request → run");
+    expect(r.notApplicable).toBe(1);
+    expect(r.connected).toBe(1);
+    expect(r.defect).toBe(0);
+  });
+
+  it("a recipe-session approval WITHOUT a run reference IS a defect", () => {
+    write("runs.jsonl", [{ taskId: "yaml:r:1", status: "done" }]);
+    write("approval_log.jsonl", [
+      { kind: "request", callId: "b", rv: 1, sessionId: "recipe" },
+    ]);
+    expect(rel("approval request → run").defect).toBe(1);
+  });
+
+  it("an orchestrator privacy-shadow row is not-applicable", () => {
+    // The orchestrator dispatch path has no recipe run by construction;
+    // `recipeName` is the discriminator the recipe path always sets.
+    write("runs.jsonl", [{ taskId: "yaml:r:1", status: "done" }]);
+    write("privacy_shadow.jsonl", [
+      { rv: 1, decision: "ALLOW" },
+      { rv: 1, decision: "ALLOW", recipeName: "r", correlationId: "yaml:r:1" },
+    ]);
+    const r = rel("privacy shadow → run");
+    expect(r.notApplicable).toBe(1);
+    expect(r.connected).toBe(1);
+  });
+});
+
+describe("approvals are a two-hop traversal", () => {
+  it("scores a decision by its parent request, not by a run id it never carries", () => {
+    write("runs.jsonl", [{ taskId: "yaml:r:1", status: "done" }]);
+    write("approval_log.jsonl", [
+      {
+        kind: "request",
+        callId: "a",
+        rv: 1,
+        sessionId: "recipe",
+        correlationId: "yaml:r:1",
+      },
+      { kind: "decision", callId: "a", decision: "approved" },
+      { kind: "attribution", callId: "a", actor: { id: "ada", kind: "human" } },
+    ]);
+    expect(rel("approval decision → request").connected).toBe(1);
+    expect(rel("approval attribution → request").connected).toBe(1);
+    expect(rel("approval decision → request").defect).toBe(0);
+  });
+
+  it("an orphan decision is unresolved — its chain is broken", () => {
+    write("runs.jsonl", []);
+    write("approval_log.jsonl", [
+      { kind: "decision", callId: "ghost", decision: "approved" },
+    ]);
+    expect(rel("approval decision → request").unresolved).toBe(1);
+  });
+});
+
+describe("integrity excludes what was never owed", () => {
+  it("legacy and not-applicable stay out of the denominator", () => {
+    write("runs.jsonl", [{ taskId: "yaml:r:1", status: "done" }]);
+    write("worker_gate_decisions.jsonl", [
+      { correlationId: "yaml:r:1", rv: 1, ruleId: "allow.reversible" }, // connected
+      { toolName: "old" }, // legacy: predates rv
+      { toolName: "old2" }, // legacy
+    ]);
+    const r = rel("gate decision → run");
+    expect(r.connected).toBe(1);
+    expect(r.legacy).toBe(2);
+    // 1 / (1 + 0 + 0) — history must not make a healthy system look broken
+    expect(r.integrity).toBe(1);
+  });
+
+  it("separates unresolved from defect rather than folding them together", () => {
+    write("runs.jsonl", [{ taskId: "yaml:present:1", status: "done" }]);
+    write("worker_gate_decisions.jsonl", [
+      { rv: 1, correlationId: "yaml:present:1" }, // connected
+      { rv: 1, correlationId: "yaml:gone:1" }, // unresolved — target missing
+      { rv: 1 }, // defect — never written
+    ]);
+    const r = rel("gate decision → run");
+    expect(r.connected).toBe(1);
+    expect(r.unresolved).toBe(1);
+    expect(r.defect).toBe(1);
+    expect(r.integrity).toBeCloseTo(1 / 3);
+  });
+
+  it("reports null integrity when nothing was expected at all", () => {
+    write("runs.jsonl", []);
+    write("worker_gate_decisions.jsonl", [{ toolName: "legacy-only" }]);
+    expect(rel("gate decision → run").integrity).toBeNull();
+  });
+});

--- a/src/evidenceRelationships.ts
+++ b/src/evidenceRelationships.ts
@@ -1,0 +1,386 @@
+/**
+ * Can Patchwork prove the evidence relationships it claims should exist?
+ *
+ * `evidenceCoverage` answers a flatter question — how many rows carry a
+ * correlation id — and that question stops being the useful one as soon as the
+ * ledgers start joining. A row without a run reference is not automatically a
+ * gap, and a row with one is not automatically connected. Three facts from the
+ * live ledgers, each of which breaks the flat reading:
+ *
+ *  1. Six approval requests carry no correlation id and every one is CORRECT:
+ *     they are MCP client-session tool calls that never belonged to a run. Two
+ *     of the four paths into the queue have no run by construction.
+ *  2. Seven `privacy_shadow` rows at `rv:1` carry no correlation id, and they
+ *     are orchestrator task dispatches (`claudeOrchestrator.ts`), not recipe
+ *     steps. Same shape, different ledger.
+ *  3. `runs.jsonl` is an EVENT log: 974 rows resolve to 505 distinct `taskId`s.
+ *     Anything counted over raw rows double-counts a healthy run.
+ *
+ * So the unit here is a RELATIONSHIP with an expectation attached, not a field.
+ * For each row: was this row supposed to reach a run at all, and if so, does the
+ * path resolve?
+ *
+ * ## The states, and why five rather than two
+ *
+ *  - `connected`      — the expected path resolves.
+ *  - `legacy`         — the row predates the version that promises the link.
+ *  - `notApplicable`  — the row was never supposed to have one (see 1 and 2).
+ *  - `unresolved`     — the link names a target that cannot be found.
+ *  - `defect`         — the writer should have supplied a usable link and did not.
+ *
+ * Collapsing `legacy` or `notApplicable` into `defect` is what makes a coverage
+ * number permanently red, and a permanently-red number is one nobody reads. The
+ * distinction is the whole point: six missing correlation ids sound broken until
+ * you establish that all six are client-session calls.
+ *
+ * `unresolved` is deliberately NOT folded into `defect` either. "The evidence
+ * named a run and the run is gone" is a different fact from "the writer never
+ * wrote one", and the difference will matter more once retention exists — an
+ * aged-out target is governance working as configured, not a broken chain.
+ *
+ * ## Integrity
+ *
+ *   integrity = connected / (connected + defect + unresolved)
+ *
+ * Legacy and not-applicable rows are counted and shown, and excluded from the
+ * denominator. Scoring against every row ever written would let history make a
+ * healthy system look broken forever.
+ *
+ * ## Counts only, never contents
+ *
+ * Same rule as `evidenceCoverage`: a correlation id IS a run's `taskId`, so
+ * nothing here returns a row, an id or any value — only counts and names.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { patchworkHome } from "./patchworkHome.js";
+
+export type RelationState =
+  | "connected"
+  | "legacy"
+  | "notApplicable"
+  | "unresolved"
+  | "defect";
+
+export interface RelationshipCoverage {
+  /** e.g. "gate decision → run". */
+  name: string;
+  /** One line an operator can act on when this relationship is not clean. */
+  note: string;
+  connected: number;
+  legacy: number;
+  notApplicable: number;
+  unresolved: number;
+  defect: number;
+  /** `connected / (connected + defect + unresolved)`; null when nothing expected. */
+  integrity: number | null;
+}
+
+export interface EvidenceRelationships {
+  dir: string;
+  relationships: RelationshipCoverage[];
+  /** Distinct `taskId`s after collapsing the run event log. */
+  distinctRuns: number;
+  /** Raw rows in `runs.jsonl`, kept so the collapse is visible rather than implied. */
+  runRows: number;
+  /** Rows that would not parse, per file. Reported, never silently skipped. */
+  corrupt: number;
+}
+
+type Row = Record<string, unknown>;
+
+function readRows(dir: string, file: string): { rows: Row[]; corrupt: number } {
+  const full = path.join(dir, file);
+  if (!existsSync(full)) return { rows: [], corrupt: 0 };
+  let text: string;
+  try {
+    text = readFileSync(full, "utf-8");
+  } catch {
+    return { rows: [], corrupt: 1 };
+  }
+  const rows: Row[] = [];
+  let corrupt = 0;
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      rows.push(JSON.parse(t) as Row);
+    } catch {
+      corrupt++;
+    }
+  }
+  return { rows, corrupt };
+}
+
+const str = (r: Row, k: string): string | undefined =>
+  typeof r[k] === "string" && r[k] !== "" ? (r[k] as string) : undefined;
+const num = (r: Row, k: string): number | undefined =>
+  typeof r[k] === "number" && Number.isFinite(r[k])
+    ? (r[k] as number)
+    : undefined;
+
+/**
+ * Collapse the run event log to the set of distinct `taskId`s.
+ *
+ * `runs.jsonl` writes a `running` row and then a terminal row for the same run,
+ * so the raw row count is ~2x the number of runs. A coverage denominator over
+ * rows would count a healthy run twice and drift as the ratio changes.
+ */
+function runIds(dir: string): { ids: Set<string>; rows: number } {
+  // Reads the rotation archive alongside the live file, for the same reason
+  // trust replay does (#1337): `runs.jsonl` is capped by BYTES, so a run can
+  // rotate out while the evidence that names it is still current. Ignoring the
+  // archive would report a healthy join as `unresolved` purely because the log
+  // grew.
+  const live = readRows(dir, "runs.jsonl");
+  const archived = readRows(dir, "runs.jsonl.1");
+  const ids = new Set<string>();
+  for (const r of [...live.rows, ...archived.rows]) {
+    const t = str(r, "taskId");
+    if (t) ids.add(t);
+  }
+  return { ids, rows: live.rows.length + archived.rows.length };
+}
+
+function tally(
+  name: string,
+  note: string,
+  items: Array<{ state: RelationState }>,
+): RelationshipCoverage {
+  const c = {
+    connected: 0,
+    legacy: 0,
+    notApplicable: 0,
+    unresolved: 0,
+    defect: 0,
+  };
+  for (const i of items) c[i.state]++;
+  const denom = c.connected + c.defect + c.unresolved;
+  return {
+    name,
+    note,
+    ...c,
+    integrity: denom === 0 ? null : c.connected / denom,
+  };
+}
+
+/**
+ * Classify a row whose link should point at a run.
+ *
+ * `expected` is decided by the CALLER, because whether a run was ever in scope
+ * is a property of the writing path and not of the row's shape.
+ */
+function toRun(
+  row: Row,
+  field: string,
+  expected: "yes" | "legacy" | "notApplicable",
+  runs: Set<string>,
+): { state: RelationState } {
+  if (expected === "legacy") return { state: "legacy" };
+  if (expected === "notApplicable") return { state: "notApplicable" };
+  const id = str(row, field);
+  if (!id) return { state: "defect" };
+  return { state: runs.has(id) ? "connected" : "unresolved" };
+}
+
+export function evidenceRelationships(
+  dir = patchworkHome(),
+): EvidenceRelationships {
+  const { ids: runs, rows: runRows } = runIds(dir);
+  let corrupt = 0;
+
+  const gate = readRows(dir, "worker_gate_decisions.jsonl");
+  const receipts = readRows(dir, "boundary_receipts.jsonl");
+  const shadow = readRows(dir, "privacy_shadow.jsonl");
+  const appr = readRows(dir, "approval_log.jsonl");
+  corrupt += gate.corrupt + receipts.corrupt + shadow.corrupt + appr.corrupt;
+
+  const rel: RelationshipCoverage[] = [];
+
+  // --- gate decisions -----------------------------------------------------
+  // Every gate decision happens inside a run — `buildWorkerAutonomyGate` is
+  // wired from one site — so at rv>=1 there is no legitimate "had no run".
+  rel.push(
+    tally(
+      "gate decision → run",
+      "a decision at rv>=1 with no run reference is a writer defect: every gate decision happens inside a run",
+      gate.rows.map((r) =>
+        toRun(
+          r,
+          "correlationId",
+          (num(r, "rv") ?? 0) >= 1 ? "yes" : "legacy",
+          runs,
+        ),
+      ),
+    ),
+  );
+  rel.push(
+    tally(
+      "gate decision → rule",
+      "at rv>=2 every decision names the rule that decided it; absence is a writer defect",
+      gate.rows.map((r) => {
+        if ((num(r, "rv") ?? 0) < 2) return { state: "legacy" as const };
+        return {
+          state: str(r, "ruleId")
+            ? ("connected" as const)
+            : ("defect" as const),
+        };
+      }),
+    ),
+  );
+
+  // --- boundary receipts --------------------------------------------------
+  rel.push(
+    tally(
+      "boundary receipt → run",
+      "receipts are written from a dispatch that always has a run id in scope",
+      receipts.rows.map((r) =>
+        toRun(
+          r,
+          "correlationId",
+          (num(r, "rv") ?? 0) >= 1 ? "yes" : "legacy",
+          runs,
+        ),
+      ),
+    ),
+  );
+
+  // --- privacy shadow -----------------------------------------------------
+  // Source-aware: a shadow row from the ORCHESTRATOR path is a task dispatch,
+  // not a recipe step, and has no run by construction. `recipeName` is the
+  // discriminator — the recipe path always sets it.
+  rel.push(
+    tally(
+      "privacy shadow → run",
+      "orchestrator dispatches legitimately have no run; only recipe-step rows are expected to join",
+      shadow.rows.map((r) =>
+        toRun(
+          r,
+          "correlationId",
+          (num(r, "rv") ?? 0) < 1
+            ? "legacy"
+            : str(r, "recipeName")
+              ? "yes"
+              : "notApplicable",
+          runs,
+        ),
+      ),
+    ),
+  );
+
+  // --- approvals ----------------------------------------------------------
+  // Source-aware again: two of the four paths into the queue are MCP
+  // client-session tool calls with no run. `sessionId` is the discriminator.
+  const requests = appr.rows.filter((r) => str(r, "kind") === "request");
+  const requestIds = new Set(
+    requests.map((r) => str(r, "callId")).filter((v): v is string => !!v),
+  );
+  rel.push(
+    tally(
+      "approval request → run",
+      "client-session (MCP) approvals never belonged to a run; only recipe/worker requests are expected to join",
+      requests.map((r) => {
+        const s = str(r, "sessionId") ?? "";
+        const fromRun = s.startsWith("recipe") || s.startsWith("worker:");
+        return toRun(
+          r,
+          "correlationId",
+          (num(r, "rv") ?? 0) < 1
+            ? "legacy"
+            : fromRun
+              ? "yes"
+              : "notApplicable",
+          runs,
+        );
+      }),
+    ),
+  );
+
+  // Two-hop: a decision reaches its run THROUGH its request. Scoring decision
+  // rows by looking for a run id directly would mark every one of them broken.
+  for (const kind of ["decision", "attribution"] as const) {
+    const rows = appr.rows.filter((r) => str(r, "kind") === kind);
+    rel.push(
+      tally(
+        `approval ${kind} → request`,
+        `a ${kind} reaches its run through its request; a callId with no request is a broken chain`,
+        rows.map((r) => {
+          const cid = str(r, "callId");
+          if (!cid) return { state: "defect" as const };
+          return {
+            state: requestIds.has(cid)
+              ? ("connected" as const)
+              : ("unresolved" as const),
+          };
+        }),
+      ),
+    );
+  }
+
+  return { dir, relationships: rel, distinctRuns: runs.size, runRows, corrupt };
+}
+
+/**
+ * Render for a human.
+ *
+ * Leads with the raw counts and puts the percentage last, for the same reason
+ * `evidenceCoverage` leads with the denominator: "98%" reads as a verdict,
+ * "59 connected · 1 defect" is the fact someone can act on.
+ */
+export function formatEvidenceRelationships(r: EvidenceRelationships): string {
+  const L: string[] = [];
+  L.push("[evidence] can the expected relationships be traversed?");
+  L.push(
+    `  ${r.runRows} run rows collapse to ${r.distinctRuns} distinct run(s)` +
+      (r.corrupt > 0 ? `  ·  ${r.corrupt} unparseable line(s)` : ""),
+  );
+  L.push("");
+  const w = Math.max(...r.relationships.map((x) => x.name.length));
+  L.push(
+    `  ${"relationship".padEnd(w)}   conn  legacy   n/a  unres  defect   integrity`,
+  );
+  for (const x of r.relationships) {
+    const pct =
+      x.integrity === null
+        ? "     —"
+        : `${(x.integrity * 100).toFixed(1)}%`.padStart(6);
+    L.push(
+      `  ${x.name.padEnd(w)}  ${String(x.connected).padStart(5)}` +
+        `  ${String(x.legacy).padStart(6)}` +
+        `  ${String(x.notApplicable).padStart(4)}` +
+        `  ${String(x.unresolved).padStart(5)}` +
+        `  ${String(x.defect).padStart(6)}   ${pct}`,
+    );
+  }
+  L.push("");
+  const broken = r.relationships.filter(
+    (x) => x.defect > 0 || x.unresolved > 0,
+  );
+  if (broken.length === 0) {
+    L.push(
+      "  No defects and nothing unresolved — every expected link resolves.",
+    );
+    L.push(
+      "  `legacy` and `n/a` are counted above and excluded from integrity on purpose:",
+    );
+    L.push(
+      "  history and rows that never owed a link must not make a healthy system look broken.",
+    );
+  } else {
+    // Name what broke, not a percentage. A number tells you something is wrong;
+    // a sentence tells you what to go and look at.
+    for (const x of broken) {
+      if (x.defect > 0) {
+        L.push(`  ${x.defect} × ${x.name}: link never written — ${x.note}`);
+      }
+      if (x.unresolved > 0) {
+        L.push(
+          `  ${x.unresolved} × ${x.name}: link names a target that cannot be found`,
+        );
+      }
+    }
+  }
+  L.push("");
+  return `${L.join("\n")}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5311,11 +5311,18 @@ if (process.argv[2] === "evidence") {
       const { evidenceCoverage, formatEvidenceCoverage } = await import(
         "./evidenceCoverage.js"
       );
+      const { evidenceRelationships, formatEvidenceRelationships } =
+        await import("./evidenceRelationships.js");
       const report = dir ? evidenceCoverage(dir) : evidenceCoverage();
+      // The raw per-ledger counts stay ABOVE the relationship view rather than
+      // being replaced by it. The percentage is the summary; the counts are the
+      // fact, and a reader who distrusts the first should be able to check it
+      // against the second without a second command.
+      const rel = dir ? evidenceRelationships(dir) : evidenceRelationships();
       process.stdout.write(
         args.includes("--json")
-          ? `${JSON.stringify(report, null, 2)}\n`
-          : formatEvidenceCoverage(report),
+          ? `${JSON.stringify({ ...report, relationships: rel }, null, 2)}\n`
+          : formatEvidenceCoverage(report) + formatEvidenceRelationships(rel),
       );
       // Always 0: this is a REPORT, not a gate. Zero joinable rows is a true
       // and expected state early on, and exiting non-zero for it would make a


### PR DESCRIPTION
**Stage 1** of turning `patchwork evidence` from *"which ledgers overlap?"* into *"can Patchwork prove the relationships it claims should exist?"*

## The flat reading gives wrong answers on live data

`evidence` asked one question — how many rows carry a `correlationId` — and it breaks three ways as soon as ledgers start joining:

| | |
|---|---|
| **6** approval requests carry no correlation id | every one **correct** — MCP client-session tool calls that never belonged to a run. Two of the four paths into the queue have no run by construction. |
| **7** `privacy_shadow` rows at `rv:1` carry none | orchestrator task dispatches, not recipe steps. Same shape, same wrong answer, different ledger. |
| `runs.jsonl` **974 rows → 505 taskIds** | it's an event log. Any denominator over rows double-counts every healthy run. |

So the unit is a **relationship with an expectation attached**, not a field: *was this row ever supposed to reach a run, and if so does the path resolve?*

## Five states, and the middle three are the point

`connected` · `legacy` · `notApplicable` · `unresolved` · `defect`

```
integrity = connected / (connected + defect + unresolved)
```

`legacy`, `notApplicable` and known-absent targets are counted, shown, and kept **out of the denominator**. Scoring against every row ever written lets history make a healthy system look broken forever — and a permanently-red number is one nobody reads.

**`unresolved` is deliberately not folded into `defect`.** "The writer never wrote a link" and "the link names a run that is gone" need different remedies, and the difference matters more once retention exists: an aged-out target is governance working as configured, not a broken chain.

## Two-hop approvals

```
decision/attribution --callId--> request --correlationId--> run
```

The decision row does not carry a run id and is not supposed to. Scoring it for one directly marks **every** decision broken.

## Rotation archive

Run ids are read from `runs.jsonl.1` as well as the live file, for the same reason trust replay does (#1337): the log is capped by **bytes**, so a run can rotate out while evidence naming it is current. Including the archive takes the run universe here from **505 → 762**.

## Live output

```
  relationship                     conn  legacy   n/a  unres  defect   integrity
  gate decision → run                31     272     0      0       0   100.0%
  gate decision → rule               23     280     0      0       0   100.0%
  boundary receipt → run            114     156     0      7       0    94.2%
  privacy shadow → run               11     311     7      0       0   100.0%
  approval request → run             17     107     6      0       0   100.0%
  approval decision → request       130       0     0      0       0   100.0%
  approval attribution → request     12       0     0      0       0   100.0%

  7 × boundary receipt → run: link names a target that cannot be found
```

The failure line **names what broke**, not a percentage — a number tells you something is wrong, a sentence tells you what to look at.

**It found something on its first run**: 7 boundary receipts naming runs that exist in none of the five run logs on this machine, all written within one minute on 2026-08-26 — the day receipt correlation shipped. Classified `unresolved`, not `defect`, which is the correct reading.

The raw per-ledger counts stay **above** the new view rather than being replaced. The percentage is the summary; the counts are the fact.

## Tests

Ten, one per rule the live ledgers forced. The source-awareness rule is **mutation-checked**: removing it turns six correct `notApplicable` rows into six false defects.

- full suite **10658 passed, 4 skipped, 0 failed**
- `typecheck`, `typecheck:tests:core`, `build`, biome clean

## Not in this change

**Stage 2 (`--check`)** — exit non-zero on defects and *actionable* unresolved. A gate should be added once the report it gates on has been read against real data for a while; shipping both at once means the first red build is also the first time anyone reads the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)