### PR TITLE
feat(evidence): chain butler_outcome_shadow.jsonl behind rv 1 (ADR-0027, wave 2 PR 1)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,11 +52,11 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-09-02 `feat/chain-butler-outcome-shadow` — ADR-0027 wave 2, PR 1 of 3: chain `butler_outcome_shadow.jsonl` (real path; no rename) through `appendChained`, new writer-owned `rv: 1`, readers skip marker rows explicitly, verifier gets its own ledger list (spine + this file) so `patchwork evidence` denominators do not change. Touches src/butler/outcomeShadowLog.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-butler-shadow worktree)
-
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-09-02 `feat/chain-butler-outcome-shadow` — ADR-0027 wave 2, PR 1 of 3: chain `butler_outcome_shadow.jsonl` (real path; no rename) through `appendChained`, new writer-owned `rv: 1`, readers skip marker rows explicitly, verifier gets its own ledger list (spine + this file) so `patchwork evidence` denominators do not change. Touches src/butler/outcomeShadowLog.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-butler-shadow worktree) PR #1578
 
 - 2026-09-02 `fix/evidence-skip-markers` — `patchwork evidence` and its relationships view counted ADR-0027 marker rows as data (one phantom row per chained ledger in every denominator, and a phantom LEGACY gate decision). Shared `isChainMarker` predicate in ledgerChain.ts, both readers skip it, failing-first test. Touches evidenceCoverage, evidenceRelationships, ledgerChain. — Claude Code (phase1-ledgers worktree) PR #1577
 - 2026-09-02 `feat/chain-privacy-shadow` — ADR-0027 follow-on, one ledger: route `privacy_shadow.jsonl` through `appendChained` (rv 1 → 2, markers skipped by the summariser, line-by-line test readers filter marker rows). Touches src/privacy/shadowLog.ts and its tests only. — Claude Code (chain-privacy-shadow worktree) PR #1574

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-09-02 `feat/chain-butler-outcome-shadow` — ADR-0027 wave 2, PR 1 of 3: chain `butler_outcome_shadow.jsonl` (real path; no rename) through `appendChained`, new writer-owned `rv: 1`, readers skip marker rows explicitly, verifier gets its own ledger list (spine + this file) so `patchwork evidence` denominators do not change. Touches src/butler/outcomeShadowLog.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-butler-shadow worktree)
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/src/__tests__/evidenceVerify.test.ts
+++ b/src/__tests__/evidenceVerify.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SPINE_LEDGERS } from "../evidenceCoverage.js";
 import {
   formatEvidenceVerify,
+  VERIFIED_LEDGERS,
   verifyEvidenceChains,
 } from "../evidenceVerify.js";
 import { appendChained, recordWriteFailure } from "../ledgerChain.js";
@@ -27,9 +28,12 @@ const ledger = (name: string) => path.join(dir, name);
 describe("verifyEvidenceChains", () => {
   it("covers every spine ledger and reports absent ones as absent and ok", () => {
     const r = verifyEvidenceChains(dir);
+    // The verifier's list is the spine PLUS non-spine chained ledgers; the
+    // spine itself is the coverage/correlation set and must not grow here.
     expect(r.ledgers.map((l) => l.file)).toEqual(
-      SPINE_LEDGERS.map((l) => l.file),
+      VERIFIED_LEDGERS.map((l) => l.file),
     );
+    expect(r.ledgers.length).toBeGreaterThan(SPINE_LEDGERS.length);
     expect(r.ledgers.every((l) => l.absent)).toBe(true);
     expect(r.ok).toBe(true);
   });

--- a/src/butler/__tests__/errandOutcomeGrader.test.ts
+++ b/src/butler/__tests__/errandOutcomeGrader.test.ts
@@ -234,7 +234,9 @@ describe("shadow ledger", () => {
     const rows = readFileSync(shadowLogPath(dir), "utf-8")
       .trim()
       .split("\n")
-      .map((l) => JSON.parse(l));
+      .map((l) => JSON.parse(l))
+      // ADR-0027 marker rows (`chain-start`, `rotation`) are not graded rows.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation");
     expect(rows).toHaveLength(1);
     expect(rows[0].wouldCountAsEvidence).toBe(true);
   });
@@ -249,7 +251,13 @@ describe("shadow ledger", () => {
       },
       { dir },
     );
-    const row = JSON.parse(readFileSync(shadowLogPath(dir), "utf-8").trim());
+    const row = readFileSync(shadowLogPath(dir), "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l))
+      // ADR-0027 marker rows (`chain-start`, `rotation`) are not graded rows.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+      .at(-1);
     expect(row.wouldCountAsEvidence).toBe(false);
   });
 
@@ -317,7 +325,15 @@ describe("SHADOW means shadow — the trust fold must not read this file", () =>
       .split("\n")
       .filter(Boolean)
       .filter((f) => !f.includes("__tests__"));
-    expect(hits).toEqual(["src/butler/outcomeShadowLog.ts"]);
+    // `evidenceVerify.ts` names the file so `patchwork evidence verify` can
+    // walk its hash chain (ADR-0027). It reads BYTES for integrity, never a
+    // disposition, and nothing it returns reaches the trust fold — which is
+    // the property this guard protects. Any third entry here needs the same
+    // justification written down.
+    expect(hits.sort()).toEqual([
+      "src/butler/outcomeShadowLog.ts",
+      "src/evidenceVerify.ts",
+    ]);
   });
 
   it("only the ingester and the CLI reach the shadow ledger's module", () => {

--- a/src/butler/__tests__/outcomeIngester.test.ts
+++ b/src/butler/__tests__/outcomeIngester.test.ts
@@ -46,10 +46,14 @@ afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
 function rows(): Record<string, unknown>[] {
   const text = readFileSync(path.join(dir, SHADOW_LOG_BASENAME), "utf-8");
-  return text
-    .split("\n")
-    .filter((l) => l.trim())
-    .map((l) => JSON.parse(l) as Record<string, unknown>);
+  return (
+    text
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      // ADR-0027 marker rows (`chain-start`, `rotation`) are not graded rows.
+      .filter((r) => r.kind !== "chain-start" && r.kind !== "rotation")
+  );
 }
 
 describe("grading a batch", () => {

--- a/src/butler/__tests__/outcomeShadowLogChain.test.ts
+++ b/src/butler/__tests__/outcomeShadowLogChain.test.ts
@@ -1,0 +1,204 @@
+/**
+ * ADR-0027 wave 2, PR 1 — `butler_outcome_shadow.jsonl` is chained.
+ *
+ * The writer was a bare best-effort `appendFileSync`: no lock, no integrity
+ * fields, and a failed append indistinguishable from a quiet day. It now goes
+ * through `appendChained`, keeps its never-throw contract (a measurement must
+ * never fail the errand it observes), and gains a writer-owned `rv: 1`.
+ *
+ * Every reader of this ledger validates rows by shape, so marker rows fell out
+ * by accident before this PR. The tests here make that explicit: a marker is
+ * metadata, never a graded outcome, in the summary, in first-seen and in the
+ * rows promotion reads.
+ *
+ * The verifier gains this ledger; `patchwork evidence` coverage does NOT. The
+ * spine list is the correlation set and adding a non-spine ledger there would
+ * change denominators an operator is already reading.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SPINE_LEDGERS } from "../../evidenceCoverage.js";
+import {
+  VERIFIED_LEDGERS,
+  verifyEvidenceChains,
+} from "../../evidenceVerify.js";
+import { chainSidecarPaths, verifyLedgerChain } from "../../ledgerChain.js";
+import {
+  appendShadowOutcome,
+  firstSeenByRef,
+  readShadowRows,
+  SHADOW_LOG_BASENAME,
+  SHADOW_OUTCOME_RV,
+  shadowLogPath,
+  summariseShadowLog,
+} from "../outcomeShadowLog.js";
+
+let dir: string;
+let file: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "butler-shadow-chain-"));
+  file = shadowLogPath(dir);
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const physicalRows = () =>
+  readFileSync(file, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+
+const grade = (
+  ref: string,
+  disposition: "confirmed" | "junk" | "unknown",
+  gradedAt: number,
+) =>
+  appendShadowOutcome(
+    {
+      ref,
+      disposition,
+      reason: "completed",
+      gradedAt,
+      recipe: "noisy-recipe",
+    },
+    { dir },
+  );
+
+const LEGACY =
+  '{"ref":"todoist.create_task:1","disposition":"unknown","reason":"open-recent","gradedAt":1000,"wouldCountAsEvidence":false}\n';
+
+describe("the writer", () => {
+  it("stamps rv, iseq and prev and produces a chain the verifier accepts", () => {
+    grade("todoist.create_task:1", "confirmed", 2000);
+    grade("todoist.create_task:2", "junk", 3000);
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.chainedRows).toBe(2);
+    expect(v.head).toBe("ok");
+    const data = physicalRows().filter((r) => r.kind === undefined);
+    expect(data[0]).toMatchObject({ rv: SHADOW_OUTCOME_RV, iseq: 1 });
+    expect(data[1]).toMatchObject({ rv: SHADOW_OUTCOME_RV, iseq: 2 });
+    expect(typeof data[1]?.prev).toBe("string");
+  });
+
+  it("leaves a legacy ledger byte-identical and commits to it with chain-start", () => {
+    writeFileSync(file, LEGACY);
+    grade("todoist.create_task:1", "confirmed", 2000);
+    expect(readFileSync(file, "utf-8").startsWith(LEGACY)).toBe(true);
+    expect(physicalRows()[0]).not.toHaveProperty("rv");
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.legacyRows).toBe(1);
+    expect(v.chainedRows).toBe(1);
+  });
+
+  it("acquires the SHARED lock: a stale lock left by a dead writer is cleared, not fatal", () => {
+    const lock = `${file}.lock`;
+    writeFileSync(lock, "");
+    const old = new Date(Date.now() - 120_000);
+    utimesSync(lock, old, old);
+    grade("todoist.create_task:1", "confirmed", 2000);
+    expect(existsSync(lock)).toBe(false);
+    expect(verifyLedgerChain(file).chainedRows).toBe(1);
+  });
+
+  it("still never throws on a failed append, and the failure becomes visible then sealed", () => {
+    // The ledger path is a DIRECTORY, so the append fails (EISDIR) while the
+    // sidecar beside it can still be written.
+    mkdirSync(file);
+    expect(() =>
+      grade("todoist.create_task:1", "confirmed", 2000),
+    ).not.toThrow();
+    expect(existsSync(chainSidecarPaths(file).writeFailed)).toBe(true);
+    rmSync(file, { recursive: true, force: true });
+    // Ledger absent, failure pending: two different facts, both reported.
+    let v = verifyLedgerChain(file);
+    expect(v.absent).toBe(true);
+    expect(v.writeFailedPending).toBe(1);
+    grade("todoist.create_task:1", "confirmed", 3000);
+    v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.writeFailedPending).toBe(0);
+    expect(v.writeFailedSealed).toBe(1);
+  });
+});
+
+describe("readers treat marker rows as metadata, never as graded outcomes", () => {
+  beforeEach(() => {
+    writeFileSync(file, LEGACY);
+    grade("todoist.create_task:1", "confirmed", 2000);
+    grade("todoist.create_task:2", "unknown", 2500);
+    // The physical file now holds: legacy row, chain-start marker, two rows.
+    expect(physicalRows().some((r) => r.kind === "chain-start")).toBe(true);
+  });
+
+  it("summary counts errands (last grade wins), not markers", () => {
+    const s = summariseShadowLog({ dir });
+    expect(s.total).toBe(2);
+    expect(s.confirmed).toBe(1);
+    expect(s.unknown).toBe(1);
+  });
+
+  it("first-seen has one entry per ref and no entry for a marker", () => {
+    const seen = firstSeenByRef({ dir });
+    expect([...seen.keys()].sort()).toEqual([
+      "todoist.create_task:1",
+      "todoist.create_task:2",
+    ]);
+    expect(seen.get("todoist.create_task:1")).toBe(1000);
+  });
+
+  it("the rows promotion reads are all graded rows", () => {
+    const rows = readShadowRows(dir);
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => typeof r.ref === "string" && !("kind" in r))).toBe(
+      true,
+    );
+  });
+
+  it("a marker that LOOKS like a row is still skipped by kind, not by luck", () => {
+    // A future marker shape that happened to carry `ref` and `disposition`
+    // must still be excluded — the skip is on `kind`, not on missing fields.
+    writeFileSync(
+      file,
+      `${readFileSync(file, "utf-8")}{"kind":"rotation","ref":"x:1","disposition":"confirmed","gradedAt":9,"droppedRows":0,"droppedLegacyRows":0,"lastDroppedHash":null,"lastDroppedIseq":null,"firstKeptIseq":null}\n`,
+    );
+    expect(readShadowRows(dir).some((r) => r.ref === "x:1")).toBe(false);
+    expect(firstSeenByRef({ dir }).has("x:1")).toBe(false);
+  });
+});
+
+describe("verifier and coverage lists", () => {
+  it("the verifier covers the spine PLUS this ledger", () => {
+    expect(VERIFIED_LEDGERS.map((l) => l.file)).toEqual([
+      ...SPINE_LEDGERS.map((l) => l.file),
+      SHADOW_LOG_BASENAME,
+    ]);
+    grade("todoist.create_task:1", "confirmed", 2000);
+    const r = verifyEvidenceChains(dir);
+    expect(r.ledgers.find((l) => l.file === SHADOW_LOG_BASENAME)).toMatchObject(
+      {
+        absent: false,
+        chainedRows: 1,
+        ok: true,
+      },
+    );
+  });
+
+  it("patchwork evidence coverage does NOT gain a Butler shadow denominator", () => {
+    expect(SPINE_LEDGERS.some((l) => l.file === SHADOW_LOG_BASENAME)).toBe(
+      false,
+    );
+  });
+});

--- a/src/butler/outcomeShadowLog.ts
+++ b/src/butler/outcomeShadowLog.ts
@@ -30,8 +30,9 @@
  * measured before/after on the real log, exactly as #1319 required.
  */
 
-import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { appendChained, isChainMarker } from "../ledgerChain.js";
 
 import { patchworkHome } from "../patchworkHome.js";
 import type { OutcomeDisposition } from "../workers/outcomeStore.js";
@@ -43,6 +44,17 @@ import type { GradedOutcome } from "./errandOutcomeGrader.js";
  * up by accident.
  */
 export const SHADOW_LOG_BASENAME = "butler_outcome_shadow.jsonl";
+
+/**
+ * Record level (ADR-0025's `rv` protocol; ADR-0027 for this ledger).
+ *
+ * 1: every row is written through `appendChained` and carries `iseq` and
+ * `prev`, stamped by the writer from the file's tail under the lock. At
+ * `rv >= 1` their absence is a WRITER DEFECT. Rows with no `rv` predate the
+ * chain; they are never re-stamped, and the `chain-start` marker commits to
+ * them as a block. Never default it on read.
+ */
+export const SHADOW_OUTCOME_RV = 1;
 
 export function shadowLogPath(override?: string): string {
   return path.join(override ?? patchworkHome(), SHADOW_LOG_BASENAME);
@@ -68,6 +80,11 @@ export interface ShadowOutcomeRow {
    * withholding rule and risk deriving it differently.
    */
   wouldCountAsEvidence: boolean;
+  /** Writer-stamped record level. Absent on rows that predate the chain. */
+  rv?: number;
+  /** ADR-0027 integrity position and previous-line hash (rv >= 1). */
+  iseq?: number;
+  prev?: string;
 }
 
 /** `unknown` is withheld by the fold; the other two are evidence. */
@@ -86,9 +103,19 @@ export function appendShadowOutcome(
   const full: ShadowOutcomeRow = {
     ...row,
     wouldCountAsEvidence: wouldCountAsEvidence(row.disposition),
+    // Stamped AFTER the caller's fields so a caller cannot claim a level.
+    rv: SHADOW_OUTCOME_RV,
   };
   try {
-    appendFileSync(shadowLogPath(opts.dir), `${JSON.stringify(full)}\n`);
+    // ADR-0027: locked, chained append. The old bare `appendFileSync` had no
+    // lock (two bridges could tear a row) and a failed append left the same
+    // bytes as a quiet day. The primitive counts the failure in the
+    // `.write_failed` sidecar and rethrows; the swallow below is unchanged.
+    appendChained(
+      shadowLogPath(opts.dir),
+      full as unknown as Record<string, unknown>,
+      { mode: 0o600 },
+    );
   } catch {
     // Swallowed on purpose. See above: an unwritable shadow ledger must not
     // turn into an errand failure.
@@ -126,6 +153,9 @@ export function firstSeenByRef(
     } catch {
       continue;
     }
+    // ADR-0027 marker rows are metadata, never an observation — skipped by
+    // KIND, so a marker that happened to carry a ref could not sneak in.
+    if (isChainMarker(row)) continue;
     if (typeof row.ref !== "string" || typeof row.gradedAt !== "number") {
       continue;
     }
@@ -271,6 +301,9 @@ export function parseShadowRows(text: string): ShadowOutcomeRow[] {
     } catch {
       continue;
     }
+    // ADR-0027 marker rows are metadata, never a graded row — by KIND, so a
+    // future marker shape carrying a ref and a disposition is still excluded.
+    if (isChainMarker(row)) continue;
     if (
       row.disposition !== "confirmed" &&
       row.disposition !== "junk" &&

--- a/src/evidenceVerify.ts
+++ b/src/evidenceVerify.ts
@@ -2,7 +2,7 @@
  * `patchwork evidence verify` — is the evidence spine internally intact?
  *
  * The offline reader ADR-0027 pairs with `appendChained`. Walks every ledger
- * on `SPINE_LEDGERS` through `verifyLedgerChain` and reduces to one verdict.
+ * on `VERIFIED_LEDGERS` through `verifyLedgerChain` and reduces to one verdict.
  *
  * Unlike `patchwork evidence`, this one GATES: `ok: false` and exit 1 on any
  * break, on a legacy-prefix mismatch, on a head sidecar that says the file
@@ -31,11 +31,23 @@ export interface EvidenceVerification {
   ledgers: LedgerVerification[];
 }
 
+/**
+ * What `evidence verify` walks: the spine PLUS chained ledgers that are not
+ * on it. Kept SEPARATE from `SPINE_LEDGERS` on purpose — that list is the
+ * correlation/coverage set behind `patchwork evidence`'s denominators, and a
+ * ledger that carries no run id has no business in a "rows carry a run id"
+ * count. Wave 2 of ADR-0027 appends here, one ledger per PR.
+ */
+export const VERIFIED_LEDGERS: ReadonlyArray<{ key: string; file: string }> = [
+  ...SPINE_LEDGERS,
+  { key: "butler outcome shadow", file: "butler_outcome_shadow.jsonl" },
+];
+
 export function verifyEvidenceChains(
   dir = patchworkHome(),
 ): EvidenceVerification {
   const ledgers: LedgerVerification[] = [];
-  for (const { key, file } of SPINE_LEDGERS) {
+  for (const { key, file } of VERIFIED_LEDGERS) {
     const v = verifyLedgerChain(path.join(dir, file));
     ledgers.push({ ...v, key, file });
   }


### PR DESCRIPTION
## What

ADR-0027 wave 2, PR 1 of 3. Chains the Butler outcome-shadow ledger and nothing else.

- **Writer**: `appendShadowOutcome` writes through `appendChained` (lock, `iseq`, `prev`, head sidecar, write-failure counter). Its never-throw contract is unchanged: a measurement must never fail the errand it observes.
- **`rv: 1`** introduced for this ledger (it had none), writer-owned and stamped after the caller's fields. Legacy rows are byte-identical, never re-stamped; the chain-start marker commits to them as a block.
- **Path unchanged**: `$PATCHWORK_HOME/butler_outcome_shadow.jsonl`. No rename, no migration.
- **Readers** (`firstSeenByRef`, `parseShadowRows`, hence summary and the rows promotion reads) skip marker rows explicitly by `kind`, not by missing fields.
- **Verifier list split**: `VERIFIED_LEDGERS` = spine + this file. `SPINE_LEDGERS` (the correlation set behind `patchwork evidence` denominators) is unchanged. The grader's reader guard now allows `evidenceVerify.ts` with the reason recorded: it reads bytes for integrity, never a disposition, and feeds no fold.

## Verification

Failing-first tests (`outcomeShadowLogChain.test.ts`): writer stamps and verifies; legacy prefix untouched and committed; stale shared lock cleared; failed append swallowed, pending, then sealed; summary / first-seen / promotion rows ignore markers including one shaped like a row; verifier includes the ledger and coverage does not. The old verifier equality assertion was the red test for the list split.

Full suite 10,935 passed; `typecheck` and `typecheck:tests:core` clean; biome clean. Run against a **copy** of the reference machine's ledger: 41 legacy rows committed and byte-identical, 2 chained, head ok, STATUS INTACT. No live ledger touched, no bridge restart.

## Not in this PR

`run_steps`, `pr_outcomes`, CLAUDE.md "chained so far", any promotion or trust-fold change, any rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)