### PR TITLE
feat(evidence): chain privacy_shadow.jsonl through the ADR-0027 append primitive

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,13 +52,12 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-09-02 `feat/chain-privacy-shadow` — ADR-0027 follow-on, one ledger: route `privacy_shadow.jsonl` through `appendChained` (rv 1 → 2, markers skipped by the summariser, line-by-line test readers filter marker rows). Touches src/privacy/shadowLog.ts and its tests only. — Claude Code (chain-privacy-shadow worktree)
-
 
 
 ## Recently closed (informal log, prune periodically)
 
 - 2026-09-02 `fix/evidence-skip-markers` — `patchwork evidence` and its relationships view counted ADR-0027 marker rows as data (one phantom row per chained ledger in every denominator, and a phantom LEGACY gate decision). Shared `isChainMarker` predicate in ledgerChain.ts, both readers skip it, failing-first test. Touches evidenceCoverage, evidenceRelationships, ledgerChain. — Claude Code (phase1-ledgers worktree) PR #1577
+- 2026-09-02 `feat/chain-privacy-shadow` — ADR-0027 follow-on, one ledger: route `privacy_shadow.jsonl` through `appendChained` (rv 1 → 2, markers skipped by the summariser, line-by-line test readers filter marker rows). Touches src/privacy/shadowLog.ts and its tests only. — Claude Code (chain-privacy-shadow worktree) PR #1574
 
 - 2026-09-02 `feat/tamper-evident-ledgers` — Phase 1 slice 1: tamper-evident ledgers. ADR for the integrity wire format (per-ledger integrity seq + prevHash behind `rv`, rotation marker, legacy prefix committed by the first chain marker, never backfilled), one shared append primitive (lock → tail read → chain → rotation → append), proven on `boundary_receipts.jsonl` (unlocked writer) and `worker_gate_decisions.jsonl` (rotation), `patchwork evidence verify`, write_failed counter. Touches boundaryReceiptLog, workerGateDecisionLog, evidenceCoverage, index.ts. — Claude Code (phase1-ledgers worktree) PR #1573
 

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-09-02 `feat/chain-privacy-shadow` — ADR-0027 follow-on, one ledger: route `privacy_shadow.jsonl` through `appendChained` (rv 1 → 2, markers skipped by the summariser, line-by-line test readers filter marker rows). Touches src/privacy/shadowLog.ts and its tests only. — Claude Code (chain-privacy-shadow worktree)
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/src/privacy/__tests__/evidenceWorkspaceSeed.test.ts
+++ b/src/privacy/__tests__/evidenceWorkspaceSeed.test.ts
@@ -150,10 +150,14 @@ async function run(): Promise<Array<{ workspaceId?: string }>> {
     // Absent under an enforcing-only config, which is a valid state for this
     // helper rather than a failure — the receipt case asserts on its own file.
     try {
-      return readFileSync(join(home, "privacy_shadow.jsonl"), "utf-8")
-        .split("\n")
-        .filter(Boolean)
-        .map((l) => JSON.parse(l) as { workspaceId?: string });
+      return (
+        readFileSync(join(home, "privacy_shadow.jsonl"), "utf-8")
+          .split("\n")
+          .filter(Boolean)
+          .map((l) => JSON.parse(l) as { kind?: string; workspaceId?: string })
+          // ADR-0027 marker rows (`chain-start`, `rotation`) share the file; skip them like every production loader.
+          .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+      );
     } catch {
       return [];
     }

--- a/src/privacy/__tests__/orchestratorShadow.test.ts
+++ b/src/privacy/__tests__/orchestratorShadow.test.ts
@@ -51,10 +51,14 @@ function writeShadowConfig(): void {
 
 function rows(): Array<Record<string, unknown>> {
   try {
-    return readFileSync(path.join(dir, "privacy_shadow.jsonl"), "utf-8")
-      .split("\n")
-      .filter((l) => l.trim())
-      .map((l) => JSON.parse(l));
+    return (
+      readFileSync(path.join(dir, "privacy_shadow.jsonl"), "utf-8")
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l) as Record<string, unknown>)
+        // ADR-0027 marker rows (`chain-start`, `rotation`) share the file; skip them like every production loader.
+        .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+    );
   } catch {
     return [];
   }

--- a/src/privacy/__tests__/privacyShadow.test.ts
+++ b/src/privacy/__tests__/privacyShadow.test.ts
@@ -153,7 +153,13 @@ describe("the ledger carries no payload", () => {
       { dir },
     );
     const raw = readFileSync(path.join(dir, "privacy_shadow.jsonl"), "utf-8");
-    const row = JSON.parse(raw.trim());
+    // ADR-0027 marker rows (`chain-start`, `rotation`) share the file; skip them like every production loader.
+    const row = raw
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+      .at(-1) as Record<string, unknown>;
     // Category NAMES are metadata; their contents are not. A privacy ledger
     // holding the prompts would be the largest unclassified copy of exactly
     // what the boundary protects.

--- a/src/privacy/__tests__/shadowAttribution.test.ts
+++ b/src/privacy/__tests__/shadowAttribution.test.ts
@@ -229,7 +229,9 @@ describe("the WIRING, not just the summariser", () => {
       const rows = readFileSync(join(home, "privacy_shadow.jsonl"), "utf-8")
         .split("\n")
         .filter(Boolean)
-        .map((l) => JSON.parse(l) as { recipeName?: string });
+        .map((l) => JSON.parse(l) as { kind?: string; recipeName?: string })
+        // ADR-0027 marker rows (`chain-start`, `rotation`) share the file; skip them like every production loader.
+        .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
 
       expect(rows.length).toBeGreaterThan(0);
       expect(rows.at(-1)?.recipeName).toBe("a-named-recipe");

--- a/src/privacy/__tests__/shadowCorrelation.test.ts
+++ b/src/privacy/__tests__/shadowCorrelation.test.ts
@@ -79,14 +79,23 @@ function writeConfig(): void {
   );
 }
 
-type Row = { rv?: number; correlationId?: string; path?: string };
+type Row = {
+  kind?: string;
+  rv?: number;
+  correlationId?: string;
+  path?: string;
+};
 
 function readJsonl(name: string): Row[] {
   try {
-    return readFileSync(join(home, name), "utf-8")
-      .split("\n")
-      .filter(Boolean)
-      .map((l) => JSON.parse(l) as Row);
+    return (
+      readFileSync(join(home, name), "utf-8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as Row)
+        // ADR-0027 marker rows (`chain-start`, `rotation`) share the file; skip them like every production loader.
+        .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+    );
   } catch {
     return [];
   }

--- a/src/privacy/__tests__/shadowLogChain.test.ts
+++ b/src/privacy/__tests__/shadowLogChain.test.ts
@@ -1,0 +1,98 @@
+/**
+ * ADR-0027, one ledger: `privacy_shadow.jsonl` is written through
+ * `appendChained`, verified through the real verifier rather than the writer's
+ * own return value.
+ *
+ * Seeded with a LEGACY prefix (a row in the pre-chain shape) so the migration
+ * boundary is proven too: legacy bytes untouched and committed to, the writer's
+ * first new row chained after them, and the existing summariser still counting
+ * only data rows — a `chain-start` marker must never enter the denominator.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { verifyLedgerChain } from "../../ledgerChain.js";
+import {
+  recordPrivacyShadow,
+  SHADOW_LOG_BASENAME,
+  SHADOW_RECORD_VERSION,
+  summarisePrivacyShadow,
+} from "../shadowLog.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "shadow-chain-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const dataRows = (file: string) =>
+  readFileSync(file, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+    // ADR-0027 marker rows carry `kind` and no data fields; skipped the way
+    // every production loader skips them.
+    .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
+
+describe("privacy shadow ledger chain", () => {
+  it("chains after a legacy prefix, stamps rv/iseq, and the summariser ignores the marker", () => {
+    const file = path.join(dir, SHADOW_LOG_BASENAME);
+    const legacy =
+      '{"at":1,"rv":1,"decision":"ALLOW","classification":"internal","destinationId":"d","destinationType":"local","reason":"old","enforcing":false}\n';
+    writeFileSync(file, legacy);
+
+    recordPrivacyShadow(
+      {
+        decision: "DENY",
+        classification: "internal",
+        destinationId: "d",
+        destinationType: "local",
+        reason: "new",
+        enforcing: false,
+      },
+      { dir, now: () => 2 },
+    );
+
+    // Legacy bytes are byte-identical afterwards — never re-stamped.
+    expect(readFileSync(file, "utf-8").startsWith(legacy)).toBe(true);
+
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.legacyRows).toBe(1);
+    expect(v.chainedRows).toBe(1);
+
+    const row = dataRows(file).at(-1);
+    expect(row).toMatchObject({ rv: SHADOW_RECORD_VERSION, iseq: 1 });
+    expect(SHADOW_RECORD_VERSION).toBe(2);
+    expect(typeof row?.prev).toBe("string");
+
+    // The marker is a third line in the file and must not be a third
+    // observation: the denominator is exactly the two data rows.
+    const s = summarisePrivacyShadow({ dir });
+    expect(s.observed).toBe(2);
+    expect(s.crossings).toBe(1);
+    expect(s.byDecision).toEqual({ ALLOW: 1, DENY: 1 });
+  });
+
+  it("still never throws when the ledger cannot be written", () => {
+    // A file where the directory should be: mkdir and append both fail.
+    const blocked = path.join(dir, "blocked");
+    writeFileSync(blocked, "");
+    expect(() =>
+      recordPrivacyShadow(
+        {
+          decision: "ALLOW",
+          classification: "internal",
+          destinationId: "d",
+          destinationType: "local",
+          reason: "r",
+          enforcing: false,
+        },
+        { dir: blocked },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/privacy/shadowLog.ts
+++ b/src/privacy/shadowLog.ts
@@ -35,9 +35,10 @@
  * mixing it into the receipts would put unenforced decisions into the evidence
  * trail that is supposed to record what actually happened.
  */
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+import { appendChained } from "../ledgerChain.js";
 import { patchworkPath } from "../patchworkHome.js";
 import type { BoundaryDecision, Classification } from "./dataPolicy.js";
 
@@ -136,7 +137,13 @@ export const COVERAGE_IS_ENUMERATED =
  * Do NOT read "no `rv`" as "old" — a stale bridge writing un-`rv`'d rows today
  * is indistinguishable from a row written months ago (#1515).
  */
-export const SHADOW_RECORD_VERSION = 1;
+/**
+ * 2 (ADR-0027): every row also carries `iseq` and `prev`, stamped by
+ * `appendChained` from the file's tail under the lock. At `rv >= 2` their
+ * absence is a WRITER DEFECT. Rows at `rv 1` predate the chain and are never
+ * re-stamped; the `chain-start` marker commits to them as a block.
+ */
+export const SHADOW_RECORD_VERSION = 2;
 
 export interface PrivacyShadowRow {
   at: number;
@@ -163,6 +170,12 @@ export interface PrivacyShadowRow {
    * ABSENT on the `orchestrator-task` path by registration, not by omission.
    */
   correlationId?: string;
+  /**
+   * ADR-0027 integrity fields, stamped by `appendChained` — never by this
+   * writer. Optional on the type because rows at `rv < 2` have none.
+   */
+  iseq?: number;
+  prev?: string;
   /** Which dispatch path produced this. Absent on rows written before paths. */
   path?: ShadowPath;
   /** Whether the classification was declared or defaulted. */
@@ -239,7 +252,14 @@ export function recordPrivacyShadow(
       rv: SHADOW_RECORD_VERSION,
       reason: row.reason.slice(0, MAX_REASON),
     };
-    appendFileSync(file, `${JSON.stringify(full)}\n`);
+    // ADR-0027: locked, chained append. This writer had no lock at all until
+    // then — two bridges sharing $PATCHWORK_HOME could tear a row — and a
+    // failed append was indistinguishable on disk from a quiet day. Both are
+    // the primitive's job now (it counts its own failures in the sidecar); the
+    // never-throw contract below is unchanged.
+    appendChained(file, full as unknown as Record<string, unknown>, {
+      mode: 0o600,
+    });
   } catch {
     // Observation only — never disturb the dispatch being observed.
   }
@@ -339,6 +359,11 @@ export function summarisePrivacyShadow(
     } catch {
       continue;
     }
+    // ADR-0027 marker rows (`kind: chain-start | rotation`) share the file.
+    // They carry `at` but no `decision`, so the shape check below already
+    // drops them; the explicit test keeps that true if the shape ever widens —
+    // a marker in the denominator would be a dispatch that never happened.
+    if ((row as { kind?: unknown }).kind !== undefined) continue;
     if (typeof row.at !== "number" || typeof row.decision !== "string")
       continue;
     if (opts.since !== undefined && row.at < opts.since) continue;


### PR DESCRIPTION
## What

ADR-0027 follow-on, **one ledger per PR**: `privacy_shadow.jsonl` now writes through `appendChained` (#1573's primitive) instead of a bare `appendFileSync`.

- `recordPrivacyShadow` — locked across bridges, `iseq` + `prev` stamped from the file's tail, a failed append counted in the `.write_failed` sidecar and sealed into the next row. The never-throw contract is unchanged: the primitive's throw lands in the existing catch.
- `SHADOW_RECORD_VERSION` 1 → 2, doc comment in the receipt ledger's style (rv >= 2 absence of `iseq`/`prev` is a writer defect; rv 1 rows are never re-stamped; the chain-start marker commits to them as a block).
- `summarisePrivacyShadow` skips marker rows on `kind` explicitly. It already dropped them by shape (no `decision`), but the explicit test means a widened shape cannot put a marker into the observed denominator.
- `PrivacyShadowRow` gains optional `iseq`/`prev`. The summariser is not an explicit-field `view()` reader, so there was no whitelist to extend (#1517's trap does not apply here).

## Tests

- New `src/privacy/__tests__/shadowLogChain.test.ts`: seeds a legacy row in the old shape, calls the real writer, asserts `verifyLedgerChain` reports `ok`, `legacyPrefix: "verified"`, `chainedRows: 1`, the new row carries `rv: 2` / `iseq: 1`, and the summariser observes exactly 2 (the marker is not counted). Written first and failed with `expected 'unchained' to be 'verified'` before wiring.
- Five existing tests read the file line-by-line; one parsed the whole file as a single JSON value and would have broken outright. Each now filters `chain-start`/`rotation` with the same one-liner `evidenceFieldRoundTrip.test.ts` uses.

## Verification

- `biome check`, `typecheck`, `typecheck:tests:core` clean.
- Full `vitest run`: 838 files / 10894 tests green. `init.test.ts` failed once only because the suite started before `dist/` was built; passes on re-run.
- `node dist/index.js evidence verify` on the reference machine: `STATUS: INTACT`, every spine ledger reported as legacy rows with no chain yet (the running bridges predate #1573, so no chained row exists on disk yet; the first chained append will write the marker).

## Not in this PR

`patchwork evidence` (coverage) and `evidenceRelationships` count every parsed line and will count a marker row once one exists — that is shared across every chained ledger and was already true for receipts and gate decisions after #1573, so it is a separate change, not a per-ledger one. No CLAUDE.md or ADR edits (docs PR follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
