### PR TITLE
chore(deps): patch fast-uri to 3.1.7 for the high-severity advisory

### DIFF
--- a/LICENSE-THIRD-PARTY.md
+++ b/LICENSE-THIRD-PARTY.md
@@ -258,7 +258,7 @@ not that it is unlicensed; check the package itself before relying on it.
 | balanced-match | 4.0.4 | MIT |
 | brace-expansion | 5.0.9 | MIT |
 | fast-deep-equal | 3.1.3 | MIT |
-| fast-uri | 3.1.5 | BSD-3-Clause |
+| fast-uri | 3.1.7 | BSD-3-Clause |
 | ipaddr.js | 2.3.0 | MIT |
 | json-schema-traverse | 1.0.0 | MIT |
 | minimatch | 10.2.4 | BlueOak-1.0.0 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1841,9 +1841,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Unblocks `main` and every open PR. **Two lines: the lockfile entry and the
generated inventory row.** No manifest change, no `ajv` bump, no allowlist, no
code.

## Why now

A high-severity advisory landed on `fast-uri` 3.0.0–3.1.5 (GHSA-5jgf-p345-68v8
and three siblings — host confusion via skipped IDN canonicalisation on
scheme-relative references). `audit-production-cves.mjs` is a **gating** CI
step, so `main` and every PR went red on a dependency nobody here changed.

## Why a patch, not a major

`ajv` declares `fast-uri: ^3.0.1`. The advisory is fixed in **3.1.6+**, and
`npm update fast-uri --package-lock-only` resolves the range to **3.1.7** — the
newest satisfying that constraint, and ≥ the fixed version. So no override, no
`ajv` migration, and nothing pinned backwards to go stale immediately.

## Why not allowlisted

The exposure is wider than "does a tool argument use `format: uri`".
Recipe-authored `expect.schema` blocks are compiled at runtime via
`ajv.compile`, and `fast-uri` sits in AJV's `$id`/`$ref` resolution path — so a
URI-normalisation confusion is reachable from **recipe content**, not only from
tool arguments. A same-major patch that already satisfies the declared range is
the cleaner answer than reasoning our way to an exception.

## No reproduction test, deliberately

An upstream parser defect. A test pinned to its internals would be maintenance
baggage protecting no Patchwork invariant. What matters is that AJV still
behaves, and the suite covers that.

## Verification

Against a **real install of 3.1.7** — the worktrees here symlink a shared
`node_modules` that still held 3.1.5, and running the suite against that would
have been verification that could not fail.

- `audit-production-cves.mjs` → **OK, no high or critical** (was FAIL).
- `audit-third-party-licenses.mjs` → caught the stale `3.1.5` inventory row;
  regenerated with `--write`, now current.
- `typecheck`; AJV validation suite; all three `expect.schema` suites
  (`stepExpect`, `stepExpectRequired`, `chainedRunLevelExpect`).
- Full vitest **848 files / 10 972 tests**.

Note for whoever installs locally: `npm install` fails on `@vscode/ripgrep`'s
postinstall (401 downloading the binary) — unrelated to this change, and
`--ignore-scripts` is the way through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)