### PR TITLE
feat(butler): give Home a truthful view of what is known, unknown, and needs attention

### DIFF
--- a/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
+++ b/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ButlerFact,
+  type ButlerSources,
+  type PendingApproval,
+  type PermissionExercise,
+  type SourceState,
+  type StandingPermission,
+  mapButlerHome,
+} from "../homeState";
+
+/**
+ * The acceptance contract for the Butler view-model: five distinctions that
+ * must survive the fold.
+ *
+ *   needs you · caught up · CANNOT TELL
+ *   established memory · low-trust observation
+ *   active permission · no permission · permission state UNAVAILABLE
+ *   did something without asking · merely has permission to
+ *   approval pending · approval source UNAVAILABLE
+ *
+ * Each of the three emphasised ones is a state that an ordinary implementation
+ * turns into an empty collection, and an empty collection reads as reassurance.
+ * `page.tsx` has already been caught by that twice — a 502 whose body parsed as
+ * JSON, and a 501 for an unreadable permission store — so these are regressions
+ * waiting to happen rather than hypotheticals.
+ */
+
+const fact = (seq: number, at: number): ButlerFact => ({
+  seq,
+  subject: "user",
+  predicate: "prefers.tea",
+  object: "strong",
+  recordedAt: at,
+  trust: 3,
+  provenance: { channel: "user", validated: true },
+});
+
+const permission = (id: string, active: boolean): StandingPermission => ({
+  id,
+  grantedAt: 1_000,
+  scope: { domains: ["task"] },
+  active,
+  ...(active ? {} : { revokedAt: 2_000 }),
+});
+
+const exercise = (at: number): PermissionExercise => ({
+  permissionId: "perm-1",
+  at,
+  toolName: "tasks.create",
+  classKey: "task:compensable:low",
+});
+
+const approval = (callId: string): PendingApproval => ({
+  callId,
+  toolName: "tasks.create",
+  tier: "low",
+  requestedAt: 5_000,
+  summary: "Add an item to your list",
+});
+
+const read = <T>(value: T): SourceState<T> => ({ state: "read", value });
+const down = <T>(reason: string): SourceState<T> => ({
+  state: "unavailable",
+  reason,
+});
+
+/** All five healthy and empty — the genuine all-clear. */
+function allClear(): ButlerSources {
+  return {
+    facts: read([]),
+    quarantine: read([]),
+    permissions: read([]),
+    exercises: read([]),
+    approvals: read([]),
+  };
+}
+
+describe("needs you · caught up · cannot tell", () => {
+  it("says caught up only when the approvals source was actually read", () => {
+    expect(mapButlerHome(allClear()).status).toEqual({ kind: "caught-up" });
+  });
+
+  it("counts what needs you", () => {
+    const s = mapButlerHome({
+      ...allClear(),
+      approvals: read([approval("a"), approval("b")]),
+    });
+    expect(s.status).toEqual({ kind: "needs-you", count: 2 });
+  });
+
+  it("cannot tell — even when the other four sources are healthy", () => {
+    // The dangerous case, and the reason status is not a boolean. Four healthy
+    // sources cannot see a pending decision, so "everything is caught up" would
+    // be confidently wrong about the only question the headline answers.
+    const s = mapButlerHome({
+      facts: read([fact(1, 10)]),
+      quarantine: read([]),
+      permissions: read([permission("p", true)]),
+      exercises: read([exercise(20)]),
+      approvals: down("I cannot check that on this bridge."),
+    });
+    expect(s.status.kind).toBe("cannot-tell");
+    expect(s.status).toMatchObject({
+      reason: "I cannot check that on this bridge.",
+    });
+    expect(JSON.stringify(s.status)).not.toContain("caught-up");
+  });
+
+  it("never reports zero pending when approvals could not be read", () => {
+    const s = mapButlerHome({ ...allClear(), approvals: down("502") });
+    expect(s.attention.state).toBe("unavailable");
+    expect(JSON.stringify(s.attention)).not.toMatch(/"value":\s*\[\]/);
+  });
+});
+
+describe("established memory vs low-trust observation", () => {
+  it("counts them separately, never as one total", () => {
+    const s = mapButlerHome({
+      ...allClear(),
+      facts: read([fact(1, 10), fact(2, 20)]),
+      quarantine: read([fact(3, 30)]),
+    });
+    expect(s.memory.established).toEqual({ state: "read", value: 2 });
+    expect(s.memory.awaitingConfirmation).toEqual({ state: "read", value: 1 });
+  });
+
+  it("keeps one available when the other is not", () => {
+    // Merging them would need both; carrying them separately means a reader
+    // still learns what IS known.
+    const s = mapButlerHome({
+      ...allClear(),
+      facts: read([fact(1, 10)]),
+      quarantine: down("quarantine unreadable"),
+    });
+    expect(s.memory.established).toEqual({ state: "read", value: 1 });
+    expect(s.memory.awaitingConfirmation.state).toBe("unavailable");
+  });
+});
+
+describe("active permission · none · state unavailable", () => {
+  it("counts only permissions still in force", () => {
+    const s = mapButlerHome({
+      ...allClear(),
+      permissions: read([permission("a", true), permission("b", false)]),
+    });
+    expect(s.permissions.active).toEqual({ state: "read", value: 1 });
+  });
+
+  it("distinguishes none from cannot-check", () => {
+    // The bridge answers 501 for a permission store it cannot read, and that
+    // must never render as "you have allowed nothing" — here the reassuring
+    // reading is the dangerous one.
+    const none = mapButlerHome(allClear()).permissions.active;
+    const unknown = mapButlerHome({
+      ...allClear(),
+      permissions: down("I cannot check that on this bridge."),
+    }).permissions.active;
+
+    expect(none).toEqual({ state: "read", value: 0 });
+    expect(unknown.state).toBe("unavailable");
+    expect(none).not.toEqual(unknown);
+  });
+});
+
+describe("did something without asking vs merely has permission to", () => {
+  it("holding a permission produces no activity claim on its own", () => {
+    const s = mapButlerHome({
+      ...allClear(),
+      permissions: read([permission("p", true)]),
+    });
+    expect(s.permissions.active).toEqual({ state: "read", value: 1 });
+    expect(s.activity).toEqual({ state: "read", value: [] });
+  });
+
+  it("only an exercise says Butler acted", () => {
+    const s = mapButlerHome({
+      ...allClear(),
+      permissions: read([permission("p", true)]),
+      exercises: read([exercise(99)]),
+    });
+    if (s.activity.state !== "read") throw new Error("expected read");
+    expect(s.activity.value).toEqual([
+      {
+        kind: "acted-without-asking",
+        at: 99,
+        toolName: "tasks.create",
+        permissionId: "perm-1",
+      },
+    ]);
+  });
+
+  it("counts the two independently", () => {
+    // One permission used four times is one permission and four actions.
+    const s = mapButlerHome({
+      ...allClear(),
+      permissions: read([permission("p", true)]),
+      exercises: read([exercise(1), exercise(2), exercise(3), exercise(4)]),
+    });
+    expect(s.permissions.active).toEqual({ state: "read", value: 1 });
+    expect(s.permissions.recentExercises).toEqual({ state: "read", value: 4 });
+  });
+});
+
+describe("activity claims only what these sources support", () => {
+  it("orders newest first across claim kinds", () => {
+    const s = mapButlerHome({
+      ...allClear(),
+      facts: read([fact(1, 100)]),
+      quarantine: read([fact(2, 300)]),
+      exercises: read([exercise(200)]),
+    });
+    if (s.activity.state !== "read") throw new Error("expected read");
+    expect(s.activity.value.map((c) => c.at)).toEqual([300, 200, 100]);
+    expect(s.activity.value.map((c) => c.kind)).toEqual([
+      "noticed-not-used",
+      "acted-without-asking",
+      "learned",
+    ]);
+  });
+
+  it("invents no claim these five sources cannot support", () => {
+    // No source records a completed errand, a refusal, or an approval that was
+    // granted and then acted on. A timeline design wanting "checked your
+    // errands — nothing needed changing" does not create the evidence for it.
+    const s = mapButlerHome({
+      ...allClear(),
+      facts: read([fact(1, 10)]),
+      exercises: read([exercise(20)]),
+    });
+    if (s.activity.state !== "read") throw new Error("expected read");
+    const kinds = new Set(s.activity.value.map((c) => c.kind));
+    for (const invented of ["completed", "refused", "approved", "checked"]) {
+      expect([...kinds].join(" ")).not.toContain(invented);
+    }
+  });
+
+  it("a partial timeline is unavailable, not a shorter timeline", () => {
+    // "Some of what happened" cannot be rendered honestly as "what happened".
+    const s = mapButlerHome({
+      ...allClear(),
+      facts: read([fact(1, 10)]),
+      exercises: down("exercises unreadable"),
+    });
+    expect(s.activity.state).toBe("unavailable");
+  });
+});
+
+describe("a failed source never becomes a successful empty one", () => {
+  it("reports every unavailable source, whole, even with four healthy", () => {
+    const s = mapButlerHome({
+      facts: read([fact(1, 10)]),
+      quarantine: read([]),
+      permissions: down("permissions: 501"),
+      exercises: read([]),
+      approvals: read([]),
+    });
+    expect(s.unavailable).toEqual([
+      { source: "permissions", reason: "permissions: 501" },
+    ]);
+    // The healthy four still answer.
+    expect(s.memory.established).toEqual({ state: "read", value: 1 });
+  });
+
+  it("carries the reason verbatim rather than a generic failure", () => {
+    const reason =
+      "I cannot check that on this bridge, so I cannot say what you have allowed.";
+    const s = mapButlerHome({ ...allClear(), permissions: down(reason) });
+    expect(s.unavailable[0]?.reason).toBe(reason);
+  });
+
+  it("all five down is not an all-clear", () => {
+    const s = mapButlerHome({
+      facts: down("a"),
+      quarantine: down("b"),
+      permissions: down("c"),
+      exercises: down("d"),
+      approvals: down("e"),
+    });
+    expect(s.status.kind).toBe("cannot-tell");
+    expect(s.unavailable).toHaveLength(5);
+    // Not one field anywhere reports a confident zero.
+    expect(JSON.stringify(s)).not.toMatch(/"value":\s*0/);
+    expect(JSON.stringify(s)).not.toMatch(/"value":\s*\[\]/);
+  });
+
+  it("the genuine all-clear and the total blackout do not agree anywhere", () => {
+    // The single assertion this whole module exists to satisfy.
+    const clear = mapButlerHome(allClear());
+    const blackout = mapButlerHome({
+      facts: down("a"),
+      quarantine: down("b"),
+      permissions: down("c"),
+      exercises: down("d"),
+      approvals: down("e"),
+    });
+    expect(clear).not.toEqual(blackout);
+    expect(clear.status).not.toEqual(blackout.status);
+    expect(clear.memory).not.toEqual(blackout.memory);
+    expect(clear.permissions).not.toEqual(blackout.permissions);
+    expect(clear.activity).not.toEqual(blackout.activity);
+    expect(clear.attention).not.toEqual(blackout.attention);
+  });
+});

--- a/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
+++ b/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
@@ -26,14 +26,30 @@ import {
  * waiting to happen rather than hypotheticals.
  */
 
+/**
+ * A fact as the store actually writes one.
+ *
+ * `trust` is a FRACTION on 0..1, not a tier index — `user_chat` sits at 1.0 and
+ * `connector` at 0.3, strictly below the 0.6 origination threshold. An earlier
+ * draft of this fixture used `trust: 3`, a value the store cannot produce, and
+ * a fixture carrying an impossible value teaches every later test built on it
+ * the wrong shape.
+ */
 const fact = (seq: number, at: number): ButlerFact => ({
   seq,
   subject: "user",
-  predicate: "prefers.tea",
-  object: "strong",
+  predicate: "tasks.default_list",
+  object: "personal",
   recordedAt: at,
-  trust: 3,
-  provenance: { channel: "user", validated: true },
+  trust: 1,
+  provenance: { channel: "user_chat", tier: 1, validated: true },
+});
+
+/** What quarantine holds: connector-derived, capped below origination. */
+const observed = (seq: number, at: number): ButlerFact => ({
+  ...fact(seq, at),
+  trust: 0.3,
+  provenance: { channel: "connector", source: "gmail", tier: 0.3, validated: false },
 });
 
 const permission = (id: string, active: boolean): StandingPermission => ({
@@ -47,13 +63,13 @@ const permission = (id: string, active: boolean): StandingPermission => ({
 const exercise = (at: number): PermissionExercise => ({
   permissionId: "perm-1",
   at,
-  toolName: "tasks.create",
+  toolName: "todoist.create_task",
   classKey: "task:compensable:low",
 });
 
 const approval = (callId: string): PendingApproval => ({
   callId,
-  toolName: "tasks.create",
+  toolName: "todoist.create_task",
   tier: "low",
   requestedAt: 5_000,
   summary: "Add an item to your list",
@@ -119,7 +135,7 @@ describe("established memory vs low-trust observation", () => {
     const s = mapButlerHome({
       ...allClear(),
       facts: read([fact(1, 10), fact(2, 20)]),
-      quarantine: read([fact(3, 30)]),
+      quarantine: read([observed(3, 30)]),
     });
     expect(s.memory.established).toEqual({ state: "read", value: 2 });
     expect(s.memory.awaitingConfirmation).toEqual({ state: "read", value: 1 });
@@ -184,7 +200,7 @@ describe("did something without asking vs merely has permission to", () => {
       {
         kind: "acted-without-asking",
         at: 99,
-        toolName: "tasks.create",
+        toolName: "todoist.create_task",
         permissionId: "perm-1",
       },
     ]);
@@ -198,7 +214,7 @@ describe("did something without asking vs merely has permission to", () => {
       exercises: read([exercise(1), exercise(2), exercise(3), exercise(4)]),
     });
     expect(s.permissions.active).toEqual({ state: "read", value: 1 });
-    expect(s.permissions.recentExercises).toEqual({ state: "read", value: 4 });
+    expect(s.permissions.actionsWithoutAsking).toEqual({ state: "read", value: 4 });
   });
 });
 
@@ -207,7 +223,7 @@ describe("activity claims only what these sources support", () => {
     const s = mapButlerHome({
       ...allClear(),
       facts: read([fact(1, 100)]),
-      quarantine: read([fact(2, 300)]),
+      quarantine: read([observed(2, 300)]),
       exercises: read([exercise(200)]),
     });
     if (s.activity.state !== "read") throw new Error("expected read");

--- a/dashboard/src/app/butler/homeState.ts
+++ b/dashboard/src/app/butler/homeState.ts
@@ -1,0 +1,336 @@
+/**
+ * What Butler Home must KNOW, independent of how it is drawn.
+ *
+ * Pure. No fetch, no React, no clock read of its own — `mapButlerHome` takes
+ * what five endpoints returned and produces one state. That separation is the
+ * point: today `page.tsx` fetches five surfaces and interprets them inside the
+ * component, so a redesign would carry that interpretation into prettier
+ * components rather than leaving it behind.
+ *
+ * ## A failed source must never become a successful empty one
+ *
+ * The rule this module exists to enforce. An unreachable endpoint rendering as
+ * `[]` is absence collapsing into a value, and it reads as reassurance: "Butler
+ * knows nothing about you" and "I could not ask" are opposite facts, and only
+ * one of them should let a reader relax.
+ *
+ * `page.tsx` already learned this the hard way — twice. The dashboard proxy
+ * answers a dead bridge with a 502 whose BODY is valid JSON, so a `.json()`
+ * parse succeeded and shape guards fell through to `[]`; and the bridge answers
+ * 501 for a permission store it cannot read, which must not read as "you have
+ * granted nothing". Both lessons are carried here rather than re-learned.
+ *
+ * ## Partial availability is representable, because today it is not
+ *
+ * The page loads all five with `Promise.all`, so ONE failure discards four
+ * healthy sources and the whole screen becomes a single error. That is the
+ * safe direction to fail, but it is still a collapse: five independent
+ * availabilities reduced to one boolean. Every source here carries its own
+ * `SourceState`, so a reader can be told what is known AND what could not be
+ * checked, at the same time.
+ *
+ * ## It decides no policy
+ *
+ * Trust tiers, what counts as established, what a permission authorises — all
+ * of that belongs to the runtime. This layer counts, groups and phrases. Where
+ * it cannot answer, it says so.
+ */
+
+// ── What the endpoints return ────────────────────────────────────────────────
+
+export interface ButlerFact {
+  seq: number;
+  subject: string;
+  predicate: string;
+  object: string;
+  recordedAt: number;
+  trust: number;
+  provenance: { channel: string; source?: string; validated: boolean };
+}
+
+export interface StandingPermission {
+  id: string;
+  grantedAt: number;
+  scope: { domains: string[] };
+  revokedAt?: number;
+  expiresAt?: number;
+  active: boolean;
+}
+
+export interface PermissionExercise {
+  permissionId: string;
+  at: number;
+  toolName: string;
+  classKey: string;
+  workerId?: string;
+  recipeName?: string;
+}
+
+export interface PendingApproval {
+  callId: string;
+  toolName: string;
+  tier: "low" | "medium" | "high";
+  requestedAt: number;
+  summary?: string;
+}
+
+// ── How a source is known ────────────────────────────────────────────────────
+
+/**
+ * One source's outcome. There is no third arm and no bare value.
+ *
+ * `unavailable` carries the REASON and no value, so a renderer physically
+ * cannot show an empty list where a failure belongs.
+ */
+export type SourceState<T> =
+  | { state: "read"; value: T }
+  | { state: "unavailable"; reason: string };
+
+export function isRead<T>(
+  s: SourceState<T>,
+): s is { state: "read"; value: T } {
+  return s.state === "read";
+}
+
+/** The five surfaces, each with its own outcome. */
+export interface ButlerSources {
+  facts: SourceState<ButlerFact[]>;
+  quarantine: SourceState<ButlerFact[]>;
+  permissions: SourceState<StandingPermission[]>;
+  exercises: SourceState<PermissionExercise[]>;
+  approvals: SourceState<PendingApproval[]>;
+}
+
+// ── The state Home renders ───────────────────────────────────────────────────
+
+/**
+ * The headline.
+ *
+ * `cannot-tell` is NOT a worse `caught-up`. "Nothing is waiting for you" and
+ * "I could not find out whether anything is waiting for you" differ by exactly
+ * the thing a reader uses the page to decide, so they are separate arms and the
+ * second carries its reason.
+ */
+export type ButlerStatus =
+  | { kind: "needs-you"; count: number }
+  | { kind: "caught-up" }
+  | { kind: "cannot-tell"; reason: string };
+
+export interface AttentionItem {
+  callId: string;
+  toolName: string;
+  tier: "low" | "medium" | "high";
+  requestedAt: number;
+  summary?: string;
+}
+
+/**
+ * An activity claim, limited to what these five sources can actually support.
+ *
+ * Deliberately NOT a generic event feed. Of the five surfaces only permission
+ * exercises record Butler DOING something, and only facts and quarantine record
+ * it coming to know something. Nothing here records a completed errand, a
+ * refusal, or an approval that was granted and then acted on — so Home cannot
+ * honestly render "checked your errands, nothing needed changing" today, however
+ * much a timeline design wants that row.
+ *
+ * Inventing it is the failure this type exists to prevent: a sentence the data
+ * cannot support is indistinguishable, to a reader, from one it can.
+ */
+export type ActivityClaim =
+  /** From a permission exercise: Butler acted under standing permission. */
+  | {
+      kind: "acted-without-asking";
+      at: number;
+      toolName: string;
+      permissionId: string;
+    }
+  /** From an established fact: Butler came to know something. */
+  | { kind: "learned"; at: number; factSeq: number }
+  /** From quarantine: Butler noticed something and has NOT used it. */
+  | { kind: "noticed-not-used"; at: number; factSeq: number };
+
+export interface MemorySummary {
+  /** Beliefs Butler may act on. */
+  established: SourceState<number>;
+  /**
+   * Low-trust observations held back from belief.
+   *
+   * Separate from `established` because the store separates them: connector-
+   * derived material is capped below the threshold at which Butler may
+   * originate a belief. One combined "things Butler knows" count would merge
+   * two populations and erase a real safety boundary.
+   */
+  awaitingConfirmation: SourceState<number>;
+}
+
+export interface PermissionSummary {
+  /**
+   * Standing permissions currently in force.
+   *
+   * `unavailable` is a THIRD state, not a zero. The bridge answers 501 when it
+   * cannot read the permission store, and "I cannot check what you have
+   * allowed" must never render as "you have allowed nothing" — the reassuring
+   * reading is the dangerous one here.
+   */
+  active: SourceState<number>;
+  /**
+   * Times a permission was actually used.
+   *
+   * Distinct from `active` on purpose: holding a permission and having acted on
+   * it are different facts, and only the second is something Butler did.
+   */
+  recentExercises: SourceState<number>;
+}
+
+export interface ButlerHomeState {
+  status: ButlerStatus;
+  attention: SourceState<AttentionItem[]>;
+  activity: SourceState<ActivityClaim[]>;
+  memory: MemorySummary;
+  permissions: PermissionSummary;
+  /**
+   * Every source that could not be read, carried WHOLE.
+   *
+   * Never truncated and never summarised to a count: the reason a thing cannot
+   * be shown is the most load-bearing prose on the page. Present even when the
+   * other four sources are healthy — partial knowledge is the common case and
+   * must not silently present as complete.
+   */
+  unavailable: { source: keyof ButlerSources; reason: string }[];
+}
+
+// ── The mapping ──────────────────────────────────────────────────────────────
+
+/** Count a read source, or carry its unavailability forward untouched. */
+function countOf<T>(s: SourceState<T[]>): SourceState<number> {
+  return s.state === "read"
+    ? { state: "read", value: s.value.length }
+    : { state: "unavailable", reason: s.reason };
+}
+
+/**
+ * Is this fact an established belief, or an observation held back from one?
+ *
+ * The threshold is the RUNTIME's, and this module does not own it. Quarantine
+ * is a separate endpoint precisely so the caller does not have to decide: what
+ * `/butler/facts` returns is established, what `/butler/quarantine` returns is
+ * not. Re-deriving that from `trust` here would create a second opinion about a
+ * safety boundary, which is how two notions of the same rule drift.
+ */
+
+/**
+ * Fold the five surfaces into one Home state.
+ *
+ * Every uncertainty in, survives out. There is no path by which an
+ * `unavailable` source becomes an empty collection.
+ */
+export function mapButlerHome(sources: ButlerSources): ButlerHomeState {
+  const unavailable: ButlerHomeState["unavailable"] = [];
+  for (const key of [
+    "facts",
+    "quarantine",
+    "permissions",
+    "exercises",
+    "approvals",
+  ] as const) {
+    const s = sources[key];
+    if (s.state === "unavailable") {
+      unavailable.push({ source: key, reason: s.reason });
+    }
+  }
+
+  // Status answers one question — does anything need you? — and only the
+  // approvals surface can answer it. If that source failed, the honest answer
+  // is that we cannot tell, EVEN IF the other four are healthy: a page saying
+  // "everything is caught up" on four sources that cannot see a pending
+  // decision is confidently wrong about the only thing it was asked.
+  const status: ButlerStatus =
+    sources.approvals.state === "unavailable"
+      ? { kind: "cannot-tell", reason: sources.approvals.reason }
+      : sources.approvals.value.length > 0
+        ? { kind: "needs-you", count: sources.approvals.value.length }
+        : { kind: "caught-up" };
+
+  const attention: SourceState<AttentionItem[]> =
+    sources.approvals.state === "read"
+      ? {
+          state: "read",
+          value: sources.approvals.value.map((a) => ({
+            callId: a.callId,
+            toolName: a.toolName,
+            tier: a.tier,
+            requestedAt: a.requestedAt,
+            ...(a.summary === undefined ? {} : { summary: a.summary }),
+          })),
+        }
+      : { state: "unavailable", reason: sources.approvals.reason };
+
+  // Activity is assembled only from claims these sources can support, and is
+  // itself a SourceState: a partial timeline presented as a whole one is a
+  // quieter version of the same lie. If any contributing source failed, the
+  // list is not "what happened" — it is "some of what happened", and there is
+  // no honest way to render that as a complete history.
+  const contributors = [
+    sources.exercises,
+    sources.facts,
+    sources.quarantine,
+  ] as const;
+  const firstFailed = contributors.find((s) => s.state === "unavailable");
+
+  let activity: SourceState<ActivityClaim[]>;
+  if (firstFailed && firstFailed.state === "unavailable") {
+    activity = { state: "unavailable", reason: firstFailed.reason };
+  } else {
+    const claims: ActivityClaim[] = [];
+    if (sources.exercises.state === "read") {
+      for (const e of sources.exercises.value) {
+        claims.push({
+          kind: "acted-without-asking",
+          at: e.at,
+          toolName: e.toolName,
+          permissionId: e.permissionId,
+        });
+      }
+    }
+    if (sources.facts.state === "read") {
+      for (const f of sources.facts.value) {
+        claims.push({ kind: "learned", at: f.recordedAt, factSeq: f.seq });
+      }
+    }
+    if (sources.quarantine.state === "read") {
+      for (const f of sources.quarantine.value) {
+        claims.push({
+          kind: "noticed-not-used",
+          at: f.recordedAt,
+          factSeq: f.seq,
+        });
+      }
+    }
+    claims.sort((a, b) => b.at - a.at);
+    activity = { state: "read", value: claims };
+  }
+
+  return {
+    status,
+    attention,
+    activity,
+    memory: {
+      established: countOf(sources.facts),
+      awaitingConfirmation: countOf(sources.quarantine),
+    },
+    permissions: {
+      // Only permissions still in force. A revoked or expired grant is history,
+      // and counting it would overstate what Butler may currently do.
+      active:
+        sources.permissions.state === "read"
+          ? {
+              state: "read",
+              value: sources.permissions.value.filter((p) => p.active).length,
+            }
+          : { state: "unavailable", reason: sources.permissions.reason },
+      recentExercises: countOf(sources.exercises),
+    },
+    unavailable,
+  };
+}

--- a/dashboard/src/app/butler/homeState.ts
+++ b/dashboard/src/app/butler/homeState.ts
@@ -45,7 +45,15 @@ export interface ButlerFact {
   object: string;
   recordedAt: number;
   trust: number;
-  provenance: { channel: string; source?: string; validated: boolean };
+  provenance: {
+    /** `user_chat` · `user_confirmed` · `recipe_agent` · `connector` · `import`. */
+    channel: string;
+    /** Connector slug when `channel === "connector"`. */
+    source?: string;
+    /** The channel's trust ceiling AS STORED, not recomputed. */
+    tier: number;
+    validated: boolean;
+  };
 }
 
 export interface StandingPermission {
@@ -175,12 +183,17 @@ export interface PermissionSummary {
    */
   active: SourceState<number>;
   /**
-   * Times a permission was actually used.
+   * Times Butler acted under a standing permission — ALL TIME, not a window.
+   *
+   * Not `recentExercises`: `/butler/permissions/exercises` returns the whole
+   * log, and a name promising recency would have a renderer write "3 recent
+   * actions" over a count spanning months. The endpoint would have to grow a
+   * window before that sentence became true.
    *
    * Distinct from `active` on purpose: holding a permission and having acted on
    * it are different facts, and only the second is something Butler did.
    */
-  recentExercises: SourceState<number>;
+  actionsWithoutAsking: SourceState<number>;
 }
 
 export interface ButlerHomeState {
@@ -329,7 +342,7 @@ export function mapButlerHome(sources: ButlerSources): ButlerHomeState {
               value: sources.permissions.value.filter((p) => p.active).length,
             }
           : { state: "unavailable", reason: sources.permissions.reason },
-      recentExercises: countOf(sources.exercises),
+      actionsWithoutAsking: countOf(sources.exercises),
     },
     unavailable,
   };

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,14 +50,21 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- **`feat/butler-view-model`** (#1568) — Butler Home view-model: types + pure
-  mapping over the five existing `/butler/*` and `/approvals` surfaces. Touches
-  only `dashboard/src/app/butler/homeState.ts` and its test; no UI, no routes,
-  no runtime. `feat/butler-home` follows and WILL touch `page.tsx` — coordinate
-  here first. Design freeze: `docs/butler-product-reset.md`.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-09-01 `feat/butler-view-model` — Butler Home view-model (#1568). Types + a pure
+  mapping over the five surfaces the page already reads. Two findings rather than a
+  refactor: `page.tsx` loads all five with `Promise.all`, so one unreadable source discards
+  four healthy ones and five independent availabilities collapse to one boolean; and the
+  five sources cannot support an activity TIMELINE at all — only permission exercises are
+  evidence of Butler doing something, facts/quarantine are knowledge events, and nothing
+  records a completed errand, a refusal, or an approval granted and then acted on. So the
+  model defines three claim kinds, not a feed, and a partial timeline is `unavailable`
+  rather than a shorter one. Closing invariant: a genuine all-clear and a total blackout
+  share no user-facing state. `feat/butler-home` follows and WILL touch `page.tsx`.
 
 - 2026-09-01 `docs/butler-product-reset` — Butler design freeze (#1567). Butler's substrate
   is built (fact store with provenance tiers, quarantine, standing permissions with exercise

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- **`feat/butler-view-model`** (#1568) — Butler Home view-model: types + pure
+  mapping over the five existing `/butler/*` and `/approvals` surfaces. Touches
+  only `dashboard/src/app/butler/homeState.ts` and its test; no UI, no routes,
+  no runtime. `feat/butler-home` follows and WILL touch `page.tsx` — coordinate
+  here first. Design freeze: `docs/butler-product-reset.md`.
 
 
 ## Recently closed (informal log, prune periodically)


### PR DESCRIPTION
Step 2 of the Butler product reset ([#1567](https://github.com/Oolab-labs/patchwork-os/pull/1567)).
Types and a pure mapping, with tests over fixtures.

**No UI, no routes, no runtime calls, and no existing test touched.** The
question this branch answers is narrow on purpose:

> Given only the five surfaces Butler actually has today, what may Home
> truthfully claim?

## The invariant everything else serves

> **A genuine all-clear and a total blackout share no user-facing state.**

Not status, not memory, not permissions, not activity, not attention. The
closing test asserts that field by field, because "Butler knows nothing about
you" and "I could not ask" are opposite facts and only one of them should let a
reader relax.

## Two discoveries — this is not a refactor

### 1. One unreadable source is currently a total blackout

`page.tsx` loads all five with `Promise.all`, so a single failure discards four
healthy sources and the whole screen becomes one error. That fails in the safe
direction, and it is still a collapse: **five independent availabilities reduced
to one boolean.**

Every source now carries its own `SourceState`, so Butler can say *I know these
things, but I could not check that other part* — a state the page cannot
currently represent at all.

Status is `cannot-tell` when approvals cannot be read **even if the other four
are healthy**, because four working sources cannot see a pending decision, and
"everything is caught up" would then be confidently wrong about the only
question the headline answers.

### 2. The five sources cannot support an activity timeline

A product finding, not a missing line of code.

Only **permission exercises** are evidence of Butler *doing* something. Facts and
quarantine are *knowledge* events. Nothing records a completed errand, a
refusal, or an approval granted and then acted on.

So Home **cannot** honestly render "Butler checked your errands — nothing needed
changing" today, however much a timeline design wants that row. The model
therefore defines three claim kinds rather than a feed, and a test asserts no
invented claim appears. A partial timeline is `unavailable`, not a shorter one:
"some of what happened" cannot be drawn as "what happened".

**Deliberately not fixed here.** Manufacturing a Butler activity feed out of
`runs.jsonl`, approvals or a gate log would distort sources that mean something
else. The missing story is recorded for a later decision framed as *what durable
event lets a person answer "what did Butler actually do for me?"* — not *how do
we populate the timeline?* That work touches evidence/runtime territory
currently under observation and is out of scope for this branch and the next.

## The acceptance contract

Five distinctions, each with a test that fails without it:

| distinction | why it collapses otherwise |
|---|---|
| needs you · caught up · **cannot tell** | an unreadable approvals source reads as "nothing pending" |
| established memory · low-trust observation | the store caps connector-derived material below belief-origination; one total erases that boundary |
| active permission · none · **unavailable** | the bridge answers 501 for an unreadable permission store; "nothing allowed" is the dangerous reading |
| did something without asking · merely has permission to | holding a permission is not an action; only an exercise is |
| approval pending · **source unavailable** | `[]` from a dead source is a convincing lie |

Both emphasised failure modes have already caught `page.tsx` in production
code — a 502 whose body parsed as valid JSON, and a 501 for an unreadable
permission store. These are regressions waiting to happen, not hypotheticals.

## Verification

18 new tests; 64 Butler tests total; dashboard typecheck clean.

**Mutation-checked:** making the mapper treat an unreadable approvals source as
an empty one fails 3 tests, including the closing invariant.

**The typecheck was itself verified**, because CLAUDE.md documents a workspace
where `tsc --noEmit` silently checks nothing: a deliberate type error in the new
file was confirmed to be caught before the clean result was trusted.

## What it decides

Nothing. Trust tiers, what counts as established, and what a permission
authorises all stay with the runtime — quarantine is a separate endpoint
precisely so this layer never has to re-derive the threshold and create a second
opinion about a safety boundary. This layer counts, groups and phrases, and says
so where it cannot answer.
