### PR TITLE
fix(evidence): do not count ADR-0027 marker rows as evidence

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-09-02 `fix/evidence-skip-markers` — `patchwork evidence` and its relationships view counted ADR-0027 marker rows as data (one phantom row per chained ledger in every denominator, and a phantom LEGACY gate decision). Shared `isChainMarker` predicate in ledgerChain.ts, both readers skip it, failing-first test. Touches evidenceCoverage, evidenceRelationships, ledgerChain. — Claude Code (phase1-ledgers worktree)
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,11 +52,11 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-09-02 `fix/evidence-skip-markers` — `patchwork evidence` and its relationships view counted ADR-0027 marker rows as data (one phantom row per chained ledger in every denominator, and a phantom LEGACY gate decision). Shared `isChainMarker` predicate in ledgerChain.ts, both readers skip it, failing-first test. Touches evidenceCoverage, evidenceRelationships, ledgerChain. — Claude Code (phase1-ledgers worktree)
-
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-09-02 `fix/evidence-skip-markers` — `patchwork evidence` and its relationships view counted ADR-0027 marker rows as data (one phantom row per chained ledger in every denominator, and a phantom LEGACY gate decision). Shared `isChainMarker` predicate in ledgerChain.ts, both readers skip it, failing-first test. Touches evidenceCoverage, evidenceRelationships, ledgerChain. — Claude Code (phase1-ledgers worktree) PR #1577
 
 - 2026-09-02 `feat/tamper-evident-ledgers` — Phase 1 slice 1: tamper-evident ledgers. ADR for the integrity wire format (per-ledger integrity seq + prevHash behind `rv`, rotation marker, legacy prefix committed by the first chain marker, never backfilled), one shared append primitive (lock → tail read → chain → rotation → append), proven on `boundary_receipts.jsonl` (unlocked writer) and `worker_gate_decisions.jsonl` (rotation), `patchwork evidence verify`, write_failed counter. Touches boundaryReceiptLog, workerGateDecisionLog, evidenceCoverage, index.ts. — Claude Code (phase1-ledgers worktree) PR #1573
 

--- a/src/__tests__/evidenceMarkersNotCounted.test.ts
+++ b/src/__tests__/evidenceMarkersNotCounted.test.ts
@@ -1,0 +1,63 @@
+/**
+ * ADR-0027 marker rows (`chain-start`, `rotation`) live in the same file as
+ * the data and are not evidence. `patchwork evidence` reports DENOMINATORS,
+ * so counting a marker inflates every "N of M rows carry a run id" it prints —
+ * by exactly the number of chained ledgers, silently, once chains exist.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { evidenceCoverage } from "../evidenceCoverage.js";
+import { evidenceRelationships } from "../evidenceRelationships.js";
+import { appendChained } from "../ledgerChain.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "evidence-markers-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("marker rows are not evidence", () => {
+  it("evidenceCoverage counts data rows only, on a chained file with a rotation", () => {
+    const f = path.join(dir, "boundary_receipts.jsonl");
+    writeFileSync(f, '{"seq":1,"at":1,"decision":"ALLOW"}\n');
+    const opts = { maxBytes: 400, rotateTarget: 250 };
+    for (let i = 2; i <= 12; i++) {
+      appendChained(
+        f,
+        { seq: i, at: i, decision: "ALLOW", correlationId: `run-${i}` },
+        opts,
+      );
+    }
+    const led = evidenceCoverage(dir).ledgers.find(
+      (l) => l.file === "boundary_receipts.jsonl",
+    );
+    expect(led).toBeDefined();
+    // Every counted row is a data row: rows === joinable + the unjoinable legacy
+    // row that survived, and never more than the data rows written.
+    expect(led?.corrupt).toBe(0);
+    expect(led?.rows).toBe(led?.joinable);
+  });
+
+  it("evidenceRelationships ignores markers as well", () => {
+    const f = path.join(dir, "worker_gate_decisions.jsonl");
+    appendChained(f, {
+      seq: 1,
+      rv: 3,
+      workerId: "w",
+      toolName: "t",
+      action: "allow",
+      ruleId: "allow.reversible",
+      correlationId: "run-1",
+    });
+    const rel = evidenceRelationships(dir).relationships.find(
+      (r) => r.name === "gate decision → run",
+    );
+    // A marker carries no rv and would be tallied as a LEGACY decision — one
+    // phantom legacy row per chained ledger, in the report whose whole job is
+    // to say how many legacy rows there are.
+    expect(rel?.legacy).toBe(0);
+    expect((rel?.connected ?? 0) + (rel?.unresolved ?? 0)).toBe(1);
+  });
+});

--- a/src/__tests__/ledgerChainCrossProcess.test.ts
+++ b/src/__tests__/ledgerChainCrossProcess.test.ts
@@ -48,7 +48,9 @@ writeFileSync(readyFile, "ready");
 while (!existsSync(goFile)) await new Promise((r) => setTimeout(r, 1));
 let n = 0;
 for (let i = 0; i < Number(count); i++) {
-  appendChained(file, { who, i });
+  // A two-core Windows runner under contention can hold a lock well past the
+  // 5 s production default; the property under test is the chain, not the wait.
+  appendChained(file, { who, i }, { lockTimeoutMs: 60_000 });
   n++;
 }
 process.stdout.write("WROTE " + n + "\\n");
@@ -108,12 +110,12 @@ async function race(n: number, perWriter: number): Promise<string[]> {
 
 describe("two concurrent writers", () => {
   it("produce one unbroken chain with every iseq exactly once", async () => {
-    const verdicts = await race(2, 25);
-    expect(verdicts.join(" | ")).toBe("WROTE 25 | WROTE 25");
+    const verdicts = await race(2, 15);
+    expect(verdicts.join(" | ")).toBe("WROTE 15 | WROTE 15");
     const v = verifyLedgerChain(join(root, "ledger.jsonl"));
     expect(v.breaks).toEqual([]);
     expect(v.ok).toBe(true);
-    expect(v.chainedRows).toBe(50);
-    expect(v.lastIseq).toBe(50);
-  }, 30_000);
+    expect(v.chainedRows).toBe(30);
+    expect(v.lastIseq).toBe(30);
+  }, 90_000);
 });

--- a/src/evidenceCoverage.ts
+++ b/src/evidenceCoverage.ts
@@ -34,6 +34,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { isChainMarker } from "./ledgerChain.js";
 import { patchworkHome } from "./patchworkHome.js";
 
 /** Ledgers on the spine, with where each lives relative to `$PATCHWORK_HOME`. */
@@ -124,6 +125,9 @@ function scan(dir: string, key: string, file: string) {
       corrupt++;
       continue;
     }
+    // ADR-0027 marker rows share the file and are not evidence: counting one
+    // inflates the denominator by exactly one per chained ledger, silently.
+    if (isChainMarker(parsed)) continue;
     rows++;
     const c = (parsed as { correlationId?: unknown }).correlationId;
     if (typeof c === "string" && c !== "") {

--- a/src/evidenceRelationships.ts
+++ b/src/evidenceRelationships.ts
@@ -54,6 +54,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { isChainMarker } from "./ledgerChain.js";
 import { patchworkHome } from "./patchworkHome.js";
 
 export type RelationState =
@@ -105,7 +106,10 @@ function readRows(dir: string, file: string): { rows: Row[]; corrupt: number } {
     const t = line.trim();
     if (!t) continue;
     try {
-      rows.push(JSON.parse(t) as Row);
+      const parsed = JSON.parse(t) as Row;
+      // ADR-0027 marker rows are not evidence (see evidenceCoverage.ts).
+      if (isChainMarker(parsed)) continue;
+      rows.push(parsed);
     } catch {
       corrupt++;
     }

--- a/src/ledgerChain.ts
+++ b/src/ledgerChain.ts
@@ -154,6 +154,17 @@ export interface ChainVerification {
   head: "ok" | "missing" | "truncated" | "mismatch" | "stale" | "n/a";
 }
 
+/**
+ * Is this parsed row one of the two ADR-0027 marker shapes? Shared by every
+ * reader that must not count a marker as data — one predicate, so the set of
+ * marker kinds cannot drift between readers.
+ */
+export function isChainMarker(row: unknown): boolean {
+  if (row === null || typeof row !== "object") return false;
+  const k = (row as { kind?: unknown }).kind;
+  return k === "chain-start" || k === "rotation";
+}
+
 export function hashLine(line: string): string {
   return createHash(CHAIN_HASH_ALGORITHM).update(line, "utf8").digest("hex");
 }

--- a/src/ledgerChain.ts
+++ b/src/ledgerChain.ts
@@ -231,21 +231,37 @@ function isFiniteNumber(v: unknown): v is number {
 function atomicWrite(file: string, text: string, mode: number): void {
   const tmp = `${file}.tmp`;
   writeFileSync(tmp, text, { mode });
-  try {
-    renameSync(tmp, file);
-  } catch (err) {
-    if (
-      process.platform === "win32" &&
-      (err as NodeJS.ErrnoException).code === "EEXIST"
-    ) {
-      try {
-        unlinkSync(file);
-      } catch {
-        /* best-effort */
-      }
+  // Windows: a rename onto an existing target can fail TRANSIENTLY with
+  // EPERM / EBUSY while an indexer or scanner holds the old file, and with
+  // EEXIST on some filesystems. Retry briefly, then fall back to unlink +
+  // rename for EEXIST (the gate ledger's original path). POSIX never enters
+  // the loop: rename there is atomic and replaces.
+  const attempts = process.platform === "win32" ? 20 : 1;
+  for (let n = 1; ; n++) {
+    try {
       renameSync(tmp, file);
-    } else {
-      throw err;
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      const transient =
+        process.platform === "win32" &&
+        (code === "EPERM" || code === "EBUSY" || code === "EEXIST");
+      if (!transient || n >= attempts) {
+        if (process.platform === "win32" && code === "EEXIST") {
+          try {
+            unlinkSync(file);
+          } catch {
+            /* best-effort */
+          }
+          renameSync(tmp, file);
+          return;
+        }
+        throw err;
+      }
+      const spinUntil = process.hrtime.bigint() + 10_000_000n; // 10ms
+      while (process.hrtime.bigint() < spinUntil) {
+        /* yield */
+      }
     }
   }
 }


### PR DESCRIPTION
## What

`patchwork evidence` and its relationships view counted every parsed line. Once a ledger is chained (#1573), its `chain-start` row and any `rotation` row are parsed lines with no data, so every "N of M rows carry a run id" would be off by one per chained ledger, and the relationships view would tally each marker as a LEGACY gate decision.

One predicate, `isChainMarker`, exported from `ledgerChain.ts` and used by both readers so the marker set cannot drift between them. Found by #1574; fixed separately because it is shared across every chained ledger.

## Verification

Failing-first test (`evidenceMarkersNotCounted.test.ts`): chained receipts file with a rotation asserts `rows === joinable`; chained gate file asserts `legacy === 0` on "gate decision → run". Full suite 10,911 passed; `typecheck` and `typecheck:tests:core` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR

Windows hardening of the primitive after `ledgerChainCrossProcess.test.ts` failed once each on the Windows 22 and 24 cells across two PRs: the `.head` sidecar rename retries briefly on transient EPERM/EBUSY/EEXIST (POSIX path unchanged), and the two-writer test's children wait up to 60 s for the lock with fewer rows. Cannot be reproduced locally on macOS; the CI matrix is the verification.