### PR TITLE
feat(evidence): chain outcome-log.jsonl behind rv 1 (ADR-0027)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-09-02 `feat/chain-outcome-log` — ADR-0027 slice: route `outcome-log.jsonl` through `appendChained`, introduce `OUTCOME_LOG_RV = 1`, skip marker rows ahead of the unkeyable accounting. Touches `src/workers/outcomeStore.ts` and its tests only. — Claude Code (chain-outcome-log worktree)
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,14 +52,13 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-09-02 `feat/chain-outcome-log` — ADR-0027 slice: route `outcome-log.jsonl` through `appendChained`, introduce `OUTCOME_LOG_RV = 1`, skip marker rows ahead of the unkeyable accounting. Touches `src/workers/outcomeStore.ts` and its tests only. — Claude Code (chain-outcome-log worktree)
-
 
 
 ## Recently closed (informal log, prune periodically)
 
 - 2026-09-02 `fix/evidence-skip-markers` — `patchwork evidence` and its relationships view counted ADR-0027 marker rows as data (one phantom row per chained ledger in every denominator, and a phantom LEGACY gate decision). Shared `isChainMarker` predicate in ledgerChain.ts, both readers skip it, failing-first test. Touches evidenceCoverage, evidenceRelationships, ledgerChain. — Claude Code (phase1-ledgers worktree) PR #1577
 - 2026-09-02 `feat/chain-privacy-shadow` — ADR-0027 follow-on, one ledger: route `privacy_shadow.jsonl` through `appendChained` (rv 1 → 2, markers skipped by the summariser, line-by-line test readers filter marker rows). Touches src/privacy/shadowLog.ts and its tests only. — Claude Code (chain-privacy-shadow worktree) PR #1574
+- 2026-09-02 `feat/chain-outcome-log` — ADR-0027 slice: route `outcome-log.jsonl` through `appendChained`, introduce `OUTCOME_LOG_RV = 1`, skip marker rows ahead of the unkeyable accounting. Touches `src/workers/outcomeStore.ts` and its tests only. — Claude Code (chain-outcome-log worktree) PR #1575
 
 - 2026-09-02 `feat/chain-approval-log` — ADR-0027 slice: route `approval_log.jsonl` through `appendChained` (rv 1 → 2, decision/attribution rows now carry rv, markers ignored by restore, writer-level chain test, line-reading tests skip markers). One ledger only. — Claude Code (chain-approval-log worktree) PR #1576
 - 2026-09-02 `feat/tamper-evident-ledgers` — Phase 1 slice 1: tamper-evident ledgers. ADR for the integrity wire format (per-ledger integrity seq + prevHash behind `rv`, rotation marker, legacy prefix committed by the first chain marker, never backfilled), one shared append primitive (lock → tail read → chain → rotation → append), proven on `boundary_receipts.jsonl` (unlocked writer) and `worker_gate_decisions.jsonl` (rotation), `patchwork evidence verify`, write_failed counter. Touches boundaryReceiptLog, workerGateDecisionLog, evidenceCoverage, index.ts. — Claude Code (phase1-ledgers worktree) PR #1573

--- a/src/__tests__/fileLockSyncWindowsContention.test.ts
+++ b/src/__tests__/fileLockSyncWindowsContention.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `withFileLockSync` on Windows: a contender can see EPERM, not EEXIST.
+ *
+ * The lock is `openSync(lock, "wx")`, and the holder releases with
+ * `unlinkSync`. On Windows a file whose delete is pending stays visible until
+ * every handle closes, and an open against it fails with EPERM (or EBUSY /
+ * EACCES depending on the filesystem filter in the way). The lock helper
+ * treated anything but EEXIST as a real error and threw — so the losing
+ * writer of two concurrent chained appends died on the reference CI matrix,
+ * intermittently, on the Windows cells only.
+ *
+ * The same codes on POSIX are real permission errors and must still throw:
+ * retrying EPERM on a read-only directory would spin until the timeout and
+ * then report a timeout instead of the actual cause.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const openFailures: { code: string; remaining: number } = {
+  code: "EPERM",
+  remaining: 0,
+};
+
+vi.mock("node:fs", async (importOriginal) => {
+  const real = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...real,
+    openSync: (p: import("node:fs").PathLike, ...rest: unknown[]) => {
+      if (String(p).endsWith(".lock") && openFailures.remaining > 0) {
+        openFailures.remaining--;
+        const err = new Error(
+          `${openFailures.code}: operation not permitted, open`,
+        ) as NodeJS.ErrnoException;
+        err.code = openFailures.code;
+        throw err;
+      }
+      return (real.openSync as (...a: unknown[]) => number)(p, ...rest);
+    },
+  };
+});
+
+const { withFileLockSync } = await import("../fileLockSync.js");
+
+let dir: string;
+let file: string;
+const realPlatform = process.platform;
+function setPlatform(p: string) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "lock-win-"));
+  file = path.join(dir, "ledger.jsonl");
+  openFailures.remaining = 0;
+});
+afterEach(() => {
+  setPlatform(realPlatform);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("withFileLockSync under Windows contention codes", () => {
+  for (const code of ["EPERM", "EBUSY", "EACCES"]) {
+    it(`treats ${code} from the lock open as contention on win32 and retries`, () => {
+      setPlatform("win32");
+      openFailures.code = code;
+      openFailures.remaining = 3;
+      const out = withFileLockSync(file, () => "ran", { timeoutMs: 2000 });
+      expect(out).toBe("ran");
+      expect(openFailures.remaining).toBe(0);
+    });
+  }
+
+  it("still throws EPERM on POSIX — a real permission error must not become a timeout", () => {
+    setPlatform("linux");
+    openFailures.code = "EPERM";
+    openFailures.remaining = 1;
+    expect(() =>
+      withFileLockSync(file, () => "ran", { timeoutMs: 500 }),
+    ).toThrow(/EPERM/);
+  });
+
+  it("still times out on win32 when the code never clears, naming the lock", () => {
+    setPlatform("win32");
+    openFailures.code = "EPERM";
+    openFailures.remaining = 1_000_000;
+    expect(() =>
+      withFileLockSync(file, () => "ran", { timeoutMs: 100 }),
+    ).toThrow(/timed out/);
+  });
+});

--- a/src/butler/__tests__/promoteShadowOutcomes.test.ts
+++ b/src/butler/__tests__/promoteShadowOutcomes.test.ts
@@ -56,10 +56,14 @@ function seedLedger(
 function ledgerRows(): Record<string, unknown>[] {
   const p = join(dir, "outcome-log.jsonl");
   try {
-    return readFileSync(p, "utf-8")
-      .split("\n")
-      .filter((l) => l.trim())
-      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    return (
+      readFileSync(p, "utf-8")
+        .split("\n")
+        .filter((l) => l.trim())
+        .map((l) => JSON.parse(l) as Record<string, unknown>)
+        // ADR-0027 marker rows (`chain-start`, `rotation`) are not records.
+        .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+    );
   } catch {
     return [];
   }

--- a/src/fileLockSync.ts
+++ b/src/fileLockSync.ts
@@ -80,7 +80,29 @@ export function withFileLockSync<T>(
       lockFd = openSync(lockFile, "wx", 0o600);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
-      if (code !== "EEXIST") throw err;
+      // EEXIST is contention everywhere. On Windows so are EPERM / EBUSY /
+      // EACCES: a lock whose delete is pending (the holder's `unlinkSync` in
+      // `finally`) stays visible until every handle closes, and an O_EXCL open
+      // against it fails with one of those instead of EEXIST. Treating them as
+      // errors made the losing writer of two concurrent chained appends die —
+      // intermittently, Windows cells only (ADR-0027's cross-process test).
+      // On POSIX the same codes are real permission errors and still throw:
+      // retrying would turn "read-only directory" into "timed out".
+      const contended =
+        code === "EEXIST" ||
+        (process.platform === "win32" &&
+          (code === "EPERM" || code === "EBUSY" || code === "EACCES"));
+      if (!contended) throw err;
+      // Deadline FIRST. The stale-lock branch below `continue`s on ENOENT
+      // (lock cleared between EEXIST and stat), and on Windows a contender
+      // can see EPERM with no lock on disk at all — so a deadline checked only
+      // after the stale branch was never reached on that path, and the wait
+      // was unbounded.
+      if (Date.now() > deadline) {
+        throw new Error(
+          `withFileLockSync: timed out after ${timeoutMs}ms waiting for ${lockFile}`,
+        );
+      }
       // Stale-lock cleanup. Best-effort: another contender may unlink
       // ours simultaneously; that race resolves benignly (next openSync
       // either wins or sees EEXIST again).
@@ -98,11 +120,6 @@ export function withFileLockSync<T>(
         // statSync ENOENT — lock cleared between EEXIST and stat; retry
         // immediately.
         continue;
-      }
-      if (Date.now() > deadline) {
-        throw new Error(
-          `withFileLockSync: timed out after ${timeoutMs}ms waiting for ${lockFile}`,
-        );
       }
       // Busy-spin for ~5ms via hrtime. Node has no sync sleep; under
       // contention the kernel preempts us, so this isn't actually a hot

--- a/src/recipeRoutes.ts
+++ b/src/recipeRoutes.ts
@@ -1427,7 +1427,7 @@ export function tryHandleRecipeRoute(
           //
           // Classified on the source's own typed signal, never on message
           // text. Everything else escaping `upsert` comes from the
-          // `appendFileSync` to outcome-log.jsonl, and answering a disk fault
+          // `appendChained` to outcome-log.jsonl, and answering a disk fault
           // with 400 + the raw message was wrong twice over: it told the
           // operator their input was malformed when the WRITE failed (a 500
           // says "retry", a 400 says "stop, you are wrong"), and it echoed a

--- a/src/recipes/tools/__tests__/outcomes.test.ts
+++ b/src/recipes/tools/__tests__/outcomes.test.ts
@@ -107,8 +107,13 @@ describe("outcomes.classify_issues", () => {
     const after = Date.now();
 
     const logPath = join(tmpHome, "outcome-log.jsonl");
-    const lines = readFileSync(logPath, "utf-8").trim().split("\n");
-    const record = JSON.parse(lines[lines.length - 1] as string);
+    // ADR-0027 marker rows (`chain-start`, `rotation`) are not records.
+    const records = readFileSync(logPath, "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
+    const record = records[records.length - 1] as Record<string, unknown>;
     expect(record.checkedAt).toBeGreaterThanOrEqual(before);
     expect(record.checkedAt).toBeLessThanOrEqual(after);
   });
@@ -129,8 +134,13 @@ describe("outcomes.classify_issues", () => {
     );
 
     const logPath = join(tmpHome, "outcome-log.jsonl");
-    const lines = readFileSync(logPath, "utf-8").trim().split("\n");
-    const record = JSON.parse(lines[lines.length - 1] as string);
+    // ADR-0027 marker rows (`chain-start`, `rotation`) are not records.
+    const records = readFileSync(logPath, "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
+    const record = records[records.length - 1] as Record<string, unknown>;
     expect(record.issueUrl).toBe("https://github.com/o/r/issues/3001");
     expect(record.disposition).toBe("confirmed");
   });

--- a/src/workers/__tests__/outcomeStoreChain.test.ts
+++ b/src/workers/__tests__/outcomeStoreChain.test.ts
@@ -1,0 +1,111 @@
+/**
+ * ADR-0027 — `outcome-log.jsonl` routed through the chained append primitive.
+ *
+ * This ledger is the trust-replay store, and its reader has one property the
+ * other chained ledgers do not: it REPORTS rows it cannot key (`unkeyableRows`)
+ * instead of dropping them. A `chain-start` / `rotation` marker has no key, so
+ * without an explicit skip every load would report a false defect. The tests
+ * here prove the migration boundary (legacy prefix untouched, committed to,
+ * first new row chained), the marker skip, and that the write-side contract —
+ * `upsert` throws on an unkeyable record and writes nothing — survives.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendChained, verifyLedgerChain } from "../../ledgerChain.js";
+import { AmbiguousActionRefError } from "../actionRef.js";
+import { OUTCOME_LOG_RV, OutcomeStore } from "../outcomeStore.js";
+
+let dir: string;
+let file: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "outcome-chain-"));
+  file = path.join(dir, "outcome-log.jsonl");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const dataRows = () =>
+  readFileSync(file, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+    // ADR-0027 marker rows live in the same file and are not records.
+    .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
+
+describe("outcome-log chain", () => {
+  it("chains after a legacy prefix and stamps rv on the new row", () => {
+    const legacy =
+      '{"issueUrl":"https://example.test/issues/1","disposition":"junk","checkedAt":1}\n';
+    writeFileSync(file, legacy);
+
+    const store = new OutcomeStore(dir);
+    store.upsert({
+      issueUrl: "https://example.test/issues/2",
+      disposition: "confirmed",
+      checkedAt: 2,
+      origin: "manual",
+    });
+
+    expect(readFileSync(file, "utf-8").startsWith(legacy)).toBe(true);
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.legacyRows).toBe(1);
+    expect(v.chainedRows).toBe(1);
+
+    const rows = dataRows();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).not.toHaveProperty("rv"); // legacy row never re-stamped
+    expect(rows[1]).toMatchObject({ rv: OUTCOME_LOG_RV, iseq: 1 });
+    expect(typeof rows[1]?.prev).toBe("string");
+
+    expect(store.getDisposition("https://example.test/issues/1")).toBe("junk");
+    expect(store.getDisposition("https://example.test/issues/2")).toBe(
+      "confirmed",
+    );
+    // A fresh instance over the same file agrees.
+    expect(
+      new OutcomeStore(dir).getDisposition("https://example.test/issues/2"),
+    ).toBe("confirmed");
+  });
+
+  it("does not report chain markers as unkeyable rows", () => {
+    appendChained(file, {
+      issueUrl: "https://example.test/issues/9",
+      disposition: "confirmed",
+      checkedAt: 9,
+      rv: OUTCOME_LOG_RV,
+    });
+    const store = new OutcomeStore(dir);
+    expect(store.unkeyableRows()).toEqual([]);
+    expect(store.readAll()).toHaveLength(1);
+    expect(store.readAll()[0]).toMatchObject({
+      issueUrl: "https://example.test/issues/9",
+      disposition: "confirmed",
+    });
+  });
+
+  it("upsert of an unkeyable record still throws and writes nothing", () => {
+    const store = new OutcomeStore(dir);
+    store.upsert({
+      issueUrl: "https://example.test/issues/1",
+      disposition: "confirmed",
+      checkedAt: 1,
+    });
+    const before = readFileSync(file, "utf-8");
+    const headBefore = readFileSync(`${file}.head`, "utf-8");
+
+    expect(() =>
+      store.upsert({ disposition: "confirmed", checkedAt: 2 }),
+    ).toThrowError(AmbiguousActionRefError);
+
+    expect(readFileSync(file, "utf-8")).toBe(before);
+    expect(readFileSync(`${file}.head`, "utf-8")).toBe(headBefore);
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.chainedRows).toBe(1);
+    expect(v.writeFailedPending).toBe(0);
+  });
+});

--- a/src/workers/outcomeStore.ts
+++ b/src/workers/outcomeStore.ts
@@ -1,5 +1,6 @@
-import { appendFileSync, existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import { appendChained } from "../ledgerChain.js";
 import { patchworkHome } from "../patchworkHome.js";
 import {
   type ActionRef,
@@ -44,6 +45,28 @@ export function resolveOutcomeLogDir(override?: string): string {
   );
 }
 
+/**
+ * Record version for `outcome-log.jsonl` — the `rv` sentinel (ADR-0025)
+ * applied to this ledger for the first time, by ADR-0027.
+ *
+ * This ledger had NO `rv` before the chain. Every row written through
+ * `upsert` from now on carries `rv: OUTCOME_LOG_RV` plus the integrity fields
+ * `iseq` / `prev` stamped by `appendChained` from the file's tail under the
+ * lock. At `rv >= 1` the absence of `iseq` or `prev` is a WRITER DEFECT, not
+ * a state this ledger can legitimately represent.
+ *
+ * A row with no `rv` predates the chain. It is never re-stamped: the
+ * `chain-start` marker commits to the legacy prefix as a block (SHA-256 of
+ * the exact bytes), so it is verifiable from the migration boundary without
+ * being touched. Do NOT default `rv` on read — `origin` already defaults
+ * absence deliberately (see its comment), and that is a documented exception
+ * for one field, not a licence for the sentinel.
+ *
+ * `rv` is stamped by the WRITER, after the caller's fields, so a caller
+ * cannot assert a level for a row it did not write.
+ */
+export const OUTCOME_LOG_RV = 1;
+
 export interface OutcomeRecord {
   /**
    * GitHub issue URL — the legacy lookup key, and still the key for any row
@@ -86,6 +109,8 @@ export interface OutcomeRecord {
    * ingester-over-manual is blocked.
    */
   origin?: "manual" | "ingester";
+  /** Record version — see `OUTCOME_LOG_RV`. Absent on rows written before the chain. */
+  rv?: number;
 }
 
 /**
@@ -163,6 +188,13 @@ function parseOutcomeLog(logPath: string): {
       unkeyable.push({ line: i + 1, reason: "malformed-json", excerpt });
       continue;
     }
+    // ADR-0027 marker rows (`chain-start`, `rotation`) live in this file and
+    // carry `kind` and no data fields. They are not records and have no key
+    // BY DESIGN, so they must be skipped BEFORE the unkeyable accounting —
+    // otherwise every load reports a false defect on line 1 of a healthy
+    // ledger, and the operator-facing "your ledger has holes" signal drowns.
+    const kind = (r as { kind?: unknown }).kind;
+    if (kind === "chain-start" || kind === "rotation") continue;
     if (!r.disposition) {
       unkeyable.push({ line: i + 1, reason: "no-disposition", excerpt });
       continue;
@@ -303,8 +335,15 @@ export class OutcomeStore {
         "An outcome record needs a usable key — either `issueUrl` or a `ref` with a tool and an id. Refusing to write a record nothing can look up.",
       );
     }
-    const line = `${JSON.stringify(record)}\n`;
-    appendFileSync(this.logPath, line, "utf-8");
+    // Writer-owned `rv`, stamped after the caller's fields; `appendChained`
+    // then adds `iseq` / `prev` under the cross-process lock (ADR-0027). A
+    // failed append is counted in the write_failed sidecar and rethrown, so
+    // the contract callers already have — fs errors propagate — is unchanged.
+    appendChained(
+      this.logPath,
+      { ...record, rv: OUTCOME_LOG_RV } as Record<string, unknown>,
+      { mode: 0o600 },
+    );
     // Re-seed the shared cache from the post-write file state so this write
     // (and any concurrent writer's) is visible immediately to every
     // OutcomeStore instance pointed at this path — not just this one.


### PR DESCRIPTION
## Summary

ADR-0027 slice: route `outcome-log.jsonl` — the trust-replay store — through the tamper-evident `appendChained` primitive (#1573). One ledger per PR, as the ADR requires; no other ledger is touched.

- `OutcomeStore.upsert` was a bare `appendFileSync` with no lock. It now stamps a writer-owned `rv: OUTCOME_LOG_RV` (this ledger carried no `rv` before) and the primitive adds `iseq`/`prev` under the cross-process lock. fs errors still propagate (now after being counted in the `write_failed` sidecar); the cache reseed after the write is unchanged.
- **Doc comment on `OUTCOME_LOG_RV`**: at `rv >= 1`, absence of `iseq`/`prev` is a writer defect; rows with no `rv` predate the chain and are never re-stamped; the chain-start marker commits to them as a block. `rv` is not defaulted on read — `origin` stays the one documented exception.
- **The reader hazard specific to this ledger**: `parseOutcomeLog` REPORTS rows it cannot key (`unkeyableRows()`) rather than dropping them, and a chain marker has no key by design. Marker rows are skipped BEFORE the unkeyable accounting, with a comment saying why. The test for this failed before the skip (a false `no-disposition` defect on line 1 of a healthy ledger).
- `upsert` of an unkeyable record still throws and writes nothing — chain, head sidecar and failure counter all asserted unchanged.
- Tests that read the file line by line (`promoteShadowOutcomes.test.ts`, `outcomes.test.ts`) skip marker rows the way every production loader does. One stale comment in `recipeRoutes.ts` naming `appendFileSync` updated.

Every writer of this ledger (`outcomes confirm|reject`, `POST /outcomes`, `outcomes.classify_issues`, `butler promote`) already goes through `upsert`, so this is the single write path.

## Verification

- `src/workers/__tests__/outcomeStoreChain.test.ts` — 3 tests, all failed before the change for the intended reasons (no chain, marker reported unkeyable, no head sidecar).
- `npm run typecheck`, `npm run typecheck:tests:core`, full `npx vitest run` green.
- `npm run build && node dist/index.js evidence verify` → `STATUS: INTACT`; `outcome-log.jsonl` reports its legacy rows with no chain yet (the live file is written by the deployed bridge, which predates this change).

Not in this PR: CLAUDE.md / ADR text (a docs PR follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR: Windows lock acquisition (shared path)

The rebased run failed on Windows 24 in the two-writer chain test at lock ACQUISITION. `withFileLockSync` treated anything but EEXIST as an error, but on Windows an exclusive open against a lock whose delete is pending fails with EPERM (or EBUSY / EACCES behind a filesystem filter). Those three codes are now contention on win32 only; on POSIX they still throw. The test for this also exposed that the stale-lock branch retried without consulting the deadline, so a contender could spin unbounded on exactly this path; the deadline is checked first now. Five tests, written first (`fileLockSyncWindowsContention.test.ts`): three codes retry and succeed on win32, EPERM still throws on linux, a code that never clears times out. Full suite 10,925 passed after rebase onto main.