### PR TITLE
feat(evidence): chain pr_outcomes.jsonl behind rv 2 (ADR-0027, wave 2 PR 3)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,12 +52,11 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- 2026-09-02 `feat/chain-pr-outcomes` — ADR-0027 wave 2, PR 3 of 3: chain `pr_outcomes.jsonl` through `appendChained` (`PR_OBSERVATION_RV` 1 → 2), `readObservations` skips marker rows by kind so a marker cannot become a phantom pull request, ledger enters `VERIFIED_LEDGERS` only. Touches src/maintenance/prOutcomeLedger.ts, src/index.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-pr-outcomes worktree)
-
 
 
 ## Recently closed (informal log, prune periodically)
 
+- 2026-09-02 `feat/chain-pr-outcomes` — ADR-0027 wave 2, PR 3 of 3: chain `pr_outcomes.jsonl` through `appendChained` (`PR_OBSERVATION_RV` 1 → 2), `readObservations` skips marker rows by kind so a marker cannot become a phantom pull request, ledger enters `VERIFIED_LEDGERS` only. Touches src/maintenance/prOutcomeLedger.ts, src/index.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-pr-outcomes worktree) PR #1580
 - 2026-09-02 `feat/chain-run-steps` — ADR-0027 wave 2, PR 2 of 3: chain `run_steps.jsonl` through `appendChained` (never-throwing writer kept; the 2 MB halving trim becomes ADR-0027 rotation with an explicit marker), new writer-owned `rv: 1`, `loadStepEvidence` skips markers by kind, ledger enters `VERIFIED_LEDGERS` only. Touches src/runStepLedger.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-run-steps worktree) PR #1579
 
 - 2026-09-02 `feat/chain-butler-outcome-shadow` — ADR-0027 wave 2, PR 1 of 3: chain `butler_outcome_shadow.jsonl` (real path; no rename) through `appendChained`, new writer-owned `rv: 1`, readers skip marker rows explicitly, verifier gets its own ledger list (spine + this file) so `patchwork evidence` denominators do not change. Touches src/butler/outcomeShadowLog.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-butler-shadow worktree) PR #1578

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- 2026-09-02 `feat/chain-pr-outcomes` — ADR-0027 wave 2, PR 3 of 3: chain `pr_outcomes.jsonl` through `appendChained` (`PR_OBSERVATION_RV` 1 → 2), `readObservations` skips marker rows by kind so a marker cannot become a phantom pull request, ledger enters `VERIFIED_LEDGERS` only. Touches src/maintenance/prOutcomeLedger.ts, src/index.ts, src/evidenceVerify.ts and their tests. — Claude Code (chain-pr-outcomes worktree)
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/src/evidenceVerify.ts
+++ b/src/evidenceVerify.ts
@@ -42,6 +42,7 @@ export const VERIFIED_LEDGERS: ReadonlyArray<{ key: string; file: string }> = [
   ...SPINE_LEDGERS,
   { key: "butler outcome shadow", file: "butler_outcome_shadow.jsonl" },
   { key: "run steps", file: "run_steps.jsonl" },
+  { key: "pr outcomes", file: "pr_outcomes.jsonl" },
 ];
 
 export function verifyEvidenceChains(

--- a/src/index.ts
+++ b/src/index.ts
@@ -5056,7 +5056,6 @@ if (process.argv[2] === "pr-outcomes") {
     process.exit(0);
   }
   (async () => {
-    const { appendFileSync } = await import("node:fs");
     const { join } = await import("node:path");
     const { patchworkPath } = await import("./patchworkHome.js");
     const { execFileSync } = await import("node:child_process");
@@ -5066,6 +5065,7 @@ if (process.argv[2] === "pr-outcomes") {
       readObservations,
       summarise,
       formatLedgerSummary,
+      appendObservation,
     } = await import("./maintenance/prOutcomeLedger.js");
     type Obs = import("./maintenance/prOutcomeLedger.js").PrObservation;
 
@@ -5191,8 +5191,10 @@ if (process.argv[2] === "pr-outcomes") {
         existing,
         incoming,
       );
-      for (const o of toAppend)
-        appendFileSync(file, `${JSON.stringify(o)}\n`, { mode: 0o600 });
+      // Through the ledger's own writer (ADR-0027): locked, chained, and a
+      // failed append counted then sealed. It throws rather than swallowing,
+      // so a collection that recorded nothing exits 1 loudly below.
+      for (const o of toAppend) appendObservation(file, o);
       process.stdout.write(
         `[pr-outcomes] ${repo}: ${incoming.length} pull request(s) queried\n` +
           `  ${toAppend.length} appended (${firstSighting} seen for the first time)\n` +

--- a/src/maintenance/__tests__/prOutcomeLedger.test.ts
+++ b/src/maintenance/__tests__/prOutcomeLedger.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   dedupeAgainst,
   formatLedgerSummary,
+  PR_OBSERVATION_RV,
   type PrObservation,
   type RawGhPr,
   summarise,
@@ -35,7 +36,7 @@ describe("toObservation", () => {
   it("keeps the raw fields a later pass will need", () => {
     const o = toObservation(raw(), { repo: "o/r", observedAt: AT });
     expect(o).toMatchObject({
-      rv: 1,
+      rv: PR_OBSERVATION_RV,
       repo: "o/r",
       number: 1543,
       state: "MERGED",

--- a/src/maintenance/__tests__/prOutcomeLedgerChain.test.ts
+++ b/src/maintenance/__tests__/prOutcomeLedgerChain.test.ts
@@ -1,0 +1,252 @@
+/**
+ * ADR-0027 wave 2, PR 3 — `pr_outcomes.jsonl` is chained.
+ *
+ * The writer was a bare `appendFileSync` loop inside the `pr-outcomes collect`
+ * command. It now goes through `appendObservation` → `appendChained`: locked,
+ * `iseq` + `prev`, a `chain-start` marker committing to the legacy prefix, a
+ * head sidecar, and a failed append counted then sealed. Unlike the run-step
+ * ledger this writer does NOT swallow its errors — `collect` already fails
+ * loudly on a failed query, and a collection that silently recorded nothing
+ * would leave a gap indistinguishable from a quiet week.
+ *
+ * The reader half matters as much. `readObservations` cast every parsed line
+ * to a `PrObservation` with no shape check, so a marker row would have become
+ * a phantom "undefined#undefined" pull request in `rows`, `distinctPrs`,
+ * `rosterlessRows`, `byState` and the weekly sweep counts.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SPINE_LEDGERS } from "../../evidenceCoverage.js";
+import {
+  VERIFIED_LEDGERS,
+  verifyEvidenceChains,
+} from "../../evidenceVerify.js";
+import { chainSidecarPaths, verifyLedgerChain } from "../../ledgerChain.js";
+import {
+  appendObservation,
+  dedupeAgainst,
+  PR_OBSERVATION_RV,
+  type PrObservation,
+  readObservations,
+  summarise,
+} from "../prOutcomeLedger.js";
+
+let dir: string;
+let file: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "pr-outcomes-chain-"));
+  file = path.join(dir, "pr_outcomes.jsonl");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const obs = (number: number, over: Partial<PrObservation> = {}) =>
+  ({
+    rv: PR_OBSERVATION_RV,
+    repo: "example-org/example-repo",
+    number,
+    observedAt: "2026-09-02T00:00:00.000Z",
+    state: "OPEN",
+    authorLogin: "example-user",
+    createdAt: "2026-09-01T00:00:00.000Z",
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    ...over,
+  }) as PrObservation;
+
+const physical = () =>
+  readFileSync(file, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+
+/**
+ * A legacy prefix with MULTIBYTE UTF-8 in it. An ASCII-only fixture cannot
+ * see a byte-length-versus-string-offset defect, which is exactly how one
+ * reached a live ledger in PR 2 of this wave.
+ */
+const LEGACY_MULTIBYTE = `${JSON.stringify({
+  rv: 1,
+  repo: "example-org/exämple-repo",
+  number: 7,
+  observedAt: "2026-08-01T00:00:00.000Z",
+  state: "MERGED",
+  authorLogin: "üser-ünicode",
+  createdAt: "2026-07-01T00:00:00.000Z",
+  additions: 3,
+  deletions: 1,
+  changedFiles: 2,
+  mergeCommitSha: "abc — em dash, ‚Äö and a snowman ☃",
+})}\n`;
+
+describe("the writer", () => {
+  it("stamps rv 2, iseq and prev, and the chain verifies", () => {
+    appendObservation(file, obs(1));
+    appendObservation(file, obs(2));
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.chainedRows).toBe(2);
+    expect(v.head).toBe("ok");
+    const rows = physical().filter((r) => r.kind === undefined);
+    expect(PR_OBSERVATION_RV).toBe(2);
+    expect(rows[0]).toMatchObject({ rv: 2, iseq: 1 });
+    expect(rows[1]).toMatchObject({ rv: 2, iseq: 2 });
+    expect(typeof rows[1]?.prev).toBe("string");
+  });
+
+  it("leaves a MULTIBYTE legacy prefix byte-identical and commits to it", () => {
+    writeFileSync(file, LEGACY_MULTIBYTE);
+    const before = readFileSync(file); // Buffer: bytes, never string offsets
+    appendObservation(file, obs(1));
+    const after = readFileSync(file);
+    expect(after.subarray(0, before.length).equals(before)).toBe(true);
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(v.legacyRows).toBe(1);
+    // Legacy rows are never re-stamped: still rv 1.
+    expect(physical()[0]).toMatchObject({ rv: 1 });
+  });
+
+  it("handles a legacy file whose last row has NO trailing newline", () => {
+    const unterminated = LEGACY_MULTIBYTE.slice(0, -1);
+    writeFileSync(file, unterminated);
+    const before = Buffer.from(unterminated, "utf-8");
+    appendObservation(file, obs(1));
+    const after = readFileSync(file);
+    expect(after.subarray(0, before.length).equals(before)).toBe(true);
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.legacyPrefix).toBe("verified");
+    expect(readObservations(file)).toHaveLength(2);
+  });
+
+  it("propagates a failed append; the failure is pending, then sealed", () => {
+    mkdirSync(file); // the ledger path is a directory, so the append fails
+    expect(() => appendObservation(file, obs(1))).toThrow();
+    expect(existsSync(chainSidecarPaths(file).writeFailed)).toBe(true);
+    rmSync(file, { recursive: true, force: true });
+    expect(verifyLedgerChain(file).writeFailedPending).toBe(1);
+    appendObservation(file, obs(1));
+    const v = verifyLedgerChain(file);
+    expect(v.ok).toBe(true);
+    expect(v.writeFailedPending).toBe(0);
+    expect(v.writeFailedSealed).toBe(1);
+  });
+
+  it("keeps authorIsWorker OMITTED when the caller omitted it", () => {
+    appendObservation(file, obs(1));
+    appendObservation(file, obs(2, { authorIsWorker: false }));
+    const rows = readObservations(file);
+    expect(rows[0] !== undefined && "authorIsWorker" in rows[0]).toBe(false);
+    expect(rows[1]?.authorIsWorker).toBe(false);
+    expect(summarise(rows).rosterlessRows).toBe(1);
+  });
+});
+
+describe("marker rows are metadata, never a pull request", () => {
+  const withMarkers = () => {
+    appendObservation(file, obs(1));
+    appendObservation(file, obs(2, { state: "MERGED" }));
+    return readObservations(file);
+  };
+
+  it("a chain-start marker never reaches rows, counts or the sweep", () => {
+    writeFileSync(file, LEGACY_MULTIBYTE);
+    appendObservation(file, obs(1));
+    const rows = readObservations(file);
+    // 1 legacy + 1 chained. The chain-start marker is not a third.
+    expect(rows).toHaveLength(2);
+    const s = summarise(rows);
+    expect(s.rows).toBe(2);
+    expect(s.distinctPrs).toBe(2);
+    expect(s.rosterlessRows).toBe(2);
+    expect(Object.keys(s.byState).sort()).toEqual(["MERGED", "OPEN"]);
+    expect(s.byState.undefined).toBeUndefined();
+  });
+
+  it("a marker SHAPED like a row is still skipped, by kind", () => {
+    withMarkers();
+    writeFileSync(
+      file,
+      `${readFileSync(file, "utf-8")}${JSON.stringify({
+        kind: "rotation",
+        at: 1,
+        droppedRows: 0,
+        droppedLegacyRows: 0,
+        lastDroppedHash: null,
+        lastDroppedIseq: null,
+        firstKeptIseq: null,
+        // Everything a PrObservation needs, so only `kind` can save us.
+        rv: 2,
+        repo: "example-org/example-repo",
+        number: 999,
+        observedAt: "2026-09-02T00:00:00.000Z",
+        state: "CLOSED",
+        authorLogin: "phantom",
+        createdAt: "2026-09-01T00:00:00.000Z",
+        additions: 0,
+        deletions: 0,
+        changedFiles: 0,
+      })}\n`,
+    );
+    const rows = readObservations(file);
+    expect(rows.some((r) => r.number === 999)).toBe(false);
+    const s = summarise(rows);
+    expect(s.rows).toBe(2);
+    expect(s.distinctPrs).toBe(2);
+    expect(s.prsWithHistory).toBe(0);
+  });
+
+  it("markers do not pollute the dedupe seen-set", () => {
+    writeFileSync(file, LEGACY_MULTIBYTE);
+    appendObservation(file, obs(1));
+    const existing = readObservations(file);
+    // A first sighting must still count as one: a marker in `existing` would
+    // otherwise sit in the seen-set under its own phantom key.
+    const d = dedupeAgainst(existing, [obs(1), obs(3)]);
+    expect(d.unchanged).toBe(1);
+    expect(d.firstSighting).toBe(1);
+    expect(d.toAppend.map((o) => o.number)).toEqual([3]);
+  });
+});
+
+describe("verifier and coverage lists", () => {
+  it("the verifier covers pr_outcomes.jsonl; the spine does not", () => {
+    expect(VERIFIED_LEDGERS.some((l) => l.file === "pr_outcomes.jsonl")).toBe(
+      true,
+    );
+    expect(SPINE_LEDGERS.some((l) => l.file === "pr_outcomes.jsonl")).toBe(
+      false,
+    );
+    appendObservation(file, obs(1));
+    expect(
+      verifyEvidenceChains(dir).ledgers.find(
+        (l) => l.file === "pr_outcomes.jsonl",
+      ),
+    ).toMatchObject({ absent: false, chainedRows: 1, ok: true });
+  });
+});
+
+describe("the collect command writes through the ledger", () => {
+  it("src/index.ts no longer appends to the ledger itself", () => {
+    const src = readFileSync(
+      path.join(__dirname, "..", "..", "index.ts"),
+      "utf-8",
+    );
+    const collect = src.slice(src.indexOf('if (sub === "collect")'));
+    const body = collect.slice(0, collect.indexOf("pull request(s) queried"));
+    expect(body).not.toMatch(/appendFileSync\s*\(\s*file/);
+    expect(body).toContain("appendObservation(file");
+  });
+});

--- a/src/maintenance/prOutcomeLedger.ts
+++ b/src/maintenance/prOutcomeLedger.ts
@@ -33,14 +33,24 @@
  * mark every historical pull request as human-authored — the same
  * never-backfill rule `workerGateDecisionLog` states in its own header.
  *
- * Rows carry `rv: 1` so a later schema change is distinguishable from an old
+ * Rows carry `rv` so a later schema change is distinguishable from an old
  * row, for the same reason the gate ledger does.
  */
 
-/** Schema version. A reader must be able to tell an old row from a new one. */
 import * as nodeFs from "node:fs";
+import { appendChained, isChainMarker } from "../ledgerChain.js";
 
-export const PR_OBSERVATION_RV = 1;
+/**
+ * Record level (ADR-0025's `rv` protocol; ADR-0027 for this ledger).
+ *
+ * 1: rows appended directly, with no integrity fields.
+ * 2: every row is written through `appendChained` and carries `iseq` and
+ * `prev`, stamped by the writer from the file's tail under the lock. At
+ * `rv >= 2` their absence is a WRITER DEFECT. Rows at `rv: 1` predate the
+ * chain; they are never re-stamped, and the `chain-start` marker commits to
+ * them as a block. Never default it on read.
+ */
+export const PR_OBSERVATION_RV = 2;
 
 export type PrState = "OPEN" | "MERGED" | "CLOSED";
 
@@ -356,10 +366,40 @@ export function readObservations(file: string): PrObservation[] {
   for (const line of nodeFs.readFileSync(file, "utf-8").split("\n")) {
     if (line.trim() === "") continue;
     try {
-      out.push(JSON.parse(line) as PrObservation);
+      const parsed: unknown = JSON.parse(line);
+      // ADR-0027 marker rows share the file with the data and are metadata,
+      // never an observation. Skipped by KIND before anything counts them:
+      // this reader casts whatever it parsed, so a marker that reached
+      // `summarise` or `dedupeAgainst` would appear as a phantom pull request
+      // ("undefined#undefined") in rows, distinctPrs, rosterlessRows, byState
+      // and the weekly sweep — a fabricated row in an evidence file.
+      if (isChainMarker(parsed)) continue;
+      out.push(parsed as PrObservation);
     } catch {
       // skipped, never repaired
     }
   }
   return out;
+}
+
+/**
+ * Append one observation through the ADR-0027 chain primitive.
+ *
+ * Deliberately NOT never-throwing, unlike the mid-flight run-step ledger. A
+ * failed append is counted in the `.write_failed` sidecar by the primitive and
+ * sealed into the next row that lands; the error then propagates so
+ * `pr-outcomes collect` exits 1 loudly, the same way it already does on a
+ * failed GitHub query. A collector that reported success having recorded
+ * nothing would leave a gap indistinguishable from a quiet week.
+ *
+ * No rotation: this ledger is the history, and history that trims itself is
+ * not history.
+ */
+export function appendObservation(file: string, obs: PrObservation): void {
+  appendChained(
+    file,
+    // Stamped AFTER the caller's fields so a caller cannot claim a level.
+    { ...obs, rv: PR_OBSERVATION_RV } as unknown as Record<string, unknown>,
+    { mode: 0o600 },
+  );
 }


### PR DESCRIPTION
Last of ADR-0027 wave 2. `pr_outcomes.jsonl` is now hash-chained.

## Writer

`pr-outcomes collect` appended to the ledger itself with a bare `appendFileSync`
loop. It now calls `appendObservation` → `appendChained`: locked, `iseq` +
`prev` read from the file's tail, head sidecar, and a failed append counted in
`.write_failed` then sealed into the next row that lands.

Unlike the run-step ledger this writer does **not** swallow its errors.
`collect` already exits 1 loudly on a failed GitHub query, and a collector that
reported success having recorded nothing would leave a gap indistinguishable
from a quiet week. No rotation either — this ledger *is* the history.

`PR_OBSERVATION_RV` 1 → 2 with the receipt-style doc comment. Legacy rows stay
byte-identical at rv 1 and are never re-stamped; the `chain-start` marker
commits to them as a block.

## Reader — the defect this closes

`readObservations` cast any parsed line to a `PrObservation` with no shape
check. A marker row would therefore have become a phantom
`undefined#undefined` pull request in `rows`, `distinctPrs`, `rosterlessRows`,
`byState`, the `dedupeAgainst` seen-set and the weekly `sweep` counts — a
fabricated row inside an evidence file. Markers are now skipped by **kind**,
before anything counts them.

## Scope held

- `pr_outcomes.jsonl` joins `VERIFIED_LEDGERS` **only**. It carries no run id,
  so it has no place in `SPINE_LEDGERS` or any coverage denominator.
- `authorIsWorker` absence semantics untouched: omitted is not false.

## Verification

- 10 new tests in `src/maintenance/__tests__/prOutcomeLedgerChain.test.ts`,
  written failing first: writer stamps rv 2 / `iseq` / `prev` and verifies; a
  **multibyte UTF-8** legacy prefix stays byte-identical (asserted on Buffers,
  not string offsets); a legacy file whose last row has **no trailing
  newline**; markers change none of rows / distinctPrs / prsWithHistory /
  dedupe / sweep counts, including a marker shaped exactly like a row;
  `authorIsWorker` stays omitted; verifier includes and spine excludes; a
  failed append is pending then sealed; and a source guard that `src/index.ts`
  no longer appends to the ledger itself.
- biome, `typecheck`, `typecheck:tests:core`, full vitest (846 files, 10 953
  tests) all green.
- Copy-of-live check against a **copy** of the real 157-row ledger: prefix
  byte-identical, `evidence verify --dir` reported `INTACT`, exit 0. That
  ledger is pure ASCII, which is precisely why the fixture here carries
  multibyte text — an ASCII-only fixture cannot see the byte-versus-string
  offset class of defect that reached PR 2 of this wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)