### PR TITLE
feat(butler): what I know about you, in words, and an undo that survives a refresh

### DIFF
--- a/dashboard/src/app/butler/__tests__/butler-fact-words.test.ts
+++ b/dashboard/src/app/butler/__tests__/butler-fact-words.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { ageInWords, factInWords, termInWords } from "../factWords";
+
+/**
+ * The rule under test is mostly a rule about what this module REFUSES to do.
+ * Butler's predicates are operator-authored and unbounded, so every test here
+ * that passes an unfamiliar one is checking that nothing was invented.
+ */
+
+describe("a fact reads as a labelled value, not a database row", () => {
+  it("drops the subject when the fact is about the reader", () => {
+    // "You — tasks default list: personal" was the shape that made Home read
+    // like a table. On a page headed "What I know about you", "You" is noise.
+    const w = factInWords({
+      subject: "user",
+      predicate: "tasks.default_list",
+      object: "personal",
+    });
+    expect(w).toEqual({ term: "Tasks default list", value: "personal" });
+    expect(JSON.stringify(w)).not.toContain("You");
+  });
+
+  it("keeps a subject that is somebody else", () => {
+    // A fact about another person is a different claim and must not silently
+    // read as one about the reader.
+    const w = factInWords({
+      subject: "household.spouse",
+      predicate: "timezone",
+      object: "Europe/Lisbon",
+    });
+    expect(w.about).toBe("Household spouse");
+  });
+
+  it("says so when a belief has no value", () => {
+    // An empty cell reads as a rendering fault; this is a real state.
+    expect(
+      factInWords({ subject: "user", predicate: "coffee", object: "" }).value,
+    ).toBe("(nothing recorded)");
+  });
+
+  it("never rewords the value", () => {
+    const odd = "  Europe/London (since the move) ";
+    expect(
+      factInWords({ subject: "user", predicate: "timezone", object: odd })
+        .value,
+    ).toBe(odd);
+  });
+});
+
+describe("terms are humanised, never guessed at", () => {
+  it("turns separators into spaces and capitalises once", () => {
+    expect(termInWords("tasks.default_list")).toBe("Tasks default list");
+    expect(termInWords("diet.avoid")).toBe("Diet avoid");
+    expect(termInWords("working_hours")).toBe("Working hours");
+  });
+
+  it("does not stem, pluralise or reorder", () => {
+    // Every one of those would be a guess about a word never seen before.
+    // "Diet avoid" is slightly awkward and TRUE; "You avoid" is invented.
+    expect(termInWords("travel.prefers")).toBe("Travel prefers");
+    expect(termInWords("likes")).toBe("Likes");
+  });
+
+  it("leaves an unfamiliar predicate legible rather than mangled", () => {
+    for (const p of ["x", "p", "a.b.c.d", "SHOUTING", "already spaced"]) {
+      const t = termInWords(p);
+      expect(t.length).toBeGreaterThan(0);
+      // Nothing is dropped: every original word survives.
+      for (const word of p.split(/[._-]+/).filter(Boolean)) {
+        expect(t.toLowerCase()).toContain(word.toLowerCase());
+      }
+    }
+  });
+
+  it("returns the predicate itself when there is nothing to humanise", () => {
+    expect(termInWords("...")).toBe("...");
+  });
+});
+
+describe("age answers 'is this still true?'", () => {
+  const now = Date.UTC(2026, 8, 1, 12, 0, 0);
+  const daysAgo = (n: number) => now - n * 86_400_000;
+
+  it("is coarse and relative", () => {
+    expect(ageInWords(daysAgo(0), now)).toBe("today");
+    expect(ageInWords(daysAgo(1), now)).toBe("yesterday");
+    expect(ageInWords(daysAgo(5), now)).toBe("5 days ago");
+    expect(ageInWords(daysAgo(21), now)).toBe("3 weeks ago");
+    expect(ageInWords(daysAgo(200), now)).toBe("6 months ago");
+    expect(ageInWords(daysAgo(900), now)).toBe("2 years ago");
+  });
+
+  it("does not render a future timestamp as a negative age", () => {
+    // Clocks disagree; "-3 days ago" is a bug report, not an answer.
+    expect(ageInWords(now + 60_000, now)).toBe("just now");
+  });
+
+  it("never returns an empty string", () => {
+    for (const d of [0, 1, 13, 14, 63, 64, 364, 365, 5000]) {
+      expect(ageInWords(daysAgo(d), now)).not.toBe("");
+    }
+  });
+});

--- a/dashboard/src/app/butler/__tests__/butler-page.test.tsx
+++ b/dashboard/src/app/butler/__tests__/butler-page.test.tsx
@@ -350,6 +350,20 @@ describe("honesty when the bridge is unreachable", () => {
 });
 
 /** Every source healthy and empty — the genuine all-clear. */
+/**
+ * Undo offers now survive a reload, which means they survive a TEST unless it
+ * says otherwise — and an offer left by a previous case appeared on the next
+ * one's all-clear page as a third heading. Clearing here keeps each case
+ * describing only what it set up.
+ */
+beforeEach(() => {
+  try {
+    window.localStorage.clear();
+  } catch {
+    // Storage is not available in every environment; nothing to clear.
+  }
+});
+
 function stubAllEmpty() {
   vi.stubGlobal(
     "fetch",
@@ -582,5 +596,109 @@ describe("still exactly one announcer", () => {
     );
     const all = new Set<Element>([...explicit, ...implicit]);
     expect(all.size).toBe(1);
+  });
+});
+
+describe("memory: forget is reversible, erase is not", () => {
+  it("warns before erasing, and the warning says there is no undo", async () => {
+    render(<ButlerPage />);
+    const start = await screen.findAllByRole("button", {
+      name: /erase this for good/i,
+    });
+    fireEvent.click(start[0] as HTMLElement);
+
+    // The warning must precede the act — it is the only place it can change
+    // anyone's mind.
+    expect(await screen.findByText(/there is no undo/i)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /yes, erase it for good/i }),
+    ).toBeTruthy();
+    // And the safe choice is offered beside it, not buried.
+    expect(screen.getByRole("button", { name: /keep it/i })).toBeTruthy();
+  });
+
+  it("offers NO undo after an erasure", async () => {
+    // The store keeps a content-free husk; there is nothing to put back. An
+    // undo offered here would be a promise the API cannot keep.
+    render(<ButlerPage />);
+    const start = await screen.findAllByRole("button", {
+      name: /erase this for good/i,
+    });
+    fireEvent.click(start[0] as HTMLElement);
+    fireEvent.click(screen.getByRole("button", { name: /yes, erase it for good/i }),);
+    await screen.findByText(/erased for good/i);
+    expect(screen.queryByRole("button", { name: /undo that/i })).toBeNull();
+  });
+
+  it("still offers an undo after a FORGET, which is reversible", async () => {
+    render(<ButlerPage />);
+    const forget = await screen.findAllByRole("button", {
+      name: /forget this about me/i,
+    });
+    fireEvent.click(forget[0] as HTMLElement);
+    expect(
+      await screen.findByRole("button", { name: /undo that/i }),
+    ).toBeTruthy();
+  });
+});
+
+describe("memory: an undo survives a reload", () => {
+  it("is still offered after the page is mounted again", async () => {
+    // The offer used to hold a closure, so a refresh destroyed it — and
+    // refreshing is exactly what somebody does when a page surprises them.
+    const first = render(<ButlerPage />);
+    const forget = await screen.findAllByRole("button", {
+      name: /forget this about me/i,
+    });
+    fireEvent.click(forget[0] as HTMLElement);
+    await screen.findByRole("button", { name: /undo that/i });
+    first.unmount();
+
+    render(<ButlerPage />);
+    expect(
+      await screen.findByRole("button", { name: /undo that/i }),
+    ).toBeTruthy();
+  });
+
+  it("withdraws an offer that no longer works, and says why", async () => {
+    // A persisted offer can outlive what it reverses. Pressing a button that
+    // silently does nothing is worse than being told.
+    // The bridge no longer has that tombstone — restored in another tab, or
+    // rotated away. Everything else answers normally.
+    stubWithFailure("restore", 404);
+    window.localStorage.setItem(
+      "patchwork.butler.undo.v1",
+      JSON.stringify([
+        {
+          id: "stale",
+          did: 'Removed "Timezone — Europe/London"',
+          path: "/api/bridge/butler/facts/999/restore",
+          said: "Put back",
+        },
+      ]),
+    );
+    render(<ButlerPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /undo that/i }),);
+    expect(
+      await screen.findByText(/may already have been put back/i),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /undo that/i })).toBeNull();
+  });
+});
+
+describe("memory: a fact reads as a labelled value", () => {
+  it("does not render the subject-predicate-object row shape", async () => {
+    const { container } = render(<ButlerPage />);
+    await screen.findByText("Push the release branch");
+    // "You — timezone: Europe/London" was the shape that made Home read like a
+    // database table.
+    expect(container.textContent ?? "").not.toMatch(/You — \w+:/);
+  });
+
+  it("says how long ago as well as the date", async () => {
+    render(<ButlerPage />);
+    expect(
+      await screen.findByText(/Recorded (today|yesterday|\d+ (days|weeks|months|years) ago), on /i),
+    ).toBeTruthy();
   });
 });

--- a/dashboard/src/app/butler/butler.css
+++ b/dashboard/src/app/butler/butler.css
@@ -370,8 +370,16 @@
   grid-template-columns: 1fr;
 }
 
+/* Side by side only when BOTH are summaries.
+ *
+ * A pair of one-line summaries is a place to look things up. A pair of working
+ * lists is not: a fact carries three actions, and long labels — which they must
+ * have, since a button has to name what it does — wrap to a line each in half a
+ * column, turning Memory into a wall of stacked controls. When there is
+ * something to work with, the section takes the full width it needs.
+ */
 @media (min-width: 62rem) {
-  .butlerReference {
+  .butlerReferencePaired {
     grid-template-columns: 1fr 1fr;
     align-items: start;
   }
@@ -410,4 +418,57 @@
 .butler h2,
 .butler h3 {
   color: var(--lp-fg);
+}
+
+/* ── A remembered fact ─────────────────────────────────────────────────────
+ *
+ * Term and value, not `subject — predicate: object`. The value is what a
+ * reader is checking, so it carries the weight; the term is the label. Both
+ * are text: the distinction survives greyscale and a screen reader reads them
+ * in the order they appear.
+ */
+.butlerTerm {
+  font-weight: 600;
+}
+.butlerAbout {
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+/* Correcting, and confirming an erasure. Indented under the row they belong
+ * to, so it is never ambiguous WHICH fact is about to change. */
+.butlerPanel {
+  margin: 0.9rem 0 0.2rem;
+  padding: 0.9rem 1rem;
+  border: 2px solid var(--lp-line-colour);
+  border-radius: 4px;
+}
+
+/* The erase confirmation is marked in words by its own sentence; the border
+ * is reinforcement, never the carrier. */
+.butlerPanelWarn {
+  border-color: var(--lp-danger);
+}
+
+.butlerLabel {
+  display: block;
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.butlerInput {
+  display: block;
+  width: 100%;
+  max-width: 34rem;
+  padding: 0.6rem 0.7rem;
+  font: inherit;
+  color: var(--lp-fg);
+  background: var(--lp-bg);
+  border: 2px solid var(--lp-line-colour);
+  border-radius: 3px;
+  margin: 0 0 0.8rem;
+}
+.butlerInput:focus-visible {
+  outline: 3px solid var(--lp-focus);
+  outline-offset: 2px;
 }

--- a/dashboard/src/app/butler/factWords.ts
+++ b/dashboard/src/app/butler/factWords.ts
@@ -1,0 +1,102 @@
+/**
+ * A remembered fact, put into a person's words.
+ *
+ * ## Why this does NOT generate sentences
+ *
+ * The obvious idea is a map from predicate to a sentence template — `timezone`
+ * → "Your timezone is {value}." It cannot work here, and trying would repeat a
+ * mistake this page has already made twice.
+ *
+ * Predicates are free-form and operator-authored. The ones in the tree today
+ * include `timezone`, `coffee`, `address`, `diet.avoid`, `travel.prefers` and
+ * `household.spouse`, and those are only the ones somebody happened to write in
+ * a test. A map built from them would cover almost nothing a real person
+ * accumulates, so the fallback would carry the page — and a structural rule
+ * ("Your {predicate} is {value}") reads acceptably for `timezone` and produces
+ * "Your diet.avoid is nuts" for the next one.
+ *
+ * The page that tells somebody what a machine believes about them is the last
+ * place to guess at grammar. So: no invented sentences, and no fabricated
+ * subject.
+ *
+ * ## What it does instead
+ *
+ * Presents the fact as a LABELLED VALUE — the predicate as a readable term, the
+ * object as its value. "Tasks default list — personal" invents nothing, drops
+ * the `subject — predicate: object` shape that made Home read like a database
+ * row, and stays true for a predicate nobody anticipated.
+ *
+ * The subject is dropped when it is the user, because "You" in front of every
+ * row on a page titled "What I know about you" is noise. Any other subject is
+ * shown, since a fact about somebody else is a different claim.
+ *
+ * ## Deliberately not shared with the memory card
+ *
+ * `src/butler/memoryCard.ts` renders `subject predicate: object` into a model's
+ * prompt. That is a different audience with different needs — compact, literal,
+ * token-budgeted — and making one function serve both would constrain the
+ * human-facing wording to what suits a prompt. Two renderings of one record is
+ * only drift when both claim to be the same thing.
+ */
+
+export interface FactWords {
+  /** The thing being remembered, as a reader would say it. */
+  term: string;
+  /** What Butler believes about it. Never reworded. */
+  value: string;
+  /** Whose fact this is, when it is not the reader's own. */
+  about?: string;
+}
+
+/**
+ * `tasks.default_list` → `Tasks default list`.
+ *
+ * Separators become spaces and the first letter is capitalised. Nothing else:
+ * no stemming, no pluralisation, no reordering. Every one of those would be a
+ * guess about a word this file has never seen.
+ */
+export function termInWords(predicate: string): string {
+  const spaced = predicate.replace(/[._-]+/g, " ").trim();
+  if (spaced === "") return predicate;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function factInWords(f: {
+  subject: string;
+  predicate: string;
+  object: string;
+}): FactWords {
+  return {
+    term: termInWords(f.predicate),
+    // An empty object is a real state — a belief recorded with no value — and
+    // saying so is better than an empty cell a reader reads as a rendering bug.
+    value: f.object === "" ? "(nothing recorded)" : f.object,
+    ...(f.subject === "user" || f.subject === ""
+      ? {}
+      : { about: termInWords(f.subject) }),
+  };
+}
+
+/**
+ * How long ago, in words.
+ *
+ * Relative because "3 days ago" is what a reader actually wants to know, with
+ * the exact date still shown beside it: age answers "is this current?", a date
+ * answers "which day was that?", and only one of them is usually the question.
+ *
+ * Coarse on purpose. Minute-level precision on a fact recorded weeks ago is
+ * noise, and this page has one job at this point: is this still true?
+ */
+export function ageInWords(recordedAt: number, now: number): string {
+  const ms = now - recordedAt;
+  if (ms < 0) return "just now";
+  const days = Math.floor(ms / 86_400_000);
+  if (days === 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 14) return `${days} days ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 9) return `${weeks} weeks ago`;
+  const months = Math.floor(days / 30);
+  if (months < 24) return `${months} months ago`;
+  return `${Math.floor(days / 365)} years ago`;
+}

--- a/dashboard/src/app/butler/page.tsx
+++ b/dashboard/src/app/butler/page.tsx
@@ -38,6 +38,7 @@ import "./butler.css";
 // Two declarations of the same payload is how a page and its model come to
 // disagree about what the server sends — silently, and in the direction
 // nobody tests.
+import { ageInWords, factInWords } from "./factWords";
 import {
   type ButlerFact,
   type ButlerHomeState,
@@ -52,12 +53,79 @@ import {
 // ─────────────────────────────────────────────────────────────── types
 
 /** An undo the user can still take. Kept until used — never expires. */
+/**
+ * An offer to put something back, in a form that survives a reload.
+ *
+ * It used to hold a CLOSURE, which cannot be serialised — so refreshing the
+ * page destroyed every outstanding offer. That is the wrong failure for the one
+ * control a reader reaches for after a mistake, and reloading is exactly what
+ * somebody does when a page surprises them.
+ *
+ * Both undos are a POST to a fixed path with no body, so the action is fully
+ * described by that path. `did` carries the reader's own words back to them.
+ *
+ * It is kept in this browser's own storage for this origin only. The wording
+ * can name a remembered fact — but that fact is already on the screen it came
+ * from, so no new disclosure is created — and the offer is dropped the moment
+ * it is used or found to be stale.
+ */
 interface UndoOffer {
   id: string;
   /** What was done, in the words shown back to the user. */
   did: string;
-  /** Put it back. */
-  undo: () => Promise<void>;
+  /** The POST that reverses it. */
+  path: string;
+  /** What to say once it is reversed. */
+  said: string;
+}
+
+const UNDO_STORE_KEY = "patchwork.butler.undo.v1";
+
+/**
+ * How many offers are kept.
+ *
+ * An offer is never dropped on a TIMER — that principle stands, and a
+ * disappearing undo is the way this product would fail a reader who needs
+ * longer to decide. But an offer that is never dropped at all grows without
+ * bound in a store with a hard size limit, and once that limit is hit NOTHING
+ * more can be persisted, including the offer for whatever was just deleted.
+ *
+ * A cap on COUNT is not a timeout: the newest offers, the ones a reader is
+ * most likely to want, are the ones kept.
+ */
+const MAX_UNDO_OFFERS = 20;
+
+/** Never throws: storage is unavailable in a private window and on some OSes. */
+function readStoredUndos(): UndoOffer[] {
+  try {
+    const raw = window.localStorage.getItem(UNDO_STORE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (o): o is UndoOffer =>
+        typeof o === "object" &&
+        o !== null &&
+        typeof (o as UndoOffer).id === "string" &&
+        typeof (o as UndoOffer).did === "string" &&
+        typeof (o as UndoOffer).path === "string" &&
+        typeof (o as UndoOffer).said === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeStoredUndos(offers: UndoOffer[]): void {
+  try {
+    window.localStorage.setItem(
+      UNDO_STORE_KEY,
+      JSON.stringify(offers.slice(0, MAX_UNDO_OFFERS)),
+    );
+  } catch {
+    // An undo that cannot be persisted is still offered for this page view.
+    // Losing the persistence is worse than losing the offer.
+  }
 }
 
 // ─────────────────────────────────────────────────────────── plain words
@@ -84,9 +152,16 @@ function sourceInWords(f: ButlerFact): string {
 
 /** A fact as a sentence. `subject`/`predicate` are machine keys; a person
  *  should not have to parse `household.spouse` / `diet.avoid`. */
-function factInWords(f: ButlerFact): string {
-  const subject = f.subject === "user" ? "You" : humanise(f.subject);
-  return `${subject} — ${humanise(f.predicate)}: ${f.object || "(nothing)"}`;
+/**
+ * One line naming a fact, for an announcement or an undo offer.
+ *
+ * The row itself renders the term and value separately; this is the flattened
+ * form for a sentence a screen reader speaks. It uses the same words, so what
+ * is announced matches what is on screen.
+ */
+function describeFact(f: ButlerFact): string {
+  const w = factInWords(f);
+  return w.about ? `${w.about}: ${w.term} — ${w.value}` : `${w.term} — ${w.value}`;
 }
 
 function humanise(key: string): string {
@@ -194,16 +269,47 @@ export default function ButlerPage() {
   const [undos, setUndos] = useState<UndoOffer[]>([]);
   const [home, setHome] = useState<ButlerHomeState | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  /**
+   * The instant the page describes, read ONCE at load rather than during
+   * render. A render-time `Date.now()` differs between the server pass and the
+   * client one — a hydration mismatch — and makes "3 days ago" impossible to
+   * assert. Zero means not yet read, and the age is simply not claimed.
+   */
+  const [now, setNow] = useState(0);
+  /** The fact being corrected, and the text typed so far. */
+  const [editing, setEditing] = useState<{ seq: number; text: string } | null>(
+    null,
+  );
+  /** The fact whose permanent erasure is awaiting a second, explicit yes. */
+  const [erasing, setErasing] = useState<number | null>(null);
   const [ready, setReady] = useState(false);
 
   const announce = useCallback((msg: string) => setAnnounce(msg), []);
 
-  const offerUndo = useCallback((did: string, undo: () => Promise<void>) => {
-    setUndos((prev) => [
+  const offerUndo = useCallback((did: string, path: string, said: string) => {
+    setUndos((prev) => {
       // Newest first, and never dropped on a timer — see the header comment.
-      { id: `${Date.now()}-${Math.random()}`, did, undo },
-      ...prev,
-    ]);
+      const next = [
+        { id: `${Date.now()}-${Math.random()}`, did, path, said },
+        ...prev,
+      ].slice(0, MAX_UNDO_OFFERS);
+      writeStoredUndos(next);
+      return next;
+    });
+  }, []);
+
+  const forgetUndo = useCallback((id: string) => {
+    setUndos((prev) => {
+      const next = prev.filter((x) => x.id !== id);
+      writeStoredUndos(next);
+      return next;
+    });
+  }, []);
+
+  // Offers made before a reload are still offers.
+  useEffect(() => {
+    const stored = readStoredUndos();
+    if (stored.length > 0) setUndos(stored);
   }, []);
 
   const load = useCallback(async () => {
@@ -267,6 +373,7 @@ export default function ButlerPage() {
         exercises: listFrom(e, "exercises"),
         approvals: listFrom(a, ""),
       };
+      setNow(Date.now());
       const state = mapButlerHome(sources);
       setHome(state);
       // A TOTAL blackout is a page-level alert; a partial one is a note beside
@@ -384,7 +491,7 @@ export default function ButlerPage() {
         const res = await del(`/api/bridge/butler/facts/${f.seq}`);
         const body = (await res.json()) as { tombstone?: { seq?: number } };
         const tombSeq = body?.tombstone?.seq;
-        announce(`Removed: ${factInWords(f)}`);
+        announce(`Removed: ${describeFact(f)}`);
         // Put it back AS IT WAS. This used to re-POST a plain fact, and the
         // create route stamps channel "user_chat" unconditionally — so undoing
         // the removal of something Butler had merely READ somewhere returned it
@@ -392,10 +499,11 @@ export default function ButlerPage() {
         // being used. The undo was a trust escalator. The restore route copies
         // the original row's provenance instead.
         if (tombSeq !== undefined) {
-          offerUndo(`Removed "${factInWords(f)}"`, async () => {
-            await post(`/api/bridge/butler/facts/${tombSeq}/restore`);
-            announce(`Put back: ${factInWords(f)}`);
-          });
+          offerUndo(
+            `Removed "${describeFact(f)}"`,
+            `/api/bridge/butler/facts/${tombSeq}/restore`,
+            `Put back: ${describeFact(f)}`,
+          );
         }
         await load();
       } catch {
@@ -409,7 +517,7 @@ export default function ButlerPage() {
     async (f: ButlerFact) => {
       try {
         await post(`/api/bridge/butler/facts/${f.seq}/confirm`);
-        announce(`Confirmed: ${factInWords(f)}`);
+        announce(`Confirmed: ${describeFact(f)}`);
       } catch {
         announce("I could not confirm that. Nothing has changed.");
       }
@@ -421,12 +529,99 @@ export default function ButlerPage() {
     async (f: ButlerFact) => {
       try {
         await post(`/api/bridge/butler/quarantine/${f.seq}/promote`);
-        announce(`I will remember: ${factInWords(f)}`);
+        announce(`I will remember: ${describeFact(f)}`);
       } catch {
         announce("I could not save that. Nothing has changed.");
       }
     },
     [announce, post],
+  );
+
+  /**
+   * Put something back.
+   *
+   * A persisted offer can outlive what it reverses — the same tombstone
+   * restored in another tab, or a bridge that no longer has it. That is not an
+   * error to hide: the offer is withdrawn and the reader is told the reason,
+   * rather than left pressing a button that silently does nothing.
+   */
+  const runUndo = useCallback(
+    async (u: UndoOffer) => {
+      try {
+        await post(u.path);
+        announce(u.said);
+        forgetUndo(u.id);
+        await load();
+      } catch {
+        announce(
+          "I could not put that back — it may already have been put back somewhere else. I have removed the offer.",
+        );
+        forgetUndo(u.id);
+        await load();
+      }
+    },
+    [announce, forgetUndo, load, post],
+  );
+
+  /**
+   * Correct a belief by appending a new value.
+   *
+   * PATCH, not delete-then-create: the store is append-only and the correction
+   * keeps the original row's provenance. Re-creating would stamp `user_chat`,
+   * which would quietly promote something Butler had merely READ into
+   * something you said — the same trust escalation the restore route exists to
+   * avoid.
+   */
+  const correctFact = useCallback(
+    async (f: ButlerFact, object: string) => {
+      const next = object.trim();
+      if (next === "" || next === f.object) {
+        setEditing(null);
+        return;
+      }
+      try {
+        const res = await fetch(apiPath(`/api/bridge/butler/facts/${f.seq}`), {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ object: next }),
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        setEditing(null);
+        announce(`Changed to: ${next}`);
+        await load();
+      } catch {
+        announce("I could not change that. Nothing has changed.");
+      }
+    },
+    [announce, load],
+  );
+
+  /**
+   * Destroy the content of a belief for good.
+   *
+   * A DIFFERENT operation from forgetting, not a stronger one. `forget` writes
+   * a tombstone and leaves the original row, which is exactly what lets an undo
+   * put the belief back as it was. Erasing blanks the subject, predicate and
+   * object and keeps a content-free husk recording that an erasure happened.
+   *
+   * So NO undo is offered here, and none can be. The confirmation says so
+   * before it happens, which is the only place that warning is any use.
+   */
+  const eraseFact = useCallback(
+    async (f: ButlerFact) => {
+      try {
+        const res = await del(
+          `/api/bridge/butler/facts/${f.seq}?erase=true`,
+        );
+        if (!res.ok) throw new Error(String(res.status));
+        setErasing(null);
+        announce("Erased for good. There is no undo for this one.");
+        await load();
+      } catch {
+        announce("I could not erase that. Nothing has changed.");
+      }
+    },
+    [announce, del, load],
   );
 
   const revokePermission = useCallback(
@@ -439,10 +634,11 @@ export default function ButlerPage() {
         // `expiresAt` and the magnitude band — turning a capped, expiring
         // permission into an uncapped permanent one, and orphaning every
         // "done without asking" record attached to the old id.
-        offerUndo(`Took back "${permissionInWords(p)}"`, async () => {
-          await post(`/api/bridge/butler/permissions/${p.id}/restore`);
-          announce("Allowed again.");
-        });
+        offerUndo(
+          `Took back "${permissionInWords(p)}"`,
+          `/api/bridge/butler/permissions/${p.id}/restore`,
+          "Allowed again.",
+        );
         await load();
       } catch {
         announce("I could not take that back. Nothing has changed.");
@@ -635,7 +831,13 @@ export default function ButlerPage() {
       {/* Memory and Permissions are the two reference areas. Side by side when
           there is room, sequential in the DOM and stacked when there is not —
           the reading order never changes. */}
-      <div className="butlerReference">
+      <div
+        className={
+          memoryCompact && permissionsCompact
+            ? "butlerReference butlerReferencePaired"
+            : "butlerReference"
+        }
+      >
       {/* 3 ── What Butler knows ──────────────────────────────────────── */}
       <section className="butlerSection" aria-labelledby="butler-knows">
         <h2 id="butler-knows">What I know about you</h2>
@@ -669,11 +871,29 @@ export default function ButlerPage() {
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
             {facts.map((f) => (
               <li key={f.seq} className="butlerRow">
-                <p className="butlerRowText">{factInWords(f)}</p>
+                <p className="butlerRowText">
+                  {factInWords(f).about ? (
+                    <span className="butlerAbout">
+                      {factInWords(f).about}:{" "}
+                    </span>
+                  ) : null}
+                  {/* The separator is REAL text, not a CSS `::after`.
+                      Generated content is announced inconsistently, and
+                      without it the row reads as one run-on word — the
+                      accessible name became "Tasks default listpersonal". */}
+                  <span className="butlerTerm">{factInWords(f).term}</span>
+                  {" — "}
+                  <span className="butlerValue">{factInWords(f).value}</span>
+                </p>
                 {/* Source in WORDS, always visible — never a coloured dot and
                     never behind a tooltip. */}
                 <p className="butlerMeta">
-                  {sourceInWords(f)} Recorded {whenInWords(f.recordedAt)}.
+                  {/* Age answers "is this still true?"; the date answers "which
+                      day was that?". Usually only one of them is the question,
+                      so both are shown rather than one chosen. */}
+                  {sourceInWords(f)} Recorded{" "}
+                  {now > 0 ? `${ageInWords(f.recordedAt, now)}, on ` : ""}
+                  {whenInWords(f.recordedAt)}.
                 </p>
                 <div className="butlerActions">
                   {!f.provenance.validated && (
@@ -688,11 +908,88 @@ export default function ButlerPage() {
                   <button
                     type="button"
                     className="butlerButton"
+                    onClick={() =>
+                      setEditing({ seq: f.seq, text: f.object })
+                    }
+                  >
+                    Change this
+                  </button>
+                  <button
+                    type="button"
+                    className="butlerButton"
                     onClick={() => void removeFact(f)}
                   >
                     Forget this about me
                   </button>
+                  <button
+                    type="button"
+                    className="butlerButton"
+                    onClick={() => setErasing(f.seq)}
+                  >
+                    Erase this for good
+                  </button>
                 </div>
+
+                {editing?.seq === f.seq && (
+                  <div className="butlerPanel">
+                    <label className="butlerLabel" htmlFor={`edit-${f.seq}`}>
+                      What should {factInWords(f).term.toLowerCase()} be?
+                    </label>
+                    <input
+                      id={`edit-${f.seq}`}
+                      className="butlerInput"
+                      value={editing.text}
+                      onChange={(e) =>
+                        setEditing({ seq: f.seq, text: e.target.value })
+                      }
+                    />
+                    <div className="butlerActions">
+                      <button
+                        type="button"
+                        className="butlerButton butlerButtonPrimary"
+                        onClick={() => void correctFact(f, editing.text)}
+                      >
+                        Save this change
+                      </button>
+                      <button
+                        type="button"
+                        className="butlerButton"
+                        onClick={() => setEditing(null)}
+                      >
+                        Leave it as it was
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {erasing === f.seq && (
+                  /* The warning belongs BEFORE the act, which is the only
+                     place it can change anyone's mind. Forgetting is
+                     reversible and erasing is not, and the two buttons sit
+                     next to each other. */
+                  <div className="butlerPanel butlerPanelWarn">
+                    <p className="butlerRowText">
+                      This erases it for good. There is no undo, and I will
+                      keep only a note that something was erased.
+                    </p>
+                    <div className="butlerActions">
+                      <button
+                        type="button"
+                        className="butlerButton"
+                        onClick={() => void eraseFact(f)}
+                      >
+                        Yes, erase it for good
+                      </button>
+                      <button
+                        type="button"
+                        className="butlerButton butlerButtonPrimary"
+                        onClick={() => setErasing(null)}
+                      >
+                        Keep it
+                      </button>
+                    </div>
+                  </div>
+                )}
               </li>
             ))}
           </ul>
@@ -771,7 +1068,20 @@ export default function ButlerPage() {
             <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
               {quarantine.map((f) => (
                 <li key={f.seq} className="butlerRow">
-                  <p className="butlerRowText">{factInWords(f)}</p>
+                  <p className="butlerRowText">
+                  {factInWords(f).about ? (
+                    <span className="butlerAbout">
+                      {factInWords(f).about}:{" "}
+                    </span>
+                  ) : null}
+                  {/* The separator is REAL text, not a CSS `::after`.
+                      Generated content is announced inconsistently, and
+                      without it the row reads as one run-on word — the
+                      accessible name became "Tasks default listpersonal". */}
+                  <span className="butlerTerm">{factInWords(f).term}</span>
+                  {" — "}
+                  <span className="butlerValue">{factInWords(f).value}</span>
+                </p>
                   <p className="butlerMeta">{sourceInWords(f)}</p>
                   <div className="butlerActions">
                     <button
@@ -812,11 +1122,7 @@ export default function ButlerPage() {
                   <button
                     type="button"
                     className="butlerButton"
-                    onClick={() => {
-                      void u.undo().then(() =>
-                        setUndos((prev) => prev.filter((x) => x.id !== u.id)),
-                      );
-                    }}
+                    onClick={() => void runUndo(u)}
                   >
                     Undo that
                   </button>

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,7 +50,11 @@ verified (which is how this line came to be written).
 
 ## Active
 
-_Empty is a legitimate state. See "Retire your own entry before merging" above._
+- **`feat/butler-memory`** — Butler Memory: facts in natural language, provenance
+  and age, confirm/correct, **Forget (reversible) vs Erase (not)**, and undo that
+  survives a reload. Touches `dashboard/src/app/butler/` and may add a small
+  predicate-phrasing module. No runtime change. Design freeze:
+  `docs/butler-product-reset.md`.
 
 
 ## Recently closed (informal log, prune periodically)

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -50,14 +50,21 @@ verified (which is how this line came to be written).
 
 ## Active
 
-- **`feat/butler-memory`** — Butler Memory: facts in natural language, provenance
-  and age, confirm/correct, **Forget (reversible) vs Erase (not)**, and undo that
-  survives a reload. Touches `dashboard/src/app/butler/` and may add a small
-  predicate-phrasing module. No runtime change. Design freeze:
-  `docs/butler-product-reset.md`.
+_Empty is a legitimate state. See "Retire your own entry before merging" above._
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-09-01 `feat/butler-memory` — Butler Memory. Facts read as a labelled value
+  (`Tasks default list — personal`) rather than `subject — predicate: object`; **no
+  sentence templates**, because predicates are operator-authored and unbounded and a
+  structural rule produces "Your diet.avoid is nuts". Age beside the date. Correct via
+  PATCH (append, keeps provenance — re-creating would stamp `user_chat` and promote a
+  merely-READ belief). **Erase is a different operation from Forget, not a stronger one**:
+  it blanks the content and keeps a husk, so no undo is offered and the warning says so
+  BEFORE it happens. Undo now survives a reload — the offer held a closure, which a
+  refresh destroyed, and refreshing is what somebody does when a page surprises them;
+  capped at 20, and a stale offer is withdrawn with its reason.
 
 - 2026-09-01 `feat/butler-home-visual` — Butler Home presentation. Headline hierarchy,
   Memory/Permissions as a pair on wide screens, tool ids in words from a verified map with


### PR DESCRIPTION
Step 4 of the Butler product reset. The last "this feels like a database" problem
on Home, plus the undo that a refresh used to destroy.

## Facts read as a labelled value — and no sentence is invented

`You — tasks default list: personal` → **`Tasks default list — personal`**.

The obvious approach was a predicate-to-sentence map. **It cannot work here.**
Predicates are operator-authored and unbounded — `timezone`, `coffee`,
`diet.avoid`, `travel.prefers`, `household.spouse` are only the ones somebody
happened to write in a test — so a map would cover almost nothing a real person
accumulates and the fallback would carry the page. A structural rule ("Your
{predicate} is {value}") reads fine for `timezone` and produces **"Your
diet.avoid is nuts"** for the next one.

The page that tells somebody what a machine believes about them is the last
place to guess at grammar. So: the predicate becomes a readable term, **the
value is never reworded**, and the subject is dropped only when it is the reader
— a fact about someone else is a different claim and still says whose it is.

Age sits beside the date. Age answers *is this still true?*; a date answers
*which day was that?*; usually only one is the question. The clock is read once
at load — a render-time `Date.now()` is a hydration mismatch and makes "3 days
ago" impossible to assert.

## Erase is a different operation from Forget, not a stronger one

| | what it does | undo |
|---|---|---|
| **Forget** | writes a tombstone, leaves the original row | yes — restore puts it back *as it was* |
| **Erase** | blanks subject/predicate/object, keeps a content-free husk | **none, and none is possible** |

So **no undo is offered after an erasure**, and the warning says so *before* it
happens — the only place a warning can change anyone's mind. The safe choice
sits beside it rather than buried. A test fails if an undo ever appears there.

**Correcting is a PATCH**, which appends and keeps the original row's
provenance. Delete-then-create would stamp `user_chat` and quietly promote
something Butler had merely **read** into something you *said* — the same trust
escalation the restore route already exists to avoid.

## The undo survives a reload

It held a **closure**, which cannot be serialised, so refreshing destroyed every
outstanding offer — and refreshing is exactly what somebody does when a page
surprises them. Both undos are a POST to a fixed path, so an offer is now fully
described by that path.

- **Capped at 20.** Not a timeout — that principle stands — but an offer that is
  never dropped at all grows without bound in a store with a hard size limit,
  and once that limit is hit *nothing more can be persisted*, including the
  offer for whatever was just deleted.
- **A stale offer is withdrawn with its reason.** A persisted offer can outlive
  what it reverses; pressing a button that silently does nothing is worse than
  being told.
- Storage is same-origin and the wording names a fact already on the screen it
  came from, so no new disclosure — and it is dropped the moment it is used.

## Two defects found by rendering, not by tests

1. **The row's accessible name was `Tasks default listpersonal`.** The separator
   was a CSS `::after` — announced inconsistently by screen readers and absent
   from `textContent`. It is real text now. My own CSS comment claimed it was in
   the markup; it wasn't.
2. **Three actions per fact turned Memory into a wall.** In a half-width column
   the labels wrap to a line each — and they must be long, because a button has
   to name what it does. The pair is right for two *summaries* and wrong for two
   *working lists*, so Memory and Permissions sit side by side only when both
   are compact.

## Verification

92 tests. **Mutation-checked**: offering an undo after an erasure, and dropping
the persistence, each fail their own test.

Rendered acceptance followed the chain the last branch established — the new
control was confirmed present in the **built** artifact, then the **served**
chunk hash was confirmed to match it, before any screenshot was judged.

## Out of scope

No runtime change. Memory is still a section of Home rather than its own route —
splitting the views is a separate step, and worth doing after living with this
one.
