### PR TITLE
feat(evidence): chain run_steps.jsonl behind rv 1 (ADR-0027, wave 2 PR 2)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-09-02 `feat/chain-run-steps` — ADR-0027 wave 2, PR 2 of 3: chain `run_steps.jsonl` through `appendChained` (never-throwing writer kept; the 2 MB halving trim becomes ADR-0027 rotation with an explicit marker), new writer-owned `rv: 1`, `loadStepEvidence` skips markers by kind, ledger enters `VERIFIED_LEDGERS` only. Touches src/runStepLedger.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-run-steps worktree)
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,11 +52,11 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-09-02 `feat/chain-run-steps` — ADR-0027 wave 2, PR 2 of 3: chain `run_steps.jsonl` through `appendChained` (never-throwing writer kept; the 2 MB halving trim becomes ADR-0027 rotation with an explicit marker), new writer-owned `rv: 1`, `loadStepEvidence` skips markers by kind, ledger enters `VERIFIED_LEDGERS` only. Touches src/runStepLedger.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-run-steps worktree)
-
 
 
 ## Recently closed (informal log, prune periodically)
+
+- 2026-09-02 `feat/chain-run-steps` — ADR-0027 wave 2, PR 2 of 3: chain `run_steps.jsonl` through `appendChained` (never-throwing writer kept; the 2 MB halving trim becomes ADR-0027 rotation with an explicit marker), new writer-owned `rv: 1`, `loadStepEvidence` skips markers by kind, ledger enters `VERIFIED_LEDGERS` only. Touches src/runStepLedger.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-run-steps worktree) PR #1579
 
 - 2026-09-02 `feat/chain-butler-outcome-shadow` — ADR-0027 wave 2, PR 1 of 3: chain `butler_outcome_shadow.jsonl` (real path; no rename) through `appendChained`, new writer-owned `rv: 1`, readers skip marker rows explicitly, verifier gets its own ledger list (spine + this file) so `patchwork evidence` denominators do not change. Touches src/butler/outcomeShadowLog.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-butler-shadow worktree) PR #1578
 

--- a/src/__tests__/ledgerChain.test.ts
+++ b/src/__tests__/ledgerChain.test.ts
@@ -105,6 +105,34 @@ describe("legacy prefix: byte-identical, committed to, never backfilled", () => 
     expect(v.legacyPrefix).toBe("mismatch");
   });
 
+  it("verifies a legacy prefix containing non-ASCII bytes (byte length is not string length)", () => {
+    // Real ledgers carry em dashes and accented text in `reason` fields. A
+    // prefix reconstructed by STRING index against a BYTE length lands on the
+    // wrong boundary and hashes differently — every chained real ledger would
+    // read as tampered on its first verify.
+    const utf8 =
+      '{"seq":1,"reason":"gated — café ✓"}\n{"seq":2,"reason":"naïve"}\n';
+    writeFileSync(file, utf8);
+    appendChained(file, { seq: 3 });
+    expect(readFileSync(file, "utf-8").startsWith(utf8)).toBe(true);
+    const v = verifyLedgerChain(file);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.ok).toBe(true);
+  });
+
+  it("a legacy file with no trailing newline gets its last line terminated, not merged into the marker", () => {
+    const unterminated = '{"seq":1,"x":"old"}\n{"seq":2,"x":"last"}';
+    writeFileSync(file, unterminated);
+    appendChained(file, { seq: 3 });
+    const r = rows();
+    expect(r[1]).toEqual({ seq: 2, x: "last" }); // still its own parseable line
+    expect(r[2]?.kind).toBe("chain-start");
+    const v = verifyLedgerChain(file);
+    expect(v.legacyRows).toBe(2);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.ok).toBe(true);
+  });
+
   it("a legacy prefix that was never chained is reported as such, not as broken", () => {
     writeFileSync(file, legacy);
     const v = verifyLedgerChain(file);

--- a/src/__tests__/runStepLedgerChain.test.ts
+++ b/src/__tests__/runStepLedgerChain.test.ts
@@ -1,0 +1,170 @@
+/**
+ * ADR-0027 wave 2, PR 2 — `run_steps.jsonl` is chained.
+ *
+ * The writer was a bare never-throwing `appendFileSync` with a hand-rolled
+ * "drop half the file at 2 MB" trim. It now goes through `appendChained`:
+ * locked, `iseq` + `prev`, an explicit rotation marker instead of a silent
+ * halving, a head sidecar, and a failed append counted then sealed. The
+ * never-throw contract is unchanged — losing a mid-flight row must not take
+ * down the run that produced it.
+ *
+ * Rotation is asserted as BOUNDED AND VALID, not as "exactly half": the old
+ * ratio was an implementation detail, and the property that matters is that
+ * the file stays under its cap, the newest rows survive, and the chain still
+ * verifies across the marker.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SPINE_LEDGERS } from "../evidenceCoverage.js";
+import { VERIFIED_LEDGERS, verifyEvidenceChains } from "../evidenceVerify.js";
+import { chainSidecarPaths, verifyLedgerChain } from "../ledgerChain.js";
+import type { RunStepResult } from "../runLog.js";
+import {
+  appendStepEvidence,
+  loadStepEvidence,
+  RUN_STEP_LEDGER_RV,
+  type RunStepLedgerRow,
+  stepLedgerPath,
+} from "../runStepLedger.js";
+
+let dir: string;
+let file: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "runsteps-chain-"));
+  file = stepLedgerPath(dir);
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const step = (
+  id: string,
+  over: Partial<RunStepResult> = {},
+): RunStepResult => ({
+  id,
+  tool: "http.post",
+  status: "ok",
+  durationMs: 5,
+  ...over,
+});
+const row = (
+  taskId: string,
+  id: string,
+  over: Partial<RunStepResult> = {},
+): RunStepLedgerRow => ({
+  taskId,
+  seq: 1,
+  recipeName: "noisy-recipe",
+  at: 1000,
+  step: step(id, over),
+});
+const physical = () =>
+  readFileSync(file, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+
+const LEGACY =
+  '{"taskId":"legacy-task","seq":1,"recipeName":"noisy-recipe","at":1,"step":{"id":"s1","tool":"http.post","status":"ok","durationMs":1}}\n';
+
+describe("the writer", () => {
+  it("stamps rv, iseq and prev and the chain verifies", () => {
+    appendStepEvidence(dir, row("t1", "s1"));
+    appendStepEvidence(dir, row("t1", "s2"));
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.chainedRows).toBe(2);
+    expect(v.head).toBe("ok");
+    const data = physical().filter((r) => r.kind === undefined);
+    expect(data[0]).toMatchObject({ rv: RUN_STEP_LEDGER_RV, iseq: 1 });
+    expect(data[1]).toMatchObject({ rv: RUN_STEP_LEDGER_RV, iseq: 2 });
+    expect(typeof data[1]?.prev).toBe("string");
+  });
+
+  it("leaves a legacy ledger byte-identical and commits to it with chain-start", () => {
+    writeFileSync(file, LEGACY);
+    appendStepEvidence(dir, row("t1", "s1"));
+    expect(readFileSync(file, "utf-8").startsWith(LEGACY)).toBe(true);
+    expect(physical()[0]).not.toHaveProperty("rv");
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.legacyRows).toBe(1);
+    // The legacy row is still evidence for its task.
+    expect(loadStepEvidence(dir).get("legacy-task")).toHaveLength(1);
+  });
+
+  it("never throws on a failed append; the failure is pending, then sealed", () => {
+    mkdirSync(file); // the ledger path is a directory, so the append fails
+    expect(() => appendStepEvidence(dir, row("t1", "s1"))).not.toThrow();
+    expect(existsSync(chainSidecarPaths(file).writeFailed)).toBe(true);
+    rmSync(file, { recursive: true, force: true });
+    expect(verifyLedgerChain(file).writeFailedPending).toBe(1);
+    appendStepEvidence(dir, row("t1", "s1"));
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.writeFailedPending).toBe(0);
+    expect(v.writeFailedSealed).toBe(1);
+  });
+});
+
+describe("rotation is bounded, explicit and still verifies", () => {
+  it("keeps the file under its cap with a rotation marker, newest rows survive, chain intact", () => {
+    const cap = 8_000;
+    const pad = "x".repeat(120);
+    for (let i = 1; i <= 120; i++) {
+      appendStepEvidence(dir, row(`t${i}`, "s1", { error: pad }), undefined, {
+        maxBytes: cap,
+      });
+    }
+    expect(statSync(file).size).toBeLessThanOrEqual(cap + 400); // one row of slack past the cap
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.rotations).toBe(1);
+    expect(v.droppedByRotation).toBeGreaterThan(0);
+    expect(v.chainedRows + v.droppedByRotation).toBe(120);
+    expect(v.lastIseq).toBe(120);
+    expect(physical()[0]?.kind).toBe("rotation");
+    // The newest task is present; the oldest was rotated away.
+    const evidence = loadStepEvidence(dir);
+    expect(evidence.has("t120")).toBe(true);
+    expect(evidence.has("t1")).toBe(false);
+  });
+});
+
+describe("the loader treats marker rows as metadata", () => {
+  it("skips markers by kind, even one that carries a taskId and a step", () => {
+    appendStepEvidence(dir, row("t1", "s1"));
+    writeFileSync(
+      file,
+      `${readFileSync(file, "utf-8")}{"kind":"rotation","taskId":"phantom","step":{"id":"s1"},"droppedRows":0,"droppedLegacyRows":0,"lastDroppedHash":null,"lastDroppedIseq":null,"firstKeptIseq":null}\n`,
+    );
+    const evidence = loadStepEvidence(dir);
+    expect(evidence.has("phantom")).toBe(false);
+    expect(evidence.get("t1")).toHaveLength(1);
+  });
+});
+
+describe("verifier and coverage lists", () => {
+  it("the verifier covers run_steps.jsonl; the spine does not", () => {
+    expect(VERIFIED_LEDGERS.some((l) => l.file === "run_steps.jsonl")).toBe(
+      true,
+    );
+    expect(SPINE_LEDGERS.some((l) => l.file === "run_steps.jsonl")).toBe(false);
+    appendStepEvidence(dir, row("t1", "s1"));
+    expect(
+      verifyEvidenceChains(dir).ledgers.find(
+        (l) => l.file === "run_steps.jsonl",
+      ),
+    ).toMatchObject({ absent: false, chainedRows: 1, ok: true });
+  });
+});

--- a/src/butler/__tests__/outcomeShadowLogChain.test.ts
+++ b/src/butler/__tests__/outcomeShadowLogChain.test.ts
@@ -181,10 +181,11 @@ describe("readers treat marker rows as metadata, never as graded outcomes", () =
 
 describe("verifier and coverage lists", () => {
   it("the verifier covers the spine PLUS this ledger", () => {
-    expect(VERIFIED_LEDGERS.map((l) => l.file)).toEqual([
-      ...SPINE_LEDGERS.map((l) => l.file),
-      SHADOW_LOG_BASENAME,
-    ]);
+    const files = VERIFIED_LEDGERS.map((l) => l.file);
+    expect(files.slice(0, SPINE_LEDGERS.length)).toEqual(
+      SPINE_LEDGERS.map((l) => l.file),
+    );
+    expect(files).toContain(SHADOW_LOG_BASENAME);
     grade("todoist.create_task:1", "confirmed", 2000);
     const r = verifyEvidenceChains(dir);
     expect(r.ledgers.find((l) => l.file === SHADOW_LOG_BASENAME)).toMatchObject(

--- a/src/evidenceVerify.ts
+++ b/src/evidenceVerify.ts
@@ -41,6 +41,7 @@ export interface EvidenceVerification {
 export const VERIFIED_LEDGERS: ReadonlyArray<{ key: string; file: string }> = [
   ...SPINE_LEDGERS,
   { key: "butler outcome shadow", file: "butler_outcome_shadow.jsonl" },
+  { key: "run steps", file: "run_steps.jsonl" },
 ];
 
 export function verifyEvidenceChains(

--- a/src/ledgerChain.ts
+++ b/src/ledgerChain.ts
@@ -428,6 +428,15 @@ export function appendChained(
         let prevHash = tail.prevHash;
         let iseq = tail.nextIseq;
         if (tail.unchained) {
+          // A legacy file whose last line has no newline would otherwise get
+          // the marker glued onto it — one unparseable line, and a prefix the
+          // verifier can never reconstruct. Terminate the line first; the
+          // commitment below covers the terminated bytes, and the legacy row's
+          // own content is byte-identical.
+          if (text.length > 0 && !text.endsWith("\n")) {
+            appendFileSync(file, "\n", { mode });
+            text += "\n";
+          }
           const marker: ChainStartMarker = {
             kind: "chain-start",
             at: now(),
@@ -506,7 +515,8 @@ export function verifyLedgerChain(file: string): ChainVerification {
   };
   if (v.absent) return v;
 
-  const text = readFileSync(file, "utf-8");
+  const bytes = readFileSync(file);
+  const text = bytes.toString("utf-8");
   const lines = splitLines(text);
 
   // Every iseq in the file, so "the expected one exists later" (reordered) can
@@ -574,10 +584,13 @@ export function verifyLedgerChain(file: string): ChainVerification {
       } else if (v.legacyRows === 0 && (p.legacyRows as number) === 0) {
         v.legacyPrefix = "none";
       } else {
-        const prefix = text.slice(0, legacyBytes);
+        // BYTES, not a string slice: `legacyBytes` is a byte count and a
+        // string index is a UTF-16 code-unit count. They agree only on pure
+        // ASCII, and real ledgers carry em dashes and accents in `reason`.
+        const prefix = bytes.subarray(0, legacyBytes).toString("utf-8");
         v.legacyPrefix =
           hashLine(prefix) === p.legacyHash &&
-          Buffer.byteLength(prefix, "utf8") === p.legacyBytes &&
+          legacyBytes === p.legacyBytes &&
           v.legacyRows === p.legacyRows
             ? "verified"
             : "mismatch";

--- a/src/runStepLedger.ts
+++ b/src/runStepLedger.ts
@@ -1,12 +1,6 @@
-import {
-  appendFileSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import { appendChained, isChainMarker } from "./ledgerChain.js";
 import type { Logger } from "./logger.js";
 import type { RunStepResult } from "./runLog.js";
 import { AGENT_STEP_TOOL, classifyActionClass } from "./workers/actionClass.js";
@@ -32,11 +26,34 @@ export interface RunStepLedgerRow {
   recipeName: string;
   at: number;
   step: RunStepResult;
+  /** Writer-stamped record level. Absent on rows that predate the chain. */
+  rv?: number;
+  /** ADR-0027 integrity position and previous-line hash (rv >= 1). */
+  iseq?: number;
+  prev?: string;
 }
+
+/**
+ * Record level (ADR-0025's `rv` protocol; ADR-0027 for this ledger).
+ *
+ * 1: every row is written through `appendChained` and carries `iseq` and
+ * `prev`, stamped by the writer from the file's tail under the lock. At
+ * `rv >= 1` their absence is a WRITER DEFECT. Rows with no `rv` predate the
+ * chain; they are never re-stamped, and the `chain-start` marker commits to
+ * them as a block. Never default it on read.
+ */
+export const RUN_STEP_LEDGER_RV = 1;
 
 /** Cap on `run_steps.jsonl`. Rows only matter until their run reaches a
  *  terminal record, so this is a crash-window buffer, not history. */
 const MAX_LEDGER_BYTES = 2 * 1024 * 1024;
+/**
+ * Low-water target after rotation. Half the cap keeps the old "newest half
+ * survives" bound while letting the primitive trim to a byte target rather
+ * than a line ratio; a target at the cap would rotate on every append once
+ * the file is full (the gate ledger measured 826 rotations in one fill).
+ */
+const ROTATE_TARGET_BYTES = MAX_LEDGER_BYTES / 2;
 
 /**
  * Is this step worth persisting mid-flight?
@@ -61,17 +78,44 @@ export function stepLedgerPath(dir: string): string {
 }
 
 /** Append one evidence row. Never throws — losing a mid-flight row must not
- *  take down the run that produced it. */
+ *  take down the run that produced it.
+ *
+ *  ADR-0027: one locked, chained append. The hand-rolled "drop half the file
+ *  at 2 MB" trim is gone; rotation is the primitive's, writes an explicit
+ *  `rotation` marker, and the chain re-anchors across it. A failed append is
+ *  counted in the `.write_failed` sidecar and sealed into the next row, so a
+ *  ledger that stopped writing is distinguishable from a quiet run.
+ *
+ *  `opts.maxBytes` is a TEST SEAM (like the gate ledger's `maxPersistBytes`):
+ *  a test that must observe rotation should not write two real megabytes. */
 export function appendStepEvidence(
   dir: string,
   row: RunStepLedgerRow,
   logger?: Logger,
+  opts: { maxBytes?: number } = {},
 ): void {
   const file = stepLedgerPath(dir);
+  const maxBytes = opts.maxBytes ?? MAX_LEDGER_BYTES;
   try {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
-    trimIfOversized(file);
-    appendFileSync(file, `${JSON.stringify(row)}\n`, { mode: 0o600 });
+    appendChained(
+      file,
+      // Stamped AFTER the caller's fields so a caller cannot claim a level.
+      { ...row, rv: RUN_STEP_LEDGER_RV } as unknown as Record<string, unknown>,
+      {
+        mode: 0o600,
+        maxBytes,
+        rotateTarget:
+          opts.maxBytes !== undefined
+            ? Math.floor(maxBytes / 2)
+            : ROTATE_TARGET_BYTES,
+        onRotate: ({ dropped, before }) => {
+          logger?.warn?.(
+            `[runsteps] rotate dropped ${dropped} of ${before} row(s) (oldest first) to get under ${maxBytes} bytes`,
+          );
+        },
+      },
+    );
   } catch (err) {
     logger?.warn?.(
       `[runsteps] append failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -101,6 +145,9 @@ export function loadStepEvidence(
     if (!line) continue;
     try {
       const parsed = JSON.parse(line) as RunStepLedgerRow;
+      // ADR-0027 marker rows are metadata, never step evidence — skipped by
+      // KIND, so a marker that happened to carry a taskId could not sneak in.
+      if (isChainMarker(parsed)) continue;
       if (!parsed?.taskId || !parsed.step?.id) continue;
       let steps = byTask.get(parsed.taskId);
       if (!steps) {
@@ -117,22 +164,4 @@ export function loadStepEvidence(
   for (const [taskId, steps] of byTask)
     out.set(taskId, Array.from(steps.values()));
   return out;
-}
-
-/** Keep the newest half when the buffer exceeds its cap. */
-function trimIfOversized(file: string): void {
-  let size: number;
-  try {
-    size = statSync(file).size;
-  } catch {
-    return;
-  }
-  if (size <= MAX_LEDGER_BYTES) return;
-  const lines = readFileSync(file, "utf-8").split("\n").filter(Boolean);
-  const keep = lines.slice(Math.floor(lines.length / 2));
-  const tmp = `${file}.tmp`;
-  writeFileSync(tmp, keep.length > 0 ? `${keep.join("\n")}\n` : "", {
-    mode: 0o600,
-  });
-  renameSync(tmp, file);
 }


### PR DESCRIPTION
## What

ADR-0027 wave 2, PR 2 of 3. Chains the in-flight step-evidence ledger and nothing else.

- **Writer**: `appendStepEvidence` writes through `appendChained` (lock, `iseq`, `prev`, head sidecar, write-failure counter). Never-throwing contract unchanged.
- **Rotation**: the hand-rolled "drop the oldest half at 2 MB" trim is replaced by the primitive's rotation with an explicit `rotation` marker and cumulative dropped counts. Asserted as bounded and valid (under cap, newest survive, chain verifies across the marker), not as "exactly half". Low-water target stays at half the cap. `opts.maxBytes` is a test seam.
- **`rv: 1`** introduced for this ledger (it had none). Legacy rows byte-identical, never re-stamped; chain-start commits to them.
- **Loader** skips marker rows explicitly by kind. `isEvidenceBearing` and the trust fold untouched.
- **Verifier**: `run_steps.jsonl` enters `VERIFIED_LEDGERS` only. Spine and every `patchwork evidence` denominator unchanged.

## Also in this PR: a verifier bug found by this PR's live check

On a copy of the reference machine's real `run_steps.jsonl`, the untouched legacy prefix verified as a MISMATCH. `verifyLedgerChain` rebuilt the prefix with a string slice (UTF-16 index) against a byte length; they agree only on pure ASCII, and real ledgers carry em dashes in `reason`. Every chained ledger would have read as tampered on its first verify after deployment; the unit tests were ASCII-only. Fixed by reconstructing the prefix from bytes. The same path also glued the chain-start marker onto a legacy file whose last line had no newline; the writer now terminates that line first. Two failing-first tests. After the fix, all six live ledgers verify on copies (280 to 351 legacy rows each).

## Verification

Failing-first tests (`runStepLedgerChain.test.ts`): stamps and verifies; legacy untouched and committed; failed append pending then sealed; bounded rotation with marker; row-shaped marker skipped; verifier includes / spine excludes. Full suite 10,943 passed; `typecheck` and `typecheck:tests:core` clean; biome clean. Copy-of-live: 26 legacy rows committed and byte-identical, chain INTACT. No live ledger touched, no bridge restart.

## Not in this PR

`pr_outcomes`, CLAUDE.md "chained so far", any trust-fold or `isEvidenceBearing` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)