### PR TITLE
feat(butler): a headline, two reference areas, and headings you can read

### DIFF
--- a/dashboard/src/app/butler/__tests__/butler-a11y.test.ts
+++ b/dashboard/src/app/butler/__tests__/butler-a11y.test.ts
@@ -411,3 +411,26 @@ describe("theme", () => {
     expect(CSS).toMatch(/:root\[data-theme="dark"\] \.butler/);
   });
 });
+
+describe("headings take Butler's own palette, not the shell's", () => {
+  /**
+   * A regression for a bug the whole suite was blind to.
+   *
+   * `.butler h1/h2` declared no colour and INHERITED — and inheritance loses to
+   * any direct rule, so the dashboard shell's `h1, h2 { color: … }` won. In
+   * dark theme the shell's near-white happened to match Butler's foreground and
+   * nothing looked wrong. In light theme the headings computed to
+   * rgb(246,247,248) on a white page: "Butler" and every section heading,
+   * invisible, on the page a first-time user lands on.
+   *
+   * Every contrast assertion in this file passed throughout, because they check
+   * the ratios of Butler's OWN tokens and those were always correct. What was
+   * wrong was which palette reached the element — which a stylesheet-parsing
+   * test cannot see unless it asks whether the rule exists at all.
+   */
+  it("declares a colour for headings rather than inheriting one", () => {
+    const block = blockFor(".butler h1,\n.butler h2,\n.butler h3");
+    expect(block, "no heading colour rule found").toBeTruthy();
+    expect(block).toMatch(/color:\s*var\(--lp-fg\)/);
+  });
+});

--- a/dashboard/src/app/butler/butler.css
+++ b/dashboard/src/app/butler/butler.css
@@ -317,3 +317,97 @@
   margin: 0 0 1.4rem;
   max-width: 34ch;
 }
+
+/* ── Home as a front door rather than a document ───────────────────────────
+ *
+ * The page was capped at 46rem and gave every section the same weight, which
+ * is what made it read as a policy document however honest its words were.
+ * Two changes, and neither of them is colour:
+ *
+ *   - the HEADLINE is unmistakably first, by size and by the space around it;
+ *   - the two reference areas sit side by side when there is room, so they
+ *     read as somewhere to look things up rather than as more of the report.
+ *
+ * PROSE stays at a comfortable measure regardless of how wide the page gets.
+ * Widening the container is not permission to widen a line of text: ~66
+ * characters is the readable limit, and a governance page whose sentences run
+ * the width of a monitor is harder to read, not more spacious.
+ */
+.butler {
+  max-width: 72rem;
+}
+
+/* Every block of prose keeps its measure even in a wide column. */
+.butlerRowText,
+.butlerMeta,
+.butlerEmpty,
+.butlerPromise {
+  max-width: 62ch;
+}
+
+.butlerStatus {
+  font-size: 1.75em;
+  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0.15em 0 2.2rem;
+  max-width: 22ch;
+}
+
+/* The promise is not the last line of the list above it. */
+.butlerPromise {
+  margin-top: 1.5rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid currentColor;
+  opacity: 0.85;
+  font-size: 0.95em;
+}
+
+/* Memory and Permissions: a pair when there is room, sequential always. */
+.butlerReference {
+  display: grid;
+  gap: 0 2.5rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 62rem) {
+  .butlerReference {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+  /* Anything that is not one of the pair runs the full width. */
+  .butlerReference > .butlerSpan {
+    grid-column: 1 / -1;
+  }
+}
+
+/* A wider PAGE is not a wider control.
+ *
+ * The decision card and its two buttons are the most important thing on the
+ * page, and stretching them to the full width made them harder to use, not
+ * more prominent — a button the width of a monitor reads as a banner. The
+ * top-level sections keep a comfortable column; only the reference pair below
+ * uses the extra width, which is what it is for.
+ */
+.butler > .butlerSection {
+  max-width: 48rem;
+}
+
+/* Headings take Butler's OWN foreground, explicitly.
+ *
+ * They set no colour and inherited — and inheritance loses to any direct rule,
+ * so a shell rule for `h1, h2` won instead. In dark theme its near-white
+ * happened to match and nothing looked wrong; in light theme the headings
+ * computed to rgb(246,247,248) on a white page and were invisible. "Butler",
+ * "Something I need to ask you" and every other heading, unreadable, on the
+ * page a first-time user lands on.
+ *
+ * Found by rendering the light theme and reading the computed colour, not by
+ * any test: the accessibility suite checks this page's own palette, and its own
+ * palette was always right. What was wrong was which palette applied.
+ */
+.butler h1,
+.butler h2,
+.butler h3 {
+  color: var(--lp-fg);
+}

--- a/dashboard/src/app/butler/page.tsx
+++ b/dashboard/src/app/butler/page.tsx
@@ -136,6 +136,34 @@ async function getJson(path: string): Promise<Record<string, unknown>> {
   return (await res.json()) as Record<string, unknown>;
 }
 
+/**
+ * Tool ids in the reader's words.
+ *
+ * Small and explicit, NOT derived. A rule that split `vendor.verb_object` and
+ * reassembled it would read most ids acceptably and some as nonsense, and the
+ * nonsense would appear on the page that reports what Butler did to somebody's
+ * accounts. Every entry below was checked against a registered tool id; an
+ * unknown id falls back to ITSELF rather than to a guess, because a raw
+ * identifier is honest and an invented sentence is not.
+ *
+ * There are hundreds of tools and this covers the few a standing permission
+ * realistically exercises. It is meant to stay short.
+ */
+const TOOL_IN_WORDS: Record<string, string> = {
+  "todoist.create_task": "Added a task in Todoist",
+  "asana.create_task": "Added a task in Asana",
+  "asana.complete_task": "Completed a task in Asana",
+  "asana.add_task_comment": "Commented on a task in Asana",
+  "github.create_issue": "Opened an issue on GitHub",
+  "discord.send_message": "Sent a message on Discord",
+  "gmail.send": "Sent an email",
+  "airtable.create_record": "Added a record in Airtable",
+};
+
+function toolInWords(id: string): string {
+  return TOOL_IN_WORDS[id] ?? id;
+}
+
 /** The five surfaces Home reads. Named so a total blackout is countable. */
 const SOURCE_COUNT = 5;
 
@@ -589,7 +617,7 @@ export default function ButlerPage() {
               {did.map((e) => (
                 <li key={`${e.permissionId}-${e.at}`} className="butlerRow">
                   <p className="butlerRowText">
-                    {e.toolName}
+                    {toolInWords(e.toolName)}
                     {e.recipeName ? ` (${e.recipeName})` : ""}
                   </p>
                   {/* The receipt the standing permission owes the reader. */}
@@ -604,13 +632,17 @@ export default function ButlerPage() {
         </section>
       )}
 
+      {/* Memory and Permissions are the two reference areas. Side by side when
+          there is room, sequential in the DOM and stacked when there is not —
+          the reading order never changes. */}
+      <div className="butlerReference">
       {/* 3 ── What Butler knows ──────────────────────────────────────── */}
       <section className="butlerSection" aria-labelledby="butler-knows">
         <h2 id="butler-knows">What I know about you</h2>
         {/* The count is the summary; the list is the detail. Stated in words
             because "6" alone does not say which population it counts, and the
             two populations differ by whether Butler may act on them. */}
-        {home?.memory.established.state === "read" && (
+        {home?.memory.established.state === "read" && !memoryCompact && (
           <p className="butlerMeta">
             {home.memory.established.value === 0
               ? "Nothing I act on yet."
@@ -667,9 +699,61 @@ export default function ButlerPage() {
         )}
       </section>
 
-      {/* 4 ── Seen, not acted on ─────────────────────────────────────── */}
+      {/* 4 ── Standing permissions ───────────────────────────────────── */}
+      <section className="butlerSection" aria-labelledby="butler-allowed">
+        <h2 id="butler-allowed">What you have allowed</h2>
+        {permissions.length === 0 ? (
+          <p className="butlerEmpty">
+            {!ready
+              ? "Looking…"
+              : home?.permissions.active.state === "unavailable"
+                ? "I could not check what you have allowed, so I cannot say."
+                : permissionsCompact
+                  ? "Nothing yet — I ask you about everything."
+                  : "Nothing. I ask you about everything."}
+          </p>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+            {permissions.map((p) => (
+              <li key={p.id} className="butlerRow">
+                <p className="butlerRowText">{permissionInWords(p)}</p>
+                {/* Live-or-not in words. A struck-through row or a grey tint
+                    would carry this in styling alone. */}
+                <p className="butlerMeta">
+                  {p.active
+                    ? `In force since ${whenInWords(p.grantedAt)}.`
+                    : `You took this back on ${whenInWords(p.revokedAt ?? p.grantedAt)}. I am keeping the record.`}
+                </p>
+                {p.active && (
+                  <div className="butlerActions">
+                    <button
+                      type="button"
+                      className="butlerButton"
+                      onClick={() => void revokePermission(p)}
+                    >
+                      Take this back
+                    </button>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        {/* A promise about what Butler will NEVER do, not a description of the
+            list above it — so it is separated rather than reading as the last
+            line of an empty state. */}
+        <p className="butlerPromise">
+          I will never do something you cannot undo without asking you first,
+          whatever you have allowed here.
+        </p>
+      </section>
+
+      {/* 5 ── Seen, not acted on ─────────────────────────────────────── */}
       {showNoticed && (
-        <section className="butlerSection" aria-labelledby="butler-seen">
+        <section
+          className="butlerSection butlerSpan"
+          aria-labelledby="butler-seen"
+        >
           <h2 id="butler-seen">Things I noticed but have not used</h2>
           <p className="butlerMeta">
             I only guessed at these. I will not act on any of them unless you tell
@@ -712,51 +796,7 @@ export default function ButlerPage() {
         </section>
       )}
 
-      {/* 5 ── Standing permissions ───────────────────────────────────── */}
-      <section className="butlerSection" aria-labelledby="butler-allowed">
-        <h2 id="butler-allowed">What you have allowed</h2>
-        {permissions.length === 0 ? (
-          <p className="butlerEmpty">
-            {!ready
-              ? "Looking…"
-              : home?.permissions.active.state === "unavailable"
-                ? "I could not check what you have allowed, so I cannot say."
-                : permissionsCompact
-                  ? "Nothing yet — I ask you about everything."
-                  : "Nothing. I ask you about everything."}
-          </p>
-        ) : (
-          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-            {permissions.map((p) => (
-              <li key={p.id} className="butlerRow">
-                <p className="butlerRowText">{permissionInWords(p)}</p>
-                {/* Live-or-not in words. A struck-through row or a grey tint
-                    would carry this in styling alone. */}
-                <p className="butlerMeta">
-                  {p.active
-                    ? `In force since ${whenInWords(p.grantedAt)}.`
-                    : `You took this back on ${whenInWords(p.revokedAt ?? p.grantedAt)}. I am keeping the record.`}
-                </p>
-                {p.active && (
-                  <div className="butlerActions">
-                    <button
-                      type="button"
-                      className="butlerButton"
-                      onClick={() => void revokePermission(p)}
-                    >
-                      Take this back
-                    </button>
-                  </div>
-                )}
-              </li>
-            ))}
-          </ul>
-        )}
-        <p className="butlerMeta">
-          I will never do something you cannot undo without asking you first,
-          whatever you have allowed here.
-        </p>
-      </section>
+      </div>
 
       {/* Undo ─────────────────────────────────────────────────────────
           Last in DOM order because it is a consequence of the sections above,

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- **`feat/butler-home-visual`** — Butler Home presentation only: visual hierarchy,
+  layout and two rendering defects found in the post-merge rendered pass. Touches
+  `dashboard/src/app/butler/{page.tsx,butler.css}` and its tests. **No data-model
+  change**, and fact phrasing (`You — predicate: object`) is deliberately LEFT for
+  `feat/butler-memory` — that is product semantics, not styling.
 
 
 ## Recently closed (informal log, prune periodically)

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,14 +50,19 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- **`feat/butler-home-visual`** — Butler Home presentation only: visual hierarchy,
-  layout and two rendering defects found in the post-merge rendered pass. Touches
-  `dashboard/src/app/butler/{page.tsx,butler.css}` and its tests. **No data-model
-  change**, and fact phrasing (`You — predicate: object`) is deliberately LEFT for
-  `feat/butler-memory` — that is product semantics, not styling.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-09-01 `feat/butler-home-visual` — Butler Home presentation. Headline hierarchy,
+  Memory/Permissions as a pair on wide screens, tool ids in words from a verified map with
+  the raw id as the honest fallback, and the two duplicate-empty-message defects. Found by
+  rendering rather than by any test: **light-theme headings were near-white on white** —
+  they inherited, and inheritance loses to the shell's `h1, h2` rule, so dark theme
+  matched by coincidence. Every contrast assertion passed throughout because Butler's own
+  tokens were always correct; what was wrong was which palette reached the element. Fact
+  phrasing left for `feat/butler-memory`.
 
 - 2026-09-01 `feat/butler-home` — Butler Home against the #1568 view-model. Status line
   first with `cannot-tell` as its own arm; per-source loading, so one dead endpoint no


### PR DESCRIPTION
Presentation only, from the rendered acceptance pass on merged #1569. **No
data-model change**, and the fact phrasing (`You — predicate: object`) is
deliberately left for `feat/butler-memory` — turning predicates into language is
product semantics, not styling.

## The bug this branch exists to have found

**Light theme was broken, and no test could see it.**

`.butler h1/h2` declared no colour and *inherited* — and inheritance loses to any
direct rule, so the dashboard shell's `h1, h2 { color: … }` won. In dark theme
the shell's near-white matched Butler's foreground by coincidence and nothing
looked wrong. In light theme the headings computed to **`rgb(246,247,248)` on a
white page**: "Butler", "Something I need to ask you" and every other heading,
invisible, on the page a first-time user lands on.

Every contrast assertion in `butler-a11y.test.ts` passed throughout — they check
the ratios of Butler's **own** tokens, and those were always correct. What was
wrong was *which palette reached the element*, which a stylesheet-parsing test
cannot see unless it asks whether the rule exists at all. It now does, and is
mutation-checked.

Found by rendering the light theme and reading the computed colour.

## What changed

- **The headline is unmistakably first** — by size and surrounding space, not
  colour. It is not a live region (that stayed fixed in #1569).
- **Memory and Permissions read as a pair** on wide screens, stacking on narrow,
  DOM order unchanged. The quarantine section moved *below* them: with it
  between the two, grid auto-placement put both in column one and the pair never
  formed.
- **Wider page, unchanged measure.** Prose keeps ~62ch and the decision card
  keeps a comfortable column. A button the width of a monitor reads as a banner,
  not as the most important control on the page.
- **Tool ids in words**, from a small explicit map with **every entry checked
  against a registered tool id**. An unknown id falls back to *itself* —
  splitting `vendor.verb_object` and reassembling it would read most ids
  acceptably and some as nonsense, on the page that reports what Butler did to
  somebody's accounts. A raw identifier is honest; an invented sentence is not.
- **Both acceptance defects fixed**: Memory said nothing twice on a calm page,
  and the never-do promise ran into the empty state as though it were its last
  line.

No new card system. The improvement is spacing, type scale and grouping — the
risk with a visual pass here was replacing "policy document" with "AI dashboard
tiles".

## Accepted

1440 and 390 wide, both themes, across all-clear / pending decision / partial
source failure / populated. On mobile the all-clear now fits a single viewport.

74 tests, dashboard typecheck, Biome, `audit-in-flight`, `audit-business-content`
green.

## A process note

The first acceptance pass rendered a **stale build twice** — once from a checkout
five merges behind, once because the previous server never died and the new one
silently failed to bind, so the old process kept serving. Both times the page
looked like the redesign had not worked.

> **Source HEAD → built artifact → running process → rendered page are four
> different things, and checking one proves nothing about the next.**

This branch verified the built chunk contained a known new string, then that the
*served* chunk hash matched the built one, before judging any screenshot. That
check immediately earned itself: it caught that `toolInWords` was never called,
so the label map was dead code and the bundler had dropped it entirely.

Whether that deserves an automated dev command is a separate decision, not this
PR.
