### PR TITLE
feat(evidence): chain approval_log.jsonl through appendChained (ADR-0027)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,8 +52,6 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-09-02 `feat/chain-approval-log` — ADR-0027 slice: route `approval_log.jsonl` through `appendChained` (rv 1 → 2, markers ignored by restore, writer-level chain test). One ledger only. — Claude Code (chain-approval-log worktree)
-
 
 
 ## Recently closed (informal log, prune periodically)
@@ -61,6 +59,7 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 - 2026-09-02 `fix/evidence-skip-markers` — `patchwork evidence` and its relationships view counted ADR-0027 marker rows as data (one phantom row per chained ledger in every denominator, and a phantom LEGACY gate decision). Shared `isChainMarker` predicate in ledgerChain.ts, both readers skip it, failing-first test. Touches evidenceCoverage, evidenceRelationships, ledgerChain. — Claude Code (phase1-ledgers worktree) PR #1577
 - 2026-09-02 `feat/chain-privacy-shadow` — ADR-0027 follow-on, one ledger: route `privacy_shadow.jsonl` through `appendChained` (rv 1 → 2, markers skipped by the summariser, line-by-line test readers filter marker rows). Touches src/privacy/shadowLog.ts and its tests only. — Claude Code (chain-privacy-shadow worktree) PR #1574
 
+- 2026-09-02 `feat/chain-approval-log` — ADR-0027 slice: route `approval_log.jsonl` through `appendChained` (rv 1 → 2, decision/attribution rows now carry rv, markers ignored by restore, writer-level chain test, line-reading tests skip markers). One ledger only. — Claude Code (chain-approval-log worktree) PR #1576
 - 2026-09-02 `feat/tamper-evident-ledgers` — Phase 1 slice 1: tamper-evident ledgers. ADR for the integrity wire format (per-ledger integrity seq + prevHash behind `rv`, rotation marker, legacy prefix committed by the first chain marker, never backfilled), one shared append primitive (lock → tail read → chain → rotation → append), proven on `boundary_receipts.jsonl` (unlocked writer) and `worker_gate_decisions.jsonl` (rotation), `patchwork evidence verify`, write_failed counter. Touches boundaryReceiptLog, workerGateDecisionLog, evidenceCoverage, index.ts. — Claude Code (phase1-ledgers worktree) PR #1573
 
 - 2026-09-01 `feat/governed-profile` — Phase 0 governed runtime: `profile: governed` config + `src/governance/*` (profile resolver, effective policy, kill-switch policy), `patchwork policy explain`, `patchwork doctor` governance section, automated-trigger gating, universal kill switch, subprocess containment, recipe `servers:` allowlist, value-based secret redaction, unified SSRF guard, untrusted-content envelope, adversarial acceptance suite. ADR-0026. Touches recipeOrchestration, both runners, transport, drivers, pluginLoader, stepObservation, http tool. — Claude Code (phase0 worktree)

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-09-02 `feat/chain-approval-log` — ADR-0027 slice: route `approval_log.jsonl` through `appendChained` (rv 1 → 2, markers ignored by restore, writer-level chain test). One ledger only. — Claude Code (chain-approval-log worktree)
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/src/__tests__/approvalAttributionDurable.test.ts
+++ b/src/__tests__/approvalAttributionDurable.test.ts
@@ -58,10 +58,16 @@ afterEach(() => {
 });
 
 function logRows(): Array<Record<string, unknown>> {
-  return readFileSync(path.join(dir, "approval_log.jsonl"), "utf8")
-    .split("\n")
-    .filter(Boolean)
-    .map((l) => JSON.parse(l) as Record<string, unknown>);
+  return (
+    readFileSync(path.join(dir, "approval_log.jsonl"), "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      // ADR-0027 marker rows (`chain-start`, `rotation`) live in the same
+      // file and carry `kind` and no data fields; skipped the way every
+      // production loader skips them.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+  );
 }
 
 async function decide(

--- a/src/__tests__/approvalCorrelationDurable.test.ts
+++ b/src/__tests__/approvalCorrelationDurable.test.ts
@@ -34,6 +34,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { enqueueApprovalWithDispatch } from "../approvalHttp.js";
+import { APPROVAL_LOG_RV } from "../approvalPersistence.js";
 import { ApprovalQueue } from "../approvalQueue.js";
 
 let dir: string;
@@ -46,10 +47,16 @@ afterEach(() => {
 
 function rows(): Array<Record<string, unknown>> {
   const file = path.join(dir, "approval_log.jsonl");
-  return readFileSync(file, "utf8")
-    .split("\n")
-    .filter((l) => l.trim())
-    .map((l) => JSON.parse(l));
+  return (
+    readFileSync(file, "utf8")
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      // ADR-0027 marker rows (`chain-start`, `rotation`) live in the same
+      // file and carry `kind` and no data fields; skipped the way every
+      // production loader skips them.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+  );
 }
 
 function requestRows(): Array<Record<string, unknown>> {
@@ -96,7 +103,7 @@ describe("approval log carries the run it belongs to", () => {
   it("stamps the schema sentinel on every request row it writes", () => {
     const queue = new ApprovalQueue({ persistDir: dir, ttlMs: 60_000 });
     queue.request({ toolName: "t", params: {}, tier: "low" });
-    expect(requestRows()[0]?.rv).toBe(1);
+    expect(requestRows()[0]?.rv).toBe(APPROVAL_LOG_RV);
   });
 
   it("omits correlationId entirely when the approval had no run", () => {
@@ -110,7 +117,7 @@ describe("approval log carries the run it belongs to", () => {
     const req = requestRows()[0];
     expect(req).toBeDefined();
     expect(Object.hasOwn(req as object, "correlationId")).toBe(false);
-    expect(req?.rv).toBe(1);
+    expect(req?.rv).toBe(APPROVAL_LOG_RV);
   });
 
   it("survives the restore round-trip", () => {

--- a/src/__tests__/approvalExpiryDurable.test.ts
+++ b/src/__tests__/approvalExpiryDurable.test.ts
@@ -45,10 +45,16 @@ afterEach(() => {
 
 function readEvents(): Array<Record<string, unknown>> {
   const file = path.join(dir, "approval_log.jsonl");
-  return readFileSync(file, "utf8")
-    .split("\n")
-    .filter((l) => l.trim().length > 0)
-    .map((l) => JSON.parse(l) as Record<string, unknown>);
+  return (
+    readFileSync(file, "utf8")
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      // ADR-0027 marker rows (`chain-start`, `rotation`) live in the same
+      // file and carry `kind` and no data fields; skipped the way every
+      // production loader skips them.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+  );
 }
 
 function requestOne(queue: ApprovalQueue) {

--- a/src/__tests__/approvalLogChain.test.ts
+++ b/src/__tests__/approvalLogChain.test.ts
@@ -1,0 +1,127 @@
+/**
+ * ADR-0027 — `approval_log.jsonl` is chained.
+ *
+ * Verified through the real verifier and the real writers (`ApprovalQueue`
+ * over `ApprovalPersistence`), never through a return value. The file is
+ * seeded with a LEGACY prefix — a request + decision pair in the rv-1 shape,
+ * written before the chain existed — so the test also proves the migration
+ * boundary: legacy bytes untouched, committed to by the `chain-start` marker,
+ * and the first new row chained after them.
+ *
+ * The restore path is exercised on the same file, because marker rows carry
+ * `kind` and no `callId`, and `loadUnresolvedRequests` keys on `kind`. A
+ * marker is neither a request nor a decision and must not break restore.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  APPROVAL_LOG_RV,
+  ApprovalPersistence,
+} from "../approvalPersistence.js";
+import { ApprovalQueue } from "../approvalQueue.js";
+import { verifyLedgerChain } from "../ledgerChain.js";
+
+let dir: string;
+let file: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "pw-approval-chain-"));
+  file = path.join(dir, "approval_log.jsonl");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const allRows = () =>
+  readFileSync(file, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+
+// ADR-0027 marker rows (`chain-start`, `rotation`) live in the same file and
+// carry `kind` and no data fields; skipped the way every production loader
+// skips them.
+const dataRows = () =>
+  allRows().filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
+
+// The rv-1 shape: `rv` on the request only, no integrity fields anywhere.
+const LEGACY =
+  '{"kind":"request","callId":"legacy-1","toolName":"gitPush","params":{},"tier":"high","requestedAt":1000,"expiresAt":null,"rv":1}\n' +
+  '{"kind":"decision","callId":"legacy-1","decision":"approved","decidedAt":2000}\n';
+
+describe("approval log chains after a legacy prefix", () => {
+  it("commits to the legacy rows, chains new request and decision, and restore ignores markers", () => {
+    writeFileSync(file, LEGACY);
+
+    const queue = new ApprovalQueue({ persistDir: dir, ttlMs: 60_000 });
+    const { callId } = queue.request({
+      toolName: "gitPush",
+      params: { remote: "origin" },
+      tier: "high",
+    });
+    queue.approve(callId);
+    // A second request, left undecided, so restore has something to return.
+    const { callId: openId } = queue.request({
+      toolName: "gitPush",
+      params: { remote: "upstream" },
+      tier: "high",
+    });
+
+    // Legacy bytes are untouched.
+    expect(readFileSync(file, "utf-8").startsWith(LEGACY)).toBe(true);
+
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.legacyRows).toBe(2);
+    expect(v.chainedRows).toBe(3);
+
+    const rows = allRows();
+    expect(rows[2]?.kind).toBe("chain-start");
+    const fresh = dataRows().slice(2);
+    expect(fresh.map((r) => r.kind)).toEqual([
+      "request",
+      "decision",
+      "request",
+    ]);
+    expect(fresh.map((r) => r.iseq)).toEqual([1, 2, 3]);
+    for (const r of fresh) {
+      expect(r.rv).toBe(APPROVAL_LOG_RV);
+      expect(typeof r.prev).toBe("string");
+    }
+
+    // Restore: exactly the undecided request, and the marker row neither
+    // counts as a request nor breaks the replay.
+    const unresolved = new ApprovalPersistence({
+      dir,
+    }).loadUnresolvedRequests();
+    expect(unresolved.map((r) => r.callId)).toEqual([openId]);
+    expect(unresolved[0]).toMatchObject({ rv: APPROVAL_LOG_RV, iseq: 3 });
+    expect(typeof unresolved[0]?.prev).toBe("string");
+
+    const restored = new ApprovalQueue({ persistDir: dir, ttlMs: 60_000 });
+    expect(restored.list().map((e) => e.callId)).toEqual([openId]);
+  });
+
+  it("a marker row alone is neither a request nor a decision", () => {
+    writeFileSync(
+      file,
+      `${JSON.stringify({
+        kind: "chain-start",
+        at: 1,
+        legacyRows: 0,
+        legacyBytes: 0,
+        legacyHash:
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      })}\n`,
+    );
+    expect(new ApprovalPersistence({ dir }).loadUnresolvedRequests()).toEqual(
+      [],
+    );
+    expect(new ApprovalQueue({ persistDir: dir }).list()).toEqual([]);
+  });
+
+  it("rv is bumped past the pre-chain level", () => {
+    expect(APPROVAL_LOG_RV).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/__tests__/approvalQueue-durability.test.ts
+++ b/src/__tests__/approvalQueue-durability.test.ts
@@ -21,10 +21,16 @@ afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
 function logLines(): unknown[] {
   const file = path.join(dir, "approval_log.jsonl");
-  return readFileSync(file, "utf8")
-    .split("\n")
-    .filter(Boolean)
-    .map((l) => JSON.parse(l));
+  return (
+    readFileSync(file, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      // ADR-0027 marker rows (`chain-start`, `rotation`) live in the same
+      // file and carry `kind` and no data fields; skipped the way every
+      // production loader skips them.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+  );
 }
 
 describe("ApprovalQueue — no persistDir (default)", () => {

--- a/src/__tests__/approvalQueue-durability.test.ts
+++ b/src/__tests__/approvalQueue-durability.test.ts
@@ -130,14 +130,19 @@ describe("ApprovalQueue — durable persistence", () => {
   });
 
   it("a still-live restored entry auto-expires on its own remaining timer", async () => {
-    const q1 = new ApprovalQueue({ persistDir: dir, ttlMs: { high: 30 } });
+    // The TTL must comfortably exceed the cost of ONE durable append: since
+    // ADR-0027 that append is a lock, a tail read and an atomic head-sidecar
+    // rename, which on a Windows CI runner can take longer than the 30 ms this
+    // test used to allow — the entry then arrived at restore already expired
+    // and the "still-live" branch was never exercised.
+    const q1 = new ApprovalQueue({ persistDir: dir, ttlMs: { high: 500 } });
     q1.request({ toolName: "gitPush", params: {}, tier: "high" });
 
     const q2 = new ApprovalQueue({ persistDir: dir });
     expect(q2.list()).toHaveLength(1);
     expect(q2.list()[0]?.owned).toBe(false);
 
-    await new Promise((r) => setTimeout(r, 60));
+    await new Promise((r) => setTimeout(r, 650));
     expect(q2.list()).toHaveLength(0);
 
     const lines = logLines() as Array<{ kind: string; decision?: string }>;

--- a/src/__tests__/evidenceFieldRoundTrip.test.ts
+++ b/src/__tests__/evidenceFieldRoundTrip.test.ts
@@ -41,6 +41,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ApprovalPersistence } from "../approvalPersistence.js";
 import { ApprovalQueue, type PendingApproval } from "../approvalQueue.js";
 import {
   BOUNDARY_RECEIPTS_BASENAME,
@@ -211,6 +212,31 @@ describe("approval request — every field reaches disk and comes back", () => {
       (k) => !Object.hasOwn(entry as object, k as string),
     );
     expect(lost, "fields lost between the file and list()").toEqual([]);
+  });
+
+  it("stamps the writer-owned fields on every event kind (ADR-0027)", () => {
+    // `rv`, `iseq` and `prev` are never caller input: the writer knows what it
+    // stamps, and the chain position is read from the file's tail. Checked on
+    // the decision row as well as the request, because a row kind the writer
+    // forgets to stamp is exactly the defect this file exists to catch.
+    const q = new ApprovalQueue({ persistDir: dir, ttlMs: 60_000 });
+    const { callId } = q.request(SENTINEL);
+    q.approve(callId);
+    const rows = rowsOf("approval_log.jsonl");
+    expect(rows.map((r) => r.kind)).toEqual(["request", "decision"]);
+    for (const row of rows) {
+      for (const k of ["rv", "iseq", "prev"]) {
+        expect(
+          Object.hasOwn(row as object, k),
+          `writer must stamp ${k} on ${String(row.kind)}`,
+        ).toBe(true);
+      }
+    }
+    // The restore path hands the event back whole, integrity fields included.
+    const [restored] = new ApprovalPersistence({
+      dir,
+    }).loadUnresolvedRequests();
+    expect(restored).toBeUndefined(); // decided — nothing to restore
   });
 });
 

--- a/src/approvalPersistence.ts
+++ b/src/approvalPersistence.ts
@@ -1,8 +1,8 @@
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type { ApprovalDecision, PendingApproval } from "./approvalQueue.js";
-import { withFileLockSync } from "./fileLockSync.js";
 import type { ActorSnapshot } from "./identity/approverFromSession.js";
+import { appendChained } from "./ledgerChain.js";
 import type { Logger } from "./logger.js";
 import { patchworkHome } from "./patchworkHome.js";
 
@@ -52,15 +52,37 @@ import { patchworkHome } from "./patchworkHome.js";
  */
 
 /**
- * Row-schema version stamped on every `request` event this build writes
- * (ADR-0025). Bump only when a field's MEANING changes, never for an additive
- * one: a reader skips a row from a version it does not know rather than
- * guessing, so a gratuitous bump silently drops rows from every existing
- * reader.
+ * Row-schema version stamped on every event this build writes (ADR-0025).
+ * Bump only when a field's MEANING changes, never for an additive one: a
+ * reader skips a row from a version it does not know rather than guessing, so
+ * a gratuitous bump silently drops rows from every existing reader.
+ *
+ *   1 — a `request` row carries `correlationId` when it belonged to a run.
  */
-export const APPROVAL_LOG_RV = 1;
+/**
+ * 2 (ADR-0027): every row — request, decision AND attribution — carries `iseq`
+ * and `prev`, stamped by `appendChained` from the file's tail under the lock.
+ * At `rv >= 2` their absence is a WRITER DEFECT. Rows at `rv 1` (and the
+ * decision/attribution rows written alongside them, which carried no `rv` at
+ * all) predate the chain and are never re-stamped; the `chain-start` marker
+ * commits to them as a block.
+ */
+export const APPROVAL_LOG_RV = 2;
 
-export interface ApprovalRequestEvent {
+/**
+ * ADR-0027 integrity fields, present on every row from `rv >= 2`. Written by
+ * the append primitive, never by a caller: `iseq` is the per-ledger integrity
+ * sequence read from the file's tail, `prev` the SHA-256 of the previous line's
+ * exact bytes. A position in the chain, not a fact about the approval — so the
+ * restore path returns them on the event and does NOT project them onto the
+ * live `PendingApproval`.
+ */
+export interface ChainedRowFields {
+  iseq?: number;
+  prev?: string;
+}
+
+export interface ApprovalRequestEvent extends ChainedRowFields {
   kind: "request";
   callId: string;
   toolName: string;
@@ -97,11 +119,13 @@ export interface ApprovalRequestEvent {
   correlationId?: string;
 }
 
-export interface ApprovalDecisionEvent {
+export interface ApprovalDecisionEvent extends ChainedRowFields {
   kind: "decision";
   callId: string;
   decision: ApprovalDecision;
   decidedAt: number;
+  /** Stamped from `rv >= 2`; a decision row at rv 1 carried no version. */
+  rv?: number;
 }
 
 /**
@@ -110,12 +134,14 @@ export interface ApprovalDecisionEvent {
  * Never written for a shared-secret (v1) session, an expired timer, or the
  * phone path's single-use token — none of those name a person.
  */
-export interface ApprovalAttributionEvent {
+export interface ApprovalAttributionEvent extends ChainedRowFields {
   kind: "attribution";
   callId: string;
   /** id + kind + display name AS IT WAS, never a roster reference. */
   actor: ActorSnapshot;
   attributedAt: number;
+  /** Stamped from `rv >= 2`; an attribution row at rv 1 carried no version. */
+  rv?: number;
 }
 
 export type ApprovalLogEvent =
@@ -205,6 +231,7 @@ export class ApprovalPersistence {
       callId,
       decision,
       decidedAt,
+      rv: APPROVAL_LOG_RV,
     };
     this.append(event);
   }
@@ -224,15 +251,22 @@ export class ApprovalPersistence {
       callId,
       actor,
       attributedAt,
+      rv: APPROVAL_LOG_RV,
     };
     this.append(event);
   }
 
   private append(event: ApprovalLogEvent): void {
     try {
-      mkdirSync(path.dirname(this.file), { recursive: true });
-      withFileLockSync(this.file, () => {
-        appendFileSync(this.file, `${JSON.stringify(event)}\n`, "utf8");
+      // ADR-0027: one locked, chained append. The primitive takes the same
+      // `${file}.lock` sentinel the old `withFileLockSync` wrapper did, so the
+      // wrapper is gone rather than nested (nesting it would wait on itself).
+      // No rotation: this is the governance ledger, and it does not shed rows
+      // (`approvalHttp` says why). Fail-soft contract unchanged — a failed
+      // append is counted in the `.write_failed` sidecar by the primitive and
+      // swallowed here after a warning, never surfaced to a live approval.
+      appendChained(this.file, event as unknown as Record<string, unknown>, {
+        mode: 0o600,
       });
     } catch (err) {
       this.logger?.warn?.(

--- a/src/recipes/__tests__/workerAutonomySmoke.test.ts
+++ b/src/recipes/__tests__/workerAutonomySmoke.test.ts
@@ -68,6 +68,7 @@ vi.mock("../../connectors/github.js", () => ({
     (listIssuesMock as (...a: unknown[]) => unknown)(...args),
 }));
 
+import { APPROVAL_LOG_RV } from "../../approvalPersistence.js";
 import {
   getApprovalQueue,
   resetApprovalQueueForTests,
@@ -358,7 +359,11 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
     )
       .split("\n")
       .filter((l) => l.trim())
-      .map((l) => JSON.parse(l) as Record<string, unknown>);
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      // ADR-0027 marker rows (`chain-start`, `rotation`) live in the same
+      // file and carry `kind` and no data fields; skipped the way every
+      // production loader skips them.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
     const gatedRequest = approvalRows.find(
       (r) => r.kind === "request" && r.toolName === "github.create_issue",
     );
@@ -370,7 +375,7 @@ describe("worker-autonomy smoke (triage-failing-tests-autofile, flag ON)", () =>
       gatedRequest?.correlationId,
       "the approval names the run that needed it",
     ).toBe(run?.taskId);
-    expect(gatedRequest?.rv).toBe(1);
+    expect(gatedRequest?.rv).toBe(APPROVAL_LOG_RV);
 
     // --- D. trust replay + DURABLE-OUTCOME LABELLING ----------------------
     // A just-approved issue write is a non-reversible SUCCESS — it must NOT


### PR DESCRIPTION
## Summary

ADR-0027 slice: route `approval_log.jsonl` — the governance ledger — through the shared tamper-evident append primitive (`appendChained`). One ledger, per the ADR's one-ledger-per-PR rule; no other ledger is touched.

- `ApprovalPersistence.append` replaces its own `withFileLockSync` + `appendFileSync` pair with `appendChained(file, event, { mode: 0o600 })`. The primitive takes the same `${file}.lock` sentinel, so the wrapper is removed rather than nested. No rotation is configured: this ledger does not shed rows. The fail-soft contract is unchanged — a failed append is counted in the `.write_failed` sidecar by the primitive and swallowed here after a warning.
- `APPROVAL_LOG_RV` 1 → 2, with the same doc-comment shape as `BOUNDARY_RECORD_VERSION`: at rv >= 2 absence of `iseq`/`prev` is a writer defect; rv-1 rows are never re-stamped; the `chain-start` marker commits to them as a block. Decision and attribution rows now carry `rv` as well (previously only requests did), so a row kind the writer forgets to stamp is detectable rather than merely unversioned.
- Readers: `loadUnresolvedRequests` and `evidenceRelationships` already key strictly on `kind`, so marker rows (`chain-start`, `rotation`, no `callId`) are ignored the same way any unknown kind is. The exhaustive-switch prohibition stands. The restore path returns the event whole (integrity fields included); they are deliberately NOT projected onto the live `PendingApproval`, because a chain position is a fact about the file, not about the approval.
- The control plane's `approvalMeasures` filters strictly on `kind`, so marker rows are invisible to it and its counts are unchanged.

## Tests

- New `src/__tests__/approvalLogChain.test.ts` (written first, failed, then wired): seeds an rv-1 request+decision pair, writes through the real `ApprovalQueue`, and asserts via `verifyLedgerChain` — `ok`, `legacyPrefix === "verified"`, 2 legacy rows, 3 chained rows with consecutive `iseq`, every new row at `rv: APPROVAL_LOG_RV`; restore returns exactly the undecided request; a lone marker row is neither a request nor a decision.
- `evidenceFieldRoundTrip`: the approval block now asserts `rv`/`iseq`/`prev` are stamped on BOTH request and decision rows. The existing `Required<>` sentinel is over caller input (`PendingApproval`) and the integrity fields are writer-owned, so they are guarded the way the gate block guards `seq`/`decidedAt` rather than added to the input sentinel.
- Every test that reads `approval_log.jsonl` line-by-line skips marker rows with the shared filter + comment; `rv` assertions read the constant instead of a literal `1`.

## Verification

- `npm run typecheck`, `npm run typecheck:tests:core`, full `npx vitest run`: green.
- `npm run build && node dist/index.js evidence verify`: see status line in the PR conversation.

Not in this PR: CLAUDE.md / ADR text (docs PR follows), any other ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
