### PR TITLE
feat(butler): the answer first, and one failure no longer takes the page down

### DIFF
--- a/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
+++ b/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
@@ -55,6 +55,7 @@ const observed = (seq: number, at: number): ButlerFact => ({
 const permission = (id: string, active: boolean): StandingPermission => ({
   id,
   grantedAt: 1_000,
+  grantedBy: null,
   scope: { domains: ["task"] },
   active,
   ...(active ? {} : { revokedAt: 2_000 }),

--- a/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
+++ b/dashboard/src/app/butler/__tests__/butler-home-state.test.ts
@@ -56,7 +56,7 @@ const permission = (id: string, active: boolean): StandingPermission => ({
   id,
   grantedAt: 1_000,
   grantedBy: null,
-  scope: { domains: ["task"] },
+  scope: { domains: ["tasks"] },
   active,
   ...(active ? {} : { revokedAt: 2_000 }),
 });

--- a/dashboard/src/app/butler/__tests__/butler-page.test.tsx
+++ b/dashboard/src/app/butler/__tests__/butler-page.test.tsx
@@ -350,21 +350,85 @@ describe("honesty when the bridge is unreachable", () => {
 });
 
 describe("structure", () => {
-  it("is a single column with sections in reading order", async () => {
+  /**
+   * This replaced an assertion listing five literal headings in one fixed
+   * order. That test was not protecting the wording — its own comment said
+   * "DOM order IS reading order", so the guarantee is that a screen-reader or
+   * keyboard user meets an urgent decision before passive information. The
+   * five headings were how that intent got frozen, and freezing it made the
+   * information architecture unchangeable without failing a test that looked
+   * like an accessibility test.
+   *
+   * The intent survives, expressed as outcomes. See
+   * docs/butler-product-reset.md.
+   */
+  it("puts what needs a decision before anything passive", async () => {
     const { container } = render(<ButlerPage />);
     await screen.findByText("Push the release branch");
     const headings = Array.from(container.querySelectorAll("h2")).map((h) =>
       (h.textContent ?? "").trim(),
     );
-    // DOM order IS reading order — the plan's §4 ordering, which a screen
-    // reader and a keyboard user both follow literally.
-    expect(headings).toEqual([
-      "Something I need to ask you",
-      "What I know about you",
-      "Things I noticed but have not used",
-      "What I did without asking",
-      "What you have allowed",
-    ]);
+    const ask = headings.findIndex((h) => /need to ask you/i.test(h));
+    expect(ask).toBeGreaterThanOrEqual(0);
+    // Everything else is reference material a reader may skip.
+    for (const [i, h] of headings.entries()) {
+      if (i === ask) continue;
+      expect(i, `"${h}" precedes the decision`).toBeGreaterThan(ask);
+    }
+  });
+
+  it("states what needs a decision before the page is scrolled", async () => {
+    render(<ButlerPage />);
+    // The headline answers the question the reader came with, in words, and
+    // does not require reaching a section to find it.
+    const status = await screen.findByText(
+      /waiting for your decision|could not find out whether/i,
+    );
+    expect(status).toBeTruthy();
+  });
+
+  it("puts an unreadable source ahead of what it would undermine", async () => {
+    // A reader who has taken in three sections must not discover afterwards
+    // that a fourth was never consulted.
+    const { container } = render(<ButlerPage />);
+    await screen.findByText("Push the release branch");
+    const headings = Array.from(container.querySelectorAll("h2")).map((h) =>
+      (h.textContent ?? "").trim(),
+    );
+    const unchecked = headings.findIndex((h) => /could not check/i.test(h));
+    if (unchecked >= 0) {
+      const ask = headings.findIndex((h) => /need to ask you/i.test(h));
+      expect(unchecked).toBeLessThan(ask);
+    }
+  });
+
+  it("does not render one empty section per source when all is well", async () => {
+    // The all-clear used to cost as much attention as an urgent page: five
+    // headings, each with its own rendering of "nothing here".
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve(
+              String(url).includes("approvals")
+                ? []
+                : { facts: [], permissions: [], exercises: [] },
+            ),
+        }),
+      ),
+    );
+    const { container } = render(<ButlerPage />);
+    await screen.findByText(/Nothing is waiting for your decision/i);
+    // Nothing could not be checked, so no apology is on the page at all.
+    expect(
+      Array.from(container.querySelectorAll("h2")).filter((h) =>
+        /could not check/i.test(h.textContent ?? ""),
+      ),
+    ).toHaveLength(0);
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("every section is labelled by its own heading", async () => {

--- a/dashboard/src/app/butler/__tests__/butler-page.test.tsx
+++ b/dashboard/src/app/butler/__tests__/butler-page.test.tsx
@@ -349,6 +349,72 @@ describe("honesty when the bridge is unreachable", () => {
   });
 });
 
+/** Every source healthy and empty — the genuine all-clear. */
+function stubAllEmpty() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve(
+            String(url).includes("approvals")
+              ? []
+              : { facts: [], permissions: [], exercises: [] },
+          ),
+      }),
+    ),
+  );
+}
+
+/** One named endpoint fails; the rest answer normally and emptily. */
+function stubWithFailure(fragment: string, status: number) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (String(url).includes(fragment)) {
+        return Promise.resolve({
+          ok: false,
+          status,
+          json: () => Promise.resolve({ error: "no" }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve(
+            String(url).includes("approvals")
+              ? []
+              : { facts: [], permissions: [], exercises: [] },
+          ),
+      });
+    }),
+  );
+}
+
+/** A 200 whose body parses but is not the shape the client expects. */
+function stubMalformed(fragment: string, body: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve(
+            String(url).includes(fragment)
+              ? body
+              : String(url).includes("approvals")
+                ? []
+                : { facts: [], permissions: [], exercises: [] },
+          ),
+      }),
+    ),
+  );
+}
+
 describe("structure", () => {
   /**
    * This replaced an assertion listing five literal headings in one fixed
@@ -390,45 +456,72 @@ describe("structure", () => {
   it("puts an unreadable source ahead of what it would undermine", async () => {
     // A reader who has taken in three sections must not discover afterwards
     // that a fourth was never consulted.
+    //
+    // The first version of this test never made a source fail and wrapped its
+    // assertion in `if (unchecked >= 0)`, so it passed by the heading being
+    // ABSENT — a guard that could not fail. One endpoint genuinely fails here.
+    stubWithFailure("permissions", 501);
     const { container } = render(<ButlerPage />);
-    await screen.findByText("Push the release branch");
-    const headings = Array.from(container.querySelectorAll("h2")).map((h) =>
-      (h.textContent ?? "").trim(),
-    );
-    const unchecked = headings.findIndex((h) => /could not check/i.test(h));
-    if (unchecked >= 0) {
-      const ask = headings.findIndex((h) => /need to ask you/i.test(h));
-      expect(unchecked).toBeLessThan(ask);
-    }
+    const headings = () =>
+      Array.from(container.querySelectorAll("h2")).map((h) =>
+        (h.textContent ?? "").trim(),
+      );
+    await screen.findAllByText(/could not make sense|cannot check/i);
+
+    const hs = headings();
+    const unchecked = hs.findIndex((h) => /could not check/i.test(h));
+    expect(unchecked, "the unavailable section must be rendered").toBeGreaterThanOrEqual(0);
+    const allowed = hs.findIndex((h) => /you have allowed/i.test(h));
+    expect(allowed).toBeGreaterThanOrEqual(0);
+    expect(unchecked).toBeLessThan(allowed);
+  });
+
+  it("names which part of Butler could not be checked", async () => {
+    // "I could not check" beside nothing tells a reader something is missing
+    // but not WHAT, so they cannot judge which sentences above to trust.
+    stubWithFailure("permissions", 501);
+    render(<ButlerPage />);
+    const row = await screen.findByText(/What you have allowed:/i);
+    expect(row).toBeTruthy();
   });
 
   it("does not render one empty section per source when all is well", async () => {
     // The all-clear used to cost as much attention as an urgent page: five
     // headings, each with its own rendering of "nothing here".
-    vi.stubGlobal(
-      "fetch",
-      vi.fn((url: string) =>
-        Promise.resolve({
-          ok: true,
-          status: 200,
-          json: () =>
-            Promise.resolve(
-              String(url).includes("approvals")
-                ? []
-                : { facts: [], permissions: [], exercises: [] },
-            ),
-        }),
-      ),
-    );
+    //
+    // An earlier version of THIS test asserted only that no apology and no
+    // alert appeared, and passed while all five empty sections were still on
+    // the page — a test named for a guarantee it never checked. It now counts
+    // the headings.
+    stubAllEmpty();
     const { container } = render(<ButlerPage />);
     await screen.findByText(/Nothing is waiting for your decision/i);
-    // Nothing could not be checked, so no apology is on the page at all.
+
+    const headings = Array.from(container.querySelectorAll("h2")).map((h) =>
+      (h.textContent ?? "").trim(),
+    );
+    // Sections whose only content would be "nothing here" are gone entirely.
+    expect(headings.join(" | ")).not.toMatch(/need to ask you/i);
+    expect(headings.join(" | ")).not.toMatch(/already said I could/i);
+    expect(headings.join(" | ")).not.toMatch(/noticed/i);
+    // What survives is the reference material a reader may still want.
+    expect(headings.length).toBeLessThanOrEqual(2);
+
     expect(
-      Array.from(container.querySelectorAll("h2")).filter((h) =>
-        /could not check/i.test(h.textContent ?? ""),
-      ),
+      headings.filter((h) => /could not check/i.test(h)),
     ).toHaveLength(0);
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("brings a section back the moment it has something to show", async () => {
+    // Compression must not become suppression: the sections above are absent
+    // because they are empty, not because they were removed.
+    const { container } = render(<ButlerPage />); // default stub has an ask
+    await screen.findByText("Push the release branch");
+    const headings = Array.from(container.querySelectorAll("h2")).map((h) =>
+      (h.textContent ?? "").trim(),
+    );
+    expect(headings.join(" | ")).toMatch(/need to ask you/i);
   });
 
   it("every section is labelled by its own heading", async () => {
@@ -438,5 +531,56 @@ describe("structure", () => {
       expect(id).toBeTruthy();
       expect(container.querySelector(`#${id}`)).toBeTruthy();
     }
+  });
+});
+
+describe("a wrong shape is not an empty result", () => {
+  it("refuses a 200 whose wrapped array is missing", async () => {
+    // The 502 lesson wearing a success code: the response parsed, nothing
+    // threw, and the page would have said "nothing allowed" about a payload it
+    // did not understand.
+    stubMalformed("permissions", { permissions: { oops: true } });
+    render(<ButlerPage />);
+    // Both the named unavailable row and the affected section say so, which
+    // is the point: a reader meets it wherever they entered the page.
+    expect(
+      (await screen.findAllByText(/could not make sense of the answer/i)).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("refuses a bare /approvals body that is not an array", async () => {
+    // /approvals returns a BARE array. A wrapper appearing here would be a
+    // server change, not an empty queue.
+    stubMalformed("approvals", { pending: [] });
+    render(<ButlerPage />);
+    expect(
+      await screen.findByText(
+        /could not find out whether anything is waiting/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("does not report zero pending when the shape drifted", async () => {
+    stubMalformed("approvals", { pending: [] });
+    render(<ButlerPage />);
+    await screen.findByText(/could not find out whether anything is waiting/i);
+    expect(screen.queryByText(/Nothing is waiting for your decision/i)).toBeNull();
+  });
+});
+
+describe("still exactly one announcer", () => {
+  it("counts implicit live regions, not only aria-live ones", async () => {
+    // `role="status"` carries implicit polite live semantics, so a visible
+    // headline marked that way becomes a SECOND announcer — approving
+    // something would be read out twice. A query for [aria-live="polite"]
+    // alone cannot see it, which is how it was nearly shipped.
+    const { container } = render(<ButlerPage />);
+    await screen.findByText("Push the release branch");
+    const explicit = container.querySelectorAll('[aria-live="polite"]');
+    const implicit = container.querySelectorAll(
+      '[role="status"], [role="log"], [role="alert"]',
+    );
+    const all = new Set<Element>([...explicit, ...implicit]);
+    expect(all.size).toBe(1);
   });
 });

--- a/dashboard/src/app/butler/butler.css
+++ b/dashboard/src/app/butler/butler.css
@@ -302,3 +302,18 @@
     flex: 1 1 100%;
   }
 }
+
+/* The headline answer, before any section.
+ *
+ * Larger than body text and stated in words, because it carries the one thing
+ * a reader came for. It is NOT coloured to signal state: "nothing is waiting"
+ * and "I could not find out" must remain distinguishable in greyscale, to a
+ * screen reader, and printed — the same rule the rest of this page keeps.
+ */
+.butlerStatus {
+  font-size: 1.35em;
+  line-height: 1.4;
+  font-weight: 600;
+  margin: 0 0 1.4rem;
+  max-width: 34ch;
+}

--- a/dashboard/src/app/butler/homeState.ts
+++ b/dashboard/src/app/butler/homeState.ts
@@ -59,9 +59,13 @@ export interface ButlerFact {
 export interface StandingPermission {
   id: string;
   grantedAt: number;
+  /** Who granted it, or null on a grant made before attribution existed. */
+  grantedBy: string | null;
   scope: { domains: string[] };
-  revokedAt?: number;
+  ceiling?: { magnitudeBand?: string; perDay?: number };
   expiresAt?: number;
+  revokedAt?: number;
+  note?: string;
   active: boolean;
 }
 

--- a/dashboard/src/app/butler/page.tsx
+++ b/dashboard/src/app/butler/page.tsx
@@ -139,6 +139,21 @@ async function getJson(path: string): Promise<Record<string, unknown>> {
 /** The five surfaces Home reads. Named so a total blackout is countable. */
 const SOURCE_COUNT = 5;
 
+/**
+ * Which part of Butler a failed source belongs to, in the reader's words.
+ *
+ * Named rather than left implicit: "I could not check" beside nothing tells a
+ * reader that something is missing but not WHAT, so they cannot judge which of
+ * the sentences above them to trust.
+ */
+const SOURCE_IN_WORDS: Record<string, string> = {
+  facts: "What I know about you",
+  quarantine: "Things I noticed",
+  permissions: "What you have allowed",
+  exercises: "What I have done",
+  approvals: "Anything waiting for your decision",
+};
+
 // ─────────────────────────────────────────────────────────────── page
 
 export default function ButlerPage() {
@@ -201,7 +216,20 @@ export default function ButlerPage() {
         const body = r.value;
         // A bare array is the /approvals shape; everything else wraps.
         const raw = key === "" ? body : (body as Record<string, unknown>)[key];
-        return { state: "read", value: (Array.isArray(raw) ? raw : []) as T[] };
+        if (!Array.isArray(raw)) {
+          // A 200 whose shape drifted is NOT an empty result. Falling through
+          // to `[]` here would defeat the whole invariant one layer before the
+          // view-model gets to protect it — and it is the same failure the 502
+          // taught this file, wearing a success code: the response parsed, so
+          // nothing threw, and the page would say "nothing pending" about a
+          // payload it did not understand.
+          return {
+            state: "unavailable",
+            reason:
+              "I asked, but I could not make sense of the answer, so I cannot say.",
+          };
+        }
+        return { state: "read", value: raw as T[] };
       };
 
       const sources: ButlerSources = {
@@ -400,6 +428,19 @@ export default function ButlerPage() {
     [exercises],
   );
 
+  // A section earns its heading when it has something to show, when it could
+  // not be checked, or while the answer is still unknown. Otherwise the
+  // headline has already said it.
+  const unread = (k: "facts" | "quarantine" | "permissions" | "exercises") =>
+    home !== null && home.unavailable.some((u) => u.source === k);
+  const showAsk =
+    !ready || ask !== undefined || home?.attention.state === "unavailable";
+  const showDone = !ready || did.length > 0 || unread("exercises");
+  const showNoticed = !ready || quarantine.length > 0 || unread("quarantine");
+  const memoryCompact = ready && facts.length === 0 && !unread("facts");
+  const permissionsCompact =
+    ready && permissions.length === 0 && !unread("permissions");
+
   return (
     <main className="butler">
       {/* One polite live region for the whole page. Assertive would interrupt
@@ -415,7 +456,12 @@ export default function ButlerPage() {
           three arms are not a ladder: "nothing is waiting for you" and "I could
           not find out whether anything is waiting for you" differ by exactly
           the thing the page is used to decide. */}
-      <p className="butlerStatus" role="status">
+      {/* Deliberately NOT a live region. `role="status"` carries implicit
+          polite semantics, so this headline would have become a SECOND
+          announcer beside `butlerAnnounce` — approving something would be read
+          out twice, once as the confirmation and once as the changed headline.
+          The page keeps exactly one announcer, on purpose. */}
+      <p className="butlerStatus">
         {!home
           ? "Looking…"
           : home.status.kind === "needs-you"
@@ -449,7 +495,9 @@ export default function ButlerPage() {
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
             {home.unavailable.map((u) => (
               <li key={u.source} className="butlerRow">
-                <p className="butlerRowText">{u.reason}</p>
+                <p className="butlerRowText">
+                  {SOURCE_IN_WORDS[u.source]}: {u.reason}
+                </p>
                 <p className="butlerMeta">
                   This is not the same as there being nothing.
                 </p>
@@ -459,82 +507,102 @@ export default function ButlerPage() {
         </section>
       )}
 
+      {/* Sections a calm page does not render at all.
+
+          The reset document's second complaint: with nothing pending, Butler
+          was five different renderings of "nothing here", and an empty section
+          cost a reader as much attention as an urgent one. A heading that only
+          ever says "Nothing right now." is not reassurance, it is a thing to
+          read before you can conclude there was nothing to read. The headline
+          above already answers it.
+
+          They come back the moment there is something to show — or something
+          that could not be checked, which is not the same as calm. */}
       {/* 1 ── The ask ────────────────────────────────────────────────── */}
-      <section className="butlerSection" aria-labelledby="butler-ask">
-        <h2 id="butler-ask">Something I need to ask you</h2>
-        {ask ? (
-          <div className="butlerRow">
-            <p className="butlerRowText">{ask.summary ?? ask.toolName}</p>
-            {/* "and not ask again about this one" was a promise nothing kept:
-                there is no suppression store, so rejecting removes the queue
-                entry and the next run asks again. Saying what actually
-                happens is worth more than a reassurance that turns out to be
-                false the first time the recipe runs on a schedule. */}
-            <p className="butlerMeta">
-              If you say yes, I will do this now. If you say no, I will leave it
-              alone this time.
-            </p>
-            <div className="butlerActions">
-              <button
-                type="button"
-                className="butlerButton butlerButtonPrimary butlerButtonFull"
-                onClick={() => void answerAsk(ask, "approve")}
-              >
-                Yes, go ahead
-              </button>
-              <button
-                type="button"
-                className="butlerButton butlerButtonFull"
-                onClick={() => void answerAsk(ask, "reject")}
-              >
-                No, leave it alone
-              </button>
+      {showAsk && (
+        <section className="butlerSection" aria-labelledby="butler-ask">
+          <h2 id="butler-ask">Something I need to ask you</h2>
+          {ask ? (
+            <div className="butlerRow">
+              <p className="butlerRowText">{ask.summary ?? ask.toolName}</p>
+              {/* "and not ask again about this one" was a promise nothing kept:
+                  there is no suppression store, so rejecting removes the queue
+                  entry and the next run asks again. Saying what actually
+                  happens is worth more than a reassurance that turns out to be
+                  false the first time the recipe runs on a schedule. */}
+              <p className="butlerMeta">
+                If you say yes, I will do this now. If you say no, I will leave it
+                alone this time.
+              </p>
+              <div className="butlerActions">
+                <button
+                  type="button"
+                  className="butlerButton butlerButtonPrimary butlerButtonFull"
+                  onClick={() => void answerAsk(ask, "approve")}
+                >
+                  Yes, go ahead
+                </button>
+                <button
+                  type="button"
+                  className="butlerButton butlerButtonFull"
+                  onClick={() => void answerAsk(ask, "reject")}
+                >
+                  No, leave it alone
+                </button>
+              </div>
             </div>
-          </div>
-        ) : (
-          <p className="butlerEmpty">
-            {!ready
-              ? "Looking…"
-              : home?.attention.state === "unavailable"
-                ? "I could not check this, so I cannot say."
-                : "Nothing right now."}
-          </p>
-        )}
-      </section>
+          ) : (
+            <p className="butlerEmpty">
+              {!ready
+                ? "Looking…"
+                : home?.attention.state === "unavailable"
+                  ? "I could not check this, so I cannot say."
+                  : "Nothing right now."}
+            </p>
+          )}
+        </section>
+      )}
 
       {/* 2 ── What Butler has done ────────────────────────────────────────── */}
-      <section className="butlerSection" aria-labelledby="butler-did">
-        <h2 id="butler-did">What I did without asking</h2>
-        {/* The only evidence Butler has that it DID anything. A completed
-            errand, a refusal, an approval acted on — none of those are
-            recorded anywhere this page can read, so none of them are claimed
-            here. See docs/butler-product-reset.md. */}
-        {did.length === 0 ? (
-          <p className="butlerEmpty">
-            {!ready
-              ? "Looking…"
-              : home?.permissions.actionsWithoutAsking.state === "unavailable"
-                ? "I could not check this, so I cannot say what I have done."
-                : "Nothing — I have asked you about everything."}
+      {showDone && (
+        <section className="butlerSection" aria-labelledby="butler-did">
+          <h2 id="butler-did">
+            Things I did because you&rsquo;d already said I could
+          </h2>
+          <p className="butlerMeta">
+            This only covers permissions you gave me in advance.
           </p>
-        ) : (
-          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-            {did.map((e) => (
-              <li key={`${e.permissionId}-${e.at}`} className="butlerRow">
-                <p className="butlerRowText">
-                  {e.toolName}
-                  {e.recipeName ? ` (${e.recipeName})` : ""}
-                </p>
-                {/* The receipt the standing permission owes the reader. */}
-                <p className="butlerMeta">
-                  I did this without asking, because you allowed it.{" "}
-                  {whenInWords(e.at)}.
-                </p>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+          {/* The only evidence Butler has that it DID anything. A completed
+              errand, a refusal, an approval acted on — none of those are
+              recorded anywhere this page can read, so none of them are claimed
+              here. See docs/butler-product-reset.md. */}
+          {did.length === 0 ? (
+            <p className="butlerEmpty">
+              {!ready
+                ? "Looking…"
+                : home?.permissions.actionsWithoutAsking.state === "unavailable"
+                  ? "I could not check this, so I cannot say what I have done."
+                  : "No actions are recorded here yet."}
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+              {did.map((e) => (
+                <li key={`${e.permissionId}-${e.at}`} className="butlerRow">
+                  <p className="butlerRowText">
+                    {e.toolName}
+                    {e.recipeName ? ` (${e.recipeName})` : ""}
+                  </p>
+                  {/* The receipt the standing permission owes the reader. */}
+                  <p className="butlerMeta">
+                    I did this without asking, because you allowed it.{" "}
+                    {whenInWords(e.at)}.
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
 
       {/* 3 ── What Butler knows ──────────────────────────────────────── */}
       <section className="butlerSection" aria-labelledby="butler-knows">
@@ -561,7 +629,9 @@ export default function ButlerPage() {
               ? "Looking…"
               : home?.memory.established.state === "unavailable"
                 ? "I could not check this, so I cannot say what I know."
-                : "Nothing yet."}
+                : memoryCompact
+                  ? "Nothing yet. Tell me something and I will remember it."
+                  : "Nothing yet."}
           </p>
         ) : (
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
@@ -598,47 +668,49 @@ export default function ButlerPage() {
       </section>
 
       {/* 4 ── Seen, not acted on ─────────────────────────────────────── */}
-      <section className="butlerSection" aria-labelledby="butler-seen">
-        <h2 id="butler-seen">Things I noticed but have not used</h2>
-        <p className="butlerMeta">
-          I only guessed at these. I will not act on any of them unless you tell
-          me they are right.
-        </p>
-        {quarantine.length === 0 ? (
-          <p className="butlerEmpty">
-            {!ready
-              ? "Looking…"
-              : home?.memory.awaitingConfirmation.state === "unavailable"
-                ? "I could not check this, so I cannot say."
-                : "Nothing here."}
+      {showNoticed && (
+        <section className="butlerSection" aria-labelledby="butler-seen">
+          <h2 id="butler-seen">Things I noticed but have not used</h2>
+          <p className="butlerMeta">
+            I only guessed at these. I will not act on any of them unless you tell
+            me they are right.
           </p>
-        ) : (
-          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-            {quarantine.map((f) => (
-              <li key={f.seq} className="butlerRow">
-                <p className="butlerRowText">{factInWords(f)}</p>
-                <p className="butlerMeta">{sourceInWords(f)}</p>
-                <div className="butlerActions">
-                  <button
-                    type="button"
-                    className="butlerButton butlerButtonPrimary"
-                    onClick={() => void promoteFact(f)}
-                  >
-                    Yes, remember this about me
-                  </button>
-                  <button
-                    type="button"
-                    className="butlerButton"
-                    onClick={() => void removeFact(f)}
-                  >
-                    No, forget you saw it
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+          {quarantine.length === 0 ? (
+            <p className="butlerEmpty">
+              {!ready
+                ? "Looking…"
+                : home?.memory.awaitingConfirmation.state === "unavailable"
+                  ? "I could not check this, so I cannot say."
+                  : "Nothing here."}
+            </p>
+          ) : (
+            <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+              {quarantine.map((f) => (
+                <li key={f.seq} className="butlerRow">
+                  <p className="butlerRowText">{factInWords(f)}</p>
+                  <p className="butlerMeta">{sourceInWords(f)}</p>
+                  <div className="butlerActions">
+                    <button
+                      type="button"
+                      className="butlerButton butlerButtonPrimary"
+                      onClick={() => void promoteFact(f)}
+                    >
+                      Yes, remember this about me
+                    </button>
+                    <button
+                      type="button"
+                      className="butlerButton"
+                      onClick={() => void removeFact(f)}
+                    >
+                      No, forget you saw it
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
 
       {/* 5 ── Standing permissions ───────────────────────────────────── */}
       <section className="butlerSection" aria-labelledby="butler-allowed">
@@ -649,7 +721,9 @@ export default function ButlerPage() {
               ? "Looking…"
               : home?.permissions.active.state === "unavailable"
                 ? "I could not check what you have allowed, so I cannot say."
-                : "Nothing. I ask you about everything."}
+                : permissionsCompact
+                  ? "Nothing yet — I ask you about everything."
+                  : "Nothing. I ask you about everything."}
           </p>
         ) : (
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>

--- a/dashboard/src/app/butler/page.tsx
+++ b/dashboard/src/app/butler/page.tsx
@@ -34,51 +34,22 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { apiPath } from "@/lib/api";
 import "./butler.css";
+// The endpoint shapes live in `homeState.ts` and are imported, not restated.
+// Two declarations of the same payload is how a page and its model come to
+// disagree about what the server sends — silently, and in the direction
+// nobody tests.
+import {
+  type ButlerFact,
+  type ButlerHomeState,
+  type ButlerSources,
+  type PendingApproval as Pending,
+  type PermissionExercise,
+  type SourceState,
+  type StandingPermission,
+  mapButlerHome,
+} from "./homeState";
 
 // ─────────────────────────────────────────────────────────────── types
-
-interface ButlerFact {
-  seq: number;
-  subject: string;
-  predicate: string;
-  object: string;
-  recordedAt: number;
-  trust: number;
-  provenance: {
-    channel: string;
-    source?: string;
-    validated: boolean;
-  };
-}
-
-interface StandingPermission {
-  id: string;
-  grantedAt: number;
-  grantedBy: string | null;
-  scope: { domains: string[] };
-  ceiling?: { magnitudeBand?: string; perDay?: number };
-  expiresAt?: number;
-  revokedAt?: number;
-  note?: string;
-  active: boolean;
-}
-
-interface PermissionExercise {
-  permissionId: string;
-  at: number;
-  toolName: string;
-  classKey: string;
-  workerId?: string;
-  recipeName?: string;
-}
-
-interface Pending {
-  callId: string;
-  toolName: string;
-  tier: "low" | "medium" | "high";
-  requestedAt: number;
-  summary?: string;
-}
 
 /** An undo the user can still take. Kept until used — never expires. */
 interface UndoOffer {
@@ -165,6 +136,9 @@ async function getJson(path: string): Promise<Record<string, unknown>> {
   return (await res.json()) as Record<string, unknown>;
 }
 
+/** The five surfaces Home reads. Named so a total blackout is countable. */
+const SOURCE_COUNT = 5;
+
 // ─────────────────────────────────────────────────────────────── page
 
 export default function ButlerPage() {
@@ -175,6 +149,7 @@ export default function ButlerPage() {
   const [asks, setAsks] = useState<Pending[]>([]);
   const [announcement, setAnnounce] = useState("");
   const [undos, setUndos] = useState<UndoOffer[]>([]);
+  const [home, setHome] = useState<ButlerHomeState | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
 
@@ -196,24 +171,77 @@ export default function ButlerPage() {
       // succeeded, the shape guards fell through to `[]`, and the page said
       // "Nothing yet." — confidently, about a bridge it never reached. Only a
       // network-level rejection ever reached the catch. Check the status.
-      const [f, q, p, e, a] = await Promise.all([
+      // Per source, NOT `Promise.all`. All-or-nothing discarded four healthy
+      // sources whenever one failed, collapsing five independent
+      // availabilities into a single boolean — safe, but it threw away
+      // everything Butler could still honestly say. `mapButlerHome` keeps each
+      // one's outcome separate; a failure can never arrive here as an empty
+      // list.
+      const [f, q, p, e, a] = await Promise.allSettled([
         getJson("/api/bridge/butler/facts"),
         getJson("/api/bridge/butler/quarantine"),
         getJson("/api/bridge/butler/permissions"),
         getJson("/api/bridge/butler/permissions/exercises"),
         getJson("/api/bridge/approvals"),
       ]);
-      setFacts(Array.isArray(f?.facts) ? f.facts : []);
-      setQuarantine(Array.isArray(q?.facts) ? q.facts : []);
-      setPermissions(Array.isArray(p?.permissions) ? p.permissions : []);
-      setExercises(Array.isArray(e?.exercises) ? e.exercises : []);
+      const listFrom = <T,>(
+        r: PromiseSettledResult<Record<string, unknown>>,
+        key: string,
+      ): SourceState<T[]> => {
+        if (r.status === "rejected") {
+          const m =
+            r.reason instanceof Error ? r.reason.message : String(r.reason);
+          return {
+            state: "unavailable",
+            reason: /^[A-Z].*[.?]$/.test(m)
+              ? m
+              : "I could not reach the bridge for this.",
+          };
+        }
+        const body = r.value;
+        // A bare array is the /approvals shape; everything else wraps.
+        const raw = key === "" ? body : (body as Record<string, unknown>)[key];
+        return { state: "read", value: (Array.isArray(raw) ? raw : []) as T[] };
+      };
+
+      const sources: ButlerSources = {
+        facts: listFrom(f, "facts"),
+        quarantine: listFrom(q, "facts"),
+        permissions: listFrom(p, "permissions"),
+        exercises: listFrom(e, "exercises"),
+        approvals: listFrom(a, ""),
+      };
+      const state = mapButlerHome(sources);
+      setHome(state);
+      // A TOTAL blackout is a page-level alert; a partial one is a note beside
+      // the sources it affects. Both were previously the same thing, because
+      // one failure took the whole page down. Keeping the alert for the total
+      // case preserves the guarantee that a dead bridge never renders as
+      // "Butler knows nothing about you" — the reader is interrupted only when
+      // there is genuinely nothing else on the page to read.
+      setLoadError(
+        state.unavailable.length === SOURCE_COUNT
+          ? (state.unavailable[0]?.reason ??
+              "I could not reach the bridge, so I cannot show you anything right now.")
+          : null,
+      );
+
+      setFacts(sources.facts.state === "read" ? sources.facts.value : []);
+      setQuarantine(
+        sources.quarantine.state === "read" ? sources.quarantine.value : [],
+      );
+      setPermissions(
+        sources.permissions.state === "read" ? sources.permissions.value : [],
+      );
+      setExercises(
+        sources.exercises.state === "read" ? sources.exercises.value : [],
+      );
       // GET /approvals returns a BARE ARRAY (src/approvalHttp.ts) — there is
       // no `pending` wrapper. Reading `.pending` off an array is undefined, so
       // this section rendered "Nothing right now." no matter how many
       // approvals were queued. The canonical /approvals page casts the body to
       // an array directly; this now agrees with the server and with it.
-      setAsks(Array.isArray(a) ? a : []);
-      setLoadError(null);
+      setAsks(sources.approvals.state === "read" ? sources.approvals.value : []);
     } catch (err) {
       // Say so. A page that silently renders "Butler knows nothing about you"
       // when the truth is "I could not reach the bridge" is worse than an
@@ -383,6 +411,22 @@ export default function ButlerPage() {
 
       <h1>Butler</h1>
 
+      {/* Status first, because it is the one thing a reader came for. The
+          three arms are not a ladder: "nothing is waiting for you" and "I could
+          not find out whether anything is waiting for you" differ by exactly
+          the thing the page is used to decide. */}
+      <p className="butlerStatus" role="status">
+        {!home
+          ? "Looking…"
+          : home.status.kind === "needs-you"
+            ? home.status.count === 1
+              ? "One thing is waiting for your decision."
+              : `${home.status.count} things are waiting for your decision.`
+            : home.status.kind === "caught-up"
+              ? "Nothing is waiting for your decision."
+              : "I could not find out whether anything is waiting for you."}
+      </p>
+
       {/* The reason is shown, not just the reassurance. The bridge answers 501
           when it cannot read the permission store, with an explicit comment
           that this must not read as "you have granted nothing" — a fixed
@@ -392,6 +436,27 @@ export default function ButlerPage() {
         <p className="butlerRowText" role="alert">
           {loadError} This is not the same as knowing nothing about you.
         </p>
+      )}
+
+      {/* What could not be checked, carried WHOLE and named source by source.
+          Placed before anything it might undermine: a reader who has already
+          read three sections should not discover afterwards that a fourth was
+          never consulted. Absent entirely when everything was read, so a
+          healthy page carries no apology. */}
+      {home && home.unavailable.length > 0 && !loadError && (
+        <section className="butlerSection" aria-labelledby="butler-unchecked">
+          <h2 id="butler-unchecked">What I could not check</h2>
+          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+            {home.unavailable.map((u) => (
+              <li key={u.source} className="butlerRow">
+                <p className="butlerRowText">{u.reason}</p>
+                <p className="butlerMeta">
+                  This is not the same as there being nothing.
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
 
       {/* 1 ── The ask ────────────────────────────────────────────────── */}
@@ -428,17 +493,75 @@ export default function ButlerPage() {
           </div>
         ) : (
           <p className="butlerEmpty">
-            {ready ? "Nothing right now." : "Looking…"}
+            {!ready
+              ? "Looking…"
+              : home?.attention.state === "unavailable"
+                ? "I could not check this, so I cannot say."
+                : "Nothing right now."}
           </p>
         )}
       </section>
 
-      {/* 2 ── What Butler knows ──────────────────────────────────────── */}
+      {/* 2 ── What Butler has done ────────────────────────────────────────── */}
+      <section className="butlerSection" aria-labelledby="butler-did">
+        <h2 id="butler-did">What I did without asking</h2>
+        {/* The only evidence Butler has that it DID anything. A completed
+            errand, a refusal, an approval acted on — none of those are
+            recorded anywhere this page can read, so none of them are claimed
+            here. See docs/butler-product-reset.md. */}
+        {did.length === 0 ? (
+          <p className="butlerEmpty">
+            {!ready
+              ? "Looking…"
+              : home?.permissions.actionsWithoutAsking.state === "unavailable"
+                ? "I could not check this, so I cannot say what I have done."
+                : "Nothing — I have asked you about everything."}
+          </p>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+            {did.map((e) => (
+              <li key={`${e.permissionId}-${e.at}`} className="butlerRow">
+                <p className="butlerRowText">
+                  {e.toolName}
+                  {e.recipeName ? ` (${e.recipeName})` : ""}
+                </p>
+                {/* The receipt the standing permission owes the reader. */}
+                <p className="butlerMeta">
+                  I did this without asking, because you allowed it.{" "}
+                  {whenInWords(e.at)}.
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* 3 ── What Butler knows ──────────────────────────────────────── */}
       <section className="butlerSection" aria-labelledby="butler-knows">
         <h2 id="butler-knows">What I know about you</h2>
+        {/* The count is the summary; the list is the detail. Stated in words
+            because "6" alone does not say which population it counts, and the
+            two populations differ by whether Butler may act on them. */}
+        {home?.memory.established.state === "read" && (
+          <p className="butlerMeta">
+            {home.memory.established.value === 0
+              ? "Nothing I act on yet."
+              : `${home.memory.established.value} ${
+                  home.memory.established.value === 1 ? "thing" : "things"
+                } I use.`}
+            {home.memory.awaitingConfirmation.state === "read" &&
+            home.memory.awaitingConfirmation.value > 0
+              ? ` ${home.memory.awaitingConfirmation.value} waiting for you to confirm.`
+              : ""}
+          </p>
+        )}
         {facts.length === 0 ? (
           <p className="butlerEmpty">
-            {ready ? "Nothing yet." : "Looking…"}
+            {!ready
+              ? "Looking…"
+              : home?.memory.established.state === "unavailable"
+                ? "I could not check this, so I cannot say what I know."
+                : "Nothing yet."}
           </p>
         ) : (
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
@@ -474,7 +597,7 @@ export default function ButlerPage() {
         )}
       </section>
 
-      {/* 3 ── Seen, not acted on ─────────────────────────────────────── */}
+      {/* 4 ── Seen, not acted on ─────────────────────────────────────── */}
       <section className="butlerSection" aria-labelledby="butler-seen">
         <h2 id="butler-seen">Things I noticed but have not used</h2>
         <p className="butlerMeta">
@@ -482,7 +605,13 @@ export default function ButlerPage() {
           me they are right.
         </p>
         {quarantine.length === 0 ? (
-          <p className="butlerEmpty">{ready ? "Nothing here." : "Looking…"}</p>
+          <p className="butlerEmpty">
+            {!ready
+              ? "Looking…"
+              : home?.memory.awaitingConfirmation.state === "unavailable"
+                ? "I could not check this, so I cannot say."
+                : "Nothing here."}
+          </p>
         ) : (
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
             {quarantine.map((f) => (
@@ -511,40 +640,16 @@ export default function ButlerPage() {
         )}
       </section>
 
-      {/* 4 ── What Butler did ────────────────────────────────────────── */}
-      <section className="butlerSection" aria-labelledby="butler-did">
-        <h2 id="butler-did">What I did without asking</h2>
-        {did.length === 0 ? (
-          <p className="butlerEmpty">
-            {ready ? "Nothing — I have asked you about everything." : "Looking…"}
-          </p>
-        ) : (
-          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-            {did.map((e) => (
-              <li key={`${e.permissionId}-${e.at}`} className="butlerRow">
-                <p className="butlerRowText">
-                  {e.toolName}
-                  {e.recipeName ? ` (${e.recipeName})` : ""}
-                </p>
-                {/* The receipt the standing permission owes the reader. */}
-                <p className="butlerMeta">
-                  I did this without asking, because you allowed it.{" "}
-                  {whenInWords(e.at)}.
-                </p>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
       {/* 5 ── Standing permissions ───────────────────────────────────── */}
       <section className="butlerSection" aria-labelledby="butler-allowed">
         <h2 id="butler-allowed">What you have allowed</h2>
         {permissions.length === 0 ? (
           <p className="butlerEmpty">
-            {ready
-              ? "Nothing. I ask you about everything."
-              : "Looking…"}
+            {!ready
+              ? "Looking…"
+              : home?.permissions.active.state === "unavailable"
+                ? "I could not check what you have allowed, so I cannot say."
+                : "Nothing. I ask you about everything."}
           </p>
         ) : (
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,14 +50,19 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- **`feat/butler-home`** — Butler Home redesign against the view-model landed in
-  #1568. **Rewrites `dashboard/src/app/butler/page.tsx`** and replaces the
-  five-heading section-order test with outcome assertions (rationale:
-  `docs/butler-product-reset.md`). Renders ONLY evidence-backed claims — no
-  sixth source, no fabricated timeline. Do not edit that page in parallel.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-09-01 `feat/butler-home` — Butler Home against the #1568 view-model. Status line
+  first with `cannot-tell` as its own arm; per-source loading, so one dead endpoint no
+  longer discards four healthy ones; every empty state separates "there is nothing" from
+  "I could not check". Action evidence moved above memory. The five endpoint shapes are now
+  imported from the view-model rather than restated — the two copies had ALREADY diverged
+  (`StandingPermission.grantedBy`). Section-order test replaced by outcome assertions, its
+  screen-reader intent preserved. "What Butler has done" remains only the standing-permission
+  subset; no sixth source.
 
 - 2026-09-01 `feat/butler-view-model` — Butler Home view-model (#1568). Types + a pure
   mapping over the five surfaces the page already reads. Two findings rather than a

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- **`feat/butler-home`** — Butler Home redesign against the view-model landed in
+  #1568. **Rewrites `dashboard/src/app/butler/page.tsx`** and replaces the
+  five-heading section-order test with outcome assertions (rationale:
+  `docs/butler-product-reset.md`). Renders ONLY evidence-backed claims — no
+  sixth source, no fabricated timeline. Do not edit that page in parallel.
 
 
 ## Recently closed (informal log, prune periodically)


### PR DESCRIPTION
Step 3 of the Butler product reset ([#1567](https://github.com/Oolab-labs/patchwork-os/pull/1567)),
built on the view-model from [#1568](https://github.com/Oolab-labs/patchwork-os/pull/1568).

## Acceptance

> **Urgent truth appears first; unavailable never becomes empty; action evidence
> appears before passive memory; and Butler says no more than its existing
> sources can prove.**

## Three findings — this is not a visual rewrite

### 1. Partial failure is now representable

The page loaded all five surfaces with `Promise.all`, so **one unreadable
endpoint discarded four healthy ones** and the whole screen became a single
error. Safe, and it still threw away everything Butler could honestly say — five
independent availabilities collapsed into one boolean.

Loading is now per source. A **total** blackout is still a page-level alert; a
**partial** one is a named note beside the sources it affects, placed ahead of
anything it would undermine — a reader who has taken in three sections must not
discover afterwards that a fourth was never consulted.

### 2. The existing failure tests shaped the design

Three tests failed mid-way through this work. They encode two real production
bugs: a 502 whose **body parsed as valid JSON**, so the page rendered "Nothing
yet." about a bridge it never reached; and a 501 for an unreadable permission
store, which must never read as "you have granted nothing".

They were treated as **product guarantees, not obstacles.** Rather than rewrite
them to match the new architecture, the page-level alert was restored for the
total-blackout case. Neither the guarantee nor its wording moved.

### 3. The redesign exposed real type drift

Having the page consume the view-model's types instead of its own immediately
found that the two `StandingPermission` declarations **had already diverged** —
the page's required `grantedBy`, the model's did not. Two declarations of one
payload is how a page and its model come to disagree about what the server
sends, silently, in the direction nobody tests. The five endpoint shapes are now
imported, not restated.

## The bug the behavioural tests caught

A stale `setLoadError(null)`, left over from the old all-or-nothing load,
silently overwrote the new per-source error state. The architecture was right,
the mapper compiled, the types checked — and the page would have shipped
rendering an all-clear over a dead bridge.

It was caught because the three unreachable-bridge tests were still red, not
because anything checked whether the new code compiled. **Another instance of
the PATH lesson**: the intended design was correct and a small piece of existing
state handling silently defeated it, and only a test asserting the *product's
claim* rather than the code's shape could see it.

## What Home now renders

- **Status first**, in three arms that are not a ladder. "Nothing is waiting for
  your decision" and "I could not find out whether anything is waiting for you"
  differ by exactly the thing the page is used to decide.
- **Needs you**, then **what Butler has done**, then memory, quarantine and
  permissions. Action evidence moved above memory because a decision and a
  report of action are what a person opens this page for; memory is reference
  material.
- **Every empty state separates** "there is nothing" from "I could not check".
- **No apology on a healthy page** — the unavailable section is absent entirely
  when all five sources were read.

## Deliberate limitation, stated plainly

**"What Butler has done" is still only the subset evidenced by
standing-permission exercises. It is not a complete Butler history.** No
completed errand, refusal, or acted-on approval is recorded anywhere this page
can read (#1568). The design sketch's "checked your errands — nothing needed
changing" remains unrenderable, and is not faked here. Whether that gap deserves
a new runtime contract is a decision to make *after* using Home without one.

No sixth source. No fabricated timeline. No composer.

## The section-order test: replaced, not deleted

It listed five literal headings in sequence, and its own comment said why: **DOM
order is reading order**. That intent survives as four outcome assertions — a
decision precedes anything passive, an unreadable source precedes what it
undermines, the headline states the answer before the page is scrolled, and an
all-clear renders no apology.

**Mutation-checked** by moving the ask to the end of the page, which fails it.

## Verification

67 tests pass (3 files), dashboard typecheck clean, Biome clean,
`audit-in-flight` and `audit-business-content` green. Accessibility invariants
untouched: single column, DOM order, no hover-only controls, nothing carried by
colour alone — the new status line is deliberately **not** colour-coded, since
its three states must survive greyscale, a screen reader and print.
