### PR TITLE
fix(governance): refuse oversized agent prompts before dispatch

### DIFF
--- a/dashboard/src/lib/haltCategory.ts
+++ b/dashboard/src/lib/haltCategory.ts
@@ -19,6 +19,7 @@ export type HaltCategory =
   /** No tool is registered under the step's id; the governed profile refuses rather than skips. */
   | "unresolved_tool"
   | "budget_exceeded"
+  | "prompt_too_large"
   | "expect_failed"
   | "step_timeout"
   | "judge_revisions_exhausted"
@@ -52,6 +53,7 @@ export const HALT_CATEGORY_LABEL: Record<HaltCategory, string> = {
   policy_denied: "policy refused",
   unresolved_tool: "tool not registered",
   budget_exceeded: "budget exceeded",
+  prompt_too_large: "prompt too large",
   expect_failed: "expect failed",
   step_timeout: "step timeout",
   judge_revisions_exhausted: "judge revisions exhausted",
@@ -88,6 +90,8 @@ export const HALT_CATEGORY_HINT: Record<HaltCategory, string> = {
     "No tool is registered under this id. Run `recipe doctor`; install or allowlist the plugin that provides it.",
   budget_exceeded:
     "Run exceeded its tokensMax budget. Raise tokensMax in the recipe or shrink prompts.",
+  prompt_too_large:
+    "The step's prompt was larger than the agent prompt limit, so nothing was sent. Shorten the prompt, or the tool output it interpolates.",
   expect_failed:
     "A step's expect: assertion didn't match. Inspect the assertion + actual output.",
   step_timeout:

--- a/dashboard/src/lib/haltPhrasing.ts
+++ b/dashboard/src/lib/haltPhrasing.ts
@@ -177,6 +177,14 @@ export function ownerHaltPhrase(
         fix: "open-trace",
         fixLabel: "See what happened",
       };
+    case "prompt_too_large":
+      // Deliberately NOT "open-trace": no model was called, so a trace has no
+      // model call to show. The fix is in the recipe, like `unsupported_step`.
+      return {
+        sentence:
+          "It built a message too large to send, so it stopped before sending anything.",
+        fix: "none",
+      };
     case "unknown":
       return {
         sentence: "It stopped for a reason we couldn't label.",

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,11 +52,11 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
-- **feat/prompt-byte-cap** (2026-09-03) — refuse over-cap agent prompts at the `executeAgent` seam (96 KiB author budget, `prompt_too_large` halt). Touches `agentExecutor.ts`, `haltCategory.ts` + the dashboard halt maps.
-
 
 
 ## Recently closed (informal log, prune periodically)
+
+- **feat/prompt-byte-cap** — 96 KiB author-prompt cap refused at the `executeAgent` seam, `prompt_too_large` halt (#1588)
 
 - 2026-09-02 `fix/fanout-item-prompts` — provenance gap 1: fan_out agent-item prompts get secret redaction (both profiles) and the existing root provenance envelope (governed) via a renderer injected by yamlRunner; nothing transitive. Touches src/recipes/yamlRunner.ts, src/recipes/tools/fanOut.ts and a new test. — Claude Code (fanout-provenance worktree) PR #1587
 - 2026-09-02 `fix/judge-artefact-envelope` — provenance gap 3: the judge's reviewed `<artefact>` gets secret redaction and closing-tag containment in BOTH profiles, plus the untrusted envelope under governed; both the first-pass and re-judge call sites. Touches src/recipes/judgeVerdict.ts, src/recipes/yamlRunner.ts and two new tests. — Claude Code (judge-artefact worktree) PR #1584

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -52,6 +52,8 @@ verified (which is how this line came to be written).
 
 _Empty is a legitimate state. See "Retire your own entry before merging" above._
 
+- **feat/prompt-byte-cap** (2026-09-03) — refuse over-cap agent prompts at the `executeAgent` seam (96 KiB author budget, `prompt_too_large` halt). Touches `agentExecutor.ts`, `haltCategory.ts` + the dashboard halt maps.
+
 
 
 ## Recently closed (informal log, prune periodically)

--- a/src/recipes/__tests__/promptByteCap.test.ts
+++ b/src/recipes/__tests__/promptByteCap.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Gap 7 — the prompt byte cap at the `executeAgent` seam.
+ *
+ * The invariant under test:
+ *
+ *   Every model-facing request crosses ONE byte-limit decision after the final
+ *   prompt is composed and before any transport receives it. No transport
+ *   implements its own cap.
+ *
+ * Three properties this file exists to pin, none of which an error-string
+ * assertion can see:
+ *
+ *   1. On breach there is NO MODEL CALL. Every test counts dep invocations and
+ *      asserts zero. A refusal that still dispatched would satisfy a message
+ *      assertion and fail the actual requirement.
+ *   2. The budget is the AUTHOR's. Mandatory governance text is reserved
+ *      separately, so switching compat -> governed must not reduce how much
+ *      prompt an author may send (the governed instruction is 550 bytes against
+ *      compat's 257; charging it to the author would silently shrink the budget
+ *      of every recipe on the machine the day the profile flips).
+ *   3. Bytes, not JavaScript string length. A four-byte codepoint counts four.
+ *
+ * Every describe block carries a positive control that DOES dispatch, so a seam
+ * that refused everything — or one that never ran at all — cannot pass.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetActiveProfileForTesting,
+  resolveProfile,
+  setActiveProfile,
+} from "../../governance/profile.js";
+import {
+  type AgentExecutorDeps,
+  executeAgent,
+  MAX_AGENT_PROMPT_BYTES,
+} from "../agentExecutor.js";
+import {
+  categoriseHaltReason,
+  HALT_CATEGORY_HINTS,
+  HALT_CATEGORY_LABELS,
+} from "../haltCategory.js";
+
+function makeDeps(
+  overrides: Partial<AgentExecutorDeps> = {},
+): AgentExecutorDeps {
+  return {
+    anthropicFn: vi.fn().mockResolvedValue({ text: "anthropic-result" }),
+    providerDriverFn: vi
+      .fn()
+      .mockImplementation((driver: string) =>
+        Promise.resolve({ text: `${driver}-result` }),
+      ),
+    claudeCliFn: vi.fn().mockResolvedValue({ text: "claude-cli-result" }),
+    localFn: vi.fn().mockResolvedValue({ text: "local-result" }),
+    probeClaudeCli: vi.fn().mockReturnValue(false),
+    loadPatchworkConfig: vi.fn().mockReturnValue({}),
+    ...overrides,
+  };
+}
+
+const governed = () =>
+  setActiveProfile(resolveProfile({ profile: "governed" }));
+const compat = () => setActiveProfile(resolveProfile({ profile: "compat" }));
+
+/** A prompt of exactly `bytes` UTF-8 bytes, built from ASCII. */
+const ascii = (bytes: number) => "a".repeat(bytes);
+/** A prompt of exactly `bytes` UTF-8 bytes, built from 4-byte codepoints. */
+const fourByte = (bytes: number) => "\u{1F600}".repeat(bytes / 4);
+
+const noDispatch = (deps: AgentExecutorDeps) => {
+  expect(deps.anthropicFn).not.toHaveBeenCalled();
+  expect(deps.providerDriverFn).not.toHaveBeenCalled();
+  expect(deps.claudeCliFn).not.toHaveBeenCalled();
+  expect(deps.localFn).not.toHaveBeenCalled();
+};
+
+beforeEach(() => _resetActiveProfileForTesting());
+
+// ── the cap itself ───────────────────────────────────────────────────────────
+
+describe("the cap is 96 KiB of author prompt", () => {
+  it("is 98304 bytes", () => {
+    expect(MAX_AGENT_PROMPT_BYTES).toBe(98_304);
+  });
+});
+
+// ── T1 / T2: refusal does not dispatch, and the control does ─────────────────
+
+describe("subprocess", () => {
+  beforeEach(compat);
+
+  // T1
+  it("over the cap: refuses without calling the CLI", async () => {
+    const deps = makeDeps();
+    const result = await executeAgent(
+      { driver: "subprocess", prompt: ascii(MAX_AGENT_PROMPT_BYTES + 1) },
+      deps,
+    );
+    noDispatch(deps);
+    expect(result.text).toMatch(/^\[agent step failed: prompt_too_large/);
+  });
+
+  // T2 — positive control. Without this, T1 passes against a seam that
+  // refuses unconditionally, or one that was never reached.
+  it("at the cap exactly: dispatches", async () => {
+    const deps = makeDeps();
+    const result = await executeAgent(
+      { driver: "subprocess", prompt: ascii(MAX_AGENT_PROMPT_BYTES) },
+      deps,
+    );
+    expect(deps.claudeCliFn).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe("claude-cli-result");
+  });
+});
+
+// ── T3: bytes, not characters ────────────────────────────────────────────────
+
+describe("measured in UTF-8 bytes", () => {
+  beforeEach(compat);
+
+  it("refuses a prompt whose CHARACTER count is well under the cap", async () => {
+    const deps = makeDeps();
+    // (cap/4)+1 emoji => cap+4 bytes, but only ~24.5k JS characters. A
+    // `.length` check would admit this.
+    const prompt = fourByte(MAX_AGENT_PROMPT_BYTES + 4);
+    expect(prompt.length).toBeLessThan(MAX_AGENT_PROMPT_BYTES);
+    expect(Buffer.byteLength(prompt, "utf8")).toBeGreaterThan(
+      MAX_AGENT_PROMPT_BYTES,
+    );
+    await executeAgent({ driver: "subprocess", prompt }, deps);
+    noDispatch(deps);
+  });
+
+  it("admits the same character count in ASCII", async () => {
+    const deps = makeDeps();
+    await executeAgent(
+      { driver: "subprocess", prompt: ascii(MAX_AGENT_PROMPT_BYTES / 4) },
+      deps,
+    );
+    expect(deps.claudeCliFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── T4: every transport, not just the argv-bound one ─────────────────────────
+
+describe("every transport inherits the cap", () => {
+  beforeEach(compat);
+
+  const cases = [
+    ["anthropic", "anthropicFn"],
+    ["openai", "providerDriverFn"],
+    ["local", "localFn"],
+    ["subprocess", "claudeCliFn"],
+  ] as const;
+
+  for (const [driver, fn] of cases) {
+    it(`${driver}: over the cap refuses without dispatching`, async () => {
+      const deps = makeDeps();
+      const result = await executeAgent(
+        { driver, prompt: ascii(MAX_AGENT_PROMPT_BYTES + 1) },
+        deps,
+      );
+      noDispatch(deps);
+      expect(result.text).toMatch(/prompt_too_large/);
+    });
+
+    it(`${driver}: under the cap dispatches (control)`, async () => {
+      const deps = makeDeps();
+      await executeAgent({ driver, prompt: "hello" }, deps);
+      expect(deps[fn]).toHaveBeenCalledTimes(1);
+    });
+  }
+});
+
+// ── T5: the author's budget does not shrink under `governed` ─────────────────
+
+describe("mandatory governance text is reserved, not charged to the author", () => {
+  // The governed instruction is 550 bytes against compat's 257. If the cap
+  // measured the composed prompt, a recipe sitting within 293 bytes of the
+  // limit would start failing the day the profile flipped — a policy change
+  // silently rewriting what recipes are allowed to say.
+  it("a prompt at the cap dispatches under BOTH profiles", async () => {
+    const atCap = ascii(MAX_AGENT_PROMPT_BYTES);
+
+    compat();
+    const c = makeDeps();
+    await executeAgent({ driver: "subprocess", prompt: atCap }, c);
+    expect(c.claudeCliFn).toHaveBeenCalledTimes(1);
+
+    _resetActiveProfileForTesting();
+    governed();
+    const g = makeDeps();
+    await executeAgent({ driver: "subprocess", prompt: atCap }, g);
+    expect(g.claudeCliFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses at the same byte figure under BOTH profiles", async () => {
+    const overCap = ascii(MAX_AGENT_PROMPT_BYTES + 1);
+
+    compat();
+    const c = makeDeps();
+    await executeAgent({ driver: "subprocess", prompt: overCap }, c);
+    noDispatch(c);
+
+    _resetActiveProfileForTesting();
+    governed();
+    const g = makeDeps();
+    await executeAgent({ driver: "subprocess", prompt: overCap }, g);
+    noDispatch(g);
+  });
+});
+
+// ── T6 / T12: the halt reason ────────────────────────────────────────────────
+
+describe("the halt reason", () => {
+  beforeEach(compat);
+
+  const reasonFor = async (bytes: number) => {
+    const deps = makeDeps();
+    const r = await executeAgent(
+      { driver: "subprocess", prompt: ascii(bytes) },
+      deps,
+    );
+    return r.text;
+  };
+
+  // T6 — and it must not be swallowed by the generic `agent ... threw` matcher.
+  it("categorises as prompt_too_large", async () => {
+    const reason = await reasonFor(MAX_AGENT_PROMPT_BYTES + 1);
+    expect(categoriseHaltReason(reason)).toBe("prompt_too_large");
+  });
+
+  // T12 — `stepObservation` truncates the matched fragment at 120 characters,
+  // which once amputated the actionable half of the LOCAL_ONLY message. Both
+  // byte figures must survive that cut.
+  it("carries both byte figures within the first 120 characters", async () => {
+    const reason = (await reasonFor(MAX_AGENT_PROMPT_BYTES + 3538)).slice(
+      0,
+      120,
+    );
+    expect(reason).toContain(String(MAX_AGENT_PROMPT_BYTES + 3538));
+    expect(reason).toContain(String(MAX_AGENT_PROMPT_BYTES));
+  });
+
+  it("never contains the prompt itself", async () => {
+    const deps = makeDeps();
+    const secretish = `SENTINEL${"b".repeat(MAX_AGENT_PROMPT_BYTES)}`;
+    const r = await executeAgent(
+      { driver: "subprocess", prompt: secretish },
+      deps,
+    );
+    expect(r.text).not.toContain("SENTINEL");
+    expect(r.text.length).toBeLessThan(400);
+  });
+});
+
+// ── T11: compat is structural, not careful ───────────────────────────────────
+
+describe("under the cap, the transport call shape is unchanged", () => {
+  beforeEach(compat);
+
+  it("passes no extra argument", async () => {
+    const deps = makeDeps();
+    await executeAgent(
+      { driver: "anthropic", prompt: "hello", model: "claude-haiku" },
+      deps,
+    );
+    expect(deps.anthropicFn).toHaveBeenCalledWith("hello", "claude-haiku");
+  });
+});
+
+// ── the category is a first-class member, not a string in one matcher ────────
+
+describe("prompt_too_large is a real halt category", () => {
+  // Both maps are `Record<HaltCategory, string>`, so a missing entry is a
+  // compile error here — but the DASHBOARD keeps its own union and compiles
+  // separately, and `haltCategoryContract.test.ts` is what catches that drift
+  // as text. This test only pins that the bridge half exists and is worded.
+  it("has a label and a fix hint", () => {
+    expect(HALT_CATEGORY_LABELS.prompt_too_large).toBeTruthy();
+    expect(HALT_CATEGORY_HINTS.prompt_too_large).toBeTruthy();
+  });
+});

--- a/src/recipes/__tests__/promptByteCapRunners.test.ts
+++ b/src/recipes/__tests__/promptByteCapRunners.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Gap 7 — the prompt byte cap as the RUNNERS see it.
+ *
+ * `promptByteCap.test.ts` pins the decision at the seam. This file pins that
+ * every path which can reach the seam actually does, and that the refusal
+ * arrives as a halted step rather than a silently-skipped one:
+ *
+ *   T7   flat runner agent step
+ *   T8   chained runner (through the injected executor)
+ *   T9   fan_out per-item agent
+ *   T10  a judge/refine REVISION
+ *
+ * Each dispatches a real driver dep, so "the model was not called" is checked
+ * where it matters — a cap that only formats a message would pass a runner test
+ * written against the returned text alone.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { MAX_AGENT_PROMPT_BYTES } from "../agentExecutor.js";
+import {
+  buildChainedDeps,
+  type RunnerDeps,
+  runYamlRecipe,
+  type YamlRecipe,
+} from "../yamlRunner.js";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "prompt-cap-runners-"));
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+const OVER = "a".repeat(MAX_AGENT_PROMPT_BYTES + 1);
+
+function baseDeps(overrides: Partial<RunnerDeps> = {}): RunnerDeps {
+  return {
+    now: () => new Date("2026-09-03T09:00:00Z"),
+    logDir: TMP,
+    testMode: true,
+    readFile: () => {
+      throw new Error("nf");
+    },
+    writeFile: () => {},
+    appendFile: () => {},
+    mkdir: () => {},
+    gitLogSince: () => "",
+    gitStaleBranches: () => "",
+    getDiagnostics: () => "",
+    ...overrides,
+  } as unknown as RunnerDeps;
+}
+
+// ── T7: flat runner ──────────────────────────────────────────────────────────
+
+describe("flat runner", () => {
+  it("halts the step with prompt_too_large and never calls the driver", async () => {
+    const localFn = vi.fn(async () => "should not be reached");
+    const recipe = {
+      name: "prompt-cap-flat",
+      trigger: { type: "manual" },
+      steps: [{ agent: { prompt: OVER, driver: "local" }, into: "answer" }],
+    } as unknown as YamlRecipe;
+
+    const result = await runYamlRecipe(recipe, baseDeps({ localFn }));
+    const halt = result.stepResults.find((s) => s.status === "error");
+
+    expect(localFn).not.toHaveBeenCalled();
+    // An over-cap step must HALT, not skip: a skipped step finishes the run
+    // `done`, which is the failure mode the unregistered-tool path already has
+    // and the one an operator cannot see.
+    expect(halt).toBeDefined();
+    expect(halt?.haltReason ?? "").toContain("prompt_too_large");
+  });
+
+  it("control: an under-cap step dispatches and succeeds", async () => {
+    const localFn = vi.fn(async () => "real answer");
+    const recipe = {
+      name: "prompt-cap-flat-ok",
+      trigger: { type: "manual" },
+      steps: [{ agent: { prompt: "small", driver: "local" }, into: "answer" }],
+    } as unknown as YamlRecipe;
+
+    const result = await runYamlRecipe(recipe, baseDeps({ localFn }));
+    expect(localFn).toHaveBeenCalledTimes(1);
+    expect(
+      result.stepResults.find((s) => s.status === "error"),
+    ).toBeUndefined();
+  });
+});
+
+// ── T9: fan_out per-item agent ───────────────────────────────────────────────
+
+describe("fan_out agent iterations", () => {
+  it("refuses the over-cap iteration without dispatching it", async () => {
+    const localFn = vi.fn(async () => "should not be reached");
+    const recipe = {
+      name: "prompt-cap-fanout",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          tool: "fan_out",
+          items: ["one", "two"],
+          as: "item",
+          do: { agent: { prompt: `${OVER}{{item}}`, driver: "local" } },
+          into: "results",
+        },
+      ],
+    } as unknown as YamlRecipe;
+
+    const result = await runYamlRecipe(recipe, baseDeps({ localFn }));
+    expect(localFn).not.toHaveBeenCalled();
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltReason ?? "").toContain("prompt_too_large");
+  });
+
+  it("control: under-cap iterations each dispatch once", async () => {
+    const localFn = vi.fn(async () => "ok");
+    const recipe = {
+      name: "prompt-cap-fanout-ok",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          tool: "fan_out",
+          items: ["one", "two"],
+          as: "item",
+          do: { agent: { prompt: "handle {{item}}", driver: "local" } },
+          into: "results",
+        },
+      ],
+    } as unknown as YamlRecipe;
+
+    await runYamlRecipe(recipe, baseDeps({ localFn }));
+    expect(localFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── T10: a judge/refine revision ─────────────────────────────────────────────
+
+describe("judge / refine", () => {
+  it("an over-cap revision refuses without dispatching, and is not counted as a completed revision", async () => {
+    // First pass is small and succeeds; the revision prompt carries the
+    // (over-cap) prior output back in, which is how a revision grows past a
+    // limit the original pass sat under.
+    const localFn = vi.fn(async () => OVER);
+    const recipe = {
+      name: "prompt-cap-revision",
+      trigger: { type: "manual" },
+      steps: [
+        {
+          agent: {
+            prompt: "draft something",
+            driver: "local",
+            reviews: "answer",
+            max_revisions: 1,
+          },
+          into: "answer",
+        },
+      ],
+    } as unknown as YamlRecipe;
+
+    const result = await runYamlRecipe(recipe, baseDeps({ localFn }));
+    const halt = result.stepResults.find((s) => s.status === "error");
+    expect(halt?.haltReason ?? "").toContain("prompt_too_large");
+    // The revision that never dispatched must not be recorded as one that did.
+    expect(halt?.revisions ?? 0).toBe(0);
+  });
+});
+
+// ── T8: chained runner ───────────────────────────────────────────────────────
+
+describe("chained runner", () => {
+  // The chained runner receives `executeAgent` as an injected dep, so mocking
+  // that dep would test the mock. The property that matters is that the
+  // PRODUCTION wiring — the closure `buildChainedDeps` hands it — routes
+  // through the real seam, and therefore inherits the cap for free.
+  it("its production executor refuses an over-cap prompt without dispatching", async () => {
+    const localFn = vi.fn(async () => "should not be reached");
+    const deps = buildChainedDeps(baseDeps({ localFn }));
+
+    const result = await deps.executeAgent(OVER, undefined, "local");
+
+    expect(localFn).not.toHaveBeenCalled();
+    const text = typeof result === "string" ? result : result.text;
+    expect(text).toContain("prompt_too_large");
+  });
+
+  it("control: an under-cap prompt dispatches once", async () => {
+    const localFn = vi.fn(async () => "real answer");
+    const deps = buildChainedDeps(baseDeps({ localFn }));
+
+    await deps.executeAgent("small", undefined, "local");
+
+    expect(localFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/recipes/__tests__/promptByteCapRunners.test.ts
+++ b/src/recipes/__tests__/promptByteCapRunners.test.ts
@@ -91,6 +91,12 @@ describe("flat runner", () => {
 // ── T9: fan_out per-item agent ───────────────────────────────────────────────
 
 describe("fan_out agent iterations", () => {
+  // fan_out's default is `on_iter_error: continue`, so the assertion is that
+  // the ITERATION fails without dispatching — not that the step halts. A cap
+  // refusal deliberately does NOT behave like the budget halt one line below it
+  // in `fanOut.ts`: a budget is global and monotonic, so once it says stop every
+  // later iteration is also refused, whereas an over-cap prompt is a property of
+  // ONE item's rendered text and the next item may be small.
   it("refuses the over-cap iteration without dispatching it", async () => {
     const localFn = vi.fn(async () => "should not be reached");
     const recipe = {
@@ -108,9 +114,16 @@ describe("fan_out agent iterations", () => {
     } as unknown as YamlRecipe;
 
     const result = await runYamlRecipe(recipe, baseDeps({ localFn }));
+
     expect(localFn).not.toHaveBeenCalled();
-    const halt = result.stepResults.find((s) => s.status === "error");
-    expect(halt?.haltReason ?? "").toContain("prompt_too_large");
+    const step = result.stepResults[0];
+    expect(step?.status).toBe("ok");
+    const aggregate = step?.output as { index: number; ok: boolean }[];
+    // Both items still appear — the loop shape is unchanged — and each records
+    // the refusal rather than a model failure.
+    expect(aggregate).toHaveLength(2);
+    expect(aggregate.every((r) => r.ok === false)).toBe(true);
+    expect(JSON.stringify(aggregate)).toContain("prompt_too_large");
   });
 
   it("control: under-cap iterations each dispatch once", async () => {
@@ -137,32 +150,43 @@ describe("fan_out agent iterations", () => {
 // ── T10: a judge/refine revision ─────────────────────────────────────────────
 
 describe("judge / refine", () => {
-  it("an over-cap revision refuses without dispatching, and is not counted as a completed revision", async () => {
-    // First pass is small and succeeds; the revision prompt carries the
-    // (over-cap) prior output back in, which is how a revision grows past a
-    // limit the original pass sat under.
-    const localFn = vi.fn(async () => OVER);
+  // The writer's prompt is small and dispatches; its OUTPUT is over-cap, and
+  // the judge prompt embeds that output in an `<artefact>` block. This is how a
+  // prompt grows past a limit nothing in the recipe text approaches — the
+  // author never wrote 96 KiB, a tool or a prior step handed it over.
+  it("an over-cap judge prompt refuses without dispatching the judge", async () => {
+    const claudeFn = vi.fn(async (prompt: string) =>
+      prompt.includes("<artefact>") ? "should not be reached" : OVER,
+    );
     const recipe = {
-      name: "prompt-cap-revision",
+      name: "prompt-cap-judge",
       trigger: { type: "manual" },
       steps: [
         {
           agent: {
-            prompt: "draft something",
-            driver: "local",
-            reviews: "answer",
-            max_revisions: 1,
+            prompt: "write the thing",
+            driver: "anthropic",
+            into: "draft",
           },
-          into: "answer",
+        },
+        {
+          agent: {
+            kind: "judge",
+            reviews: "draft",
+            max_revisions: 1,
+            prompt: "review the draft",
+            driver: "anthropic",
+          },
         },
       ],
     } as unknown as YamlRecipe;
 
-    const result = await runYamlRecipe(recipe, baseDeps({ localFn }));
+    const result = await runYamlRecipe(recipe, baseDeps({ claudeFn }));
+
+    // The writer ran once; the judge never did.
+    expect(claudeFn).toHaveBeenCalledTimes(1);
     const halt = result.stepResults.find((s) => s.status === "error");
     expect(halt?.haltReason ?? "").toContain("prompt_too_large");
-    // The revision that never dispatched must not be recorded as one that did.
-    expect(halt?.revisions ?? 0).toBe(0);
   });
 });
 

--- a/src/recipes/agentExecutor.ts
+++ b/src/recipes/agentExecutor.ts
@@ -555,6 +555,27 @@ function evaluateAgainst(
   });
 }
 
+/**
+ * Ceiling on the AUTHORED prompt an agent step may dispatch, in UTF-8 bytes.
+ *
+ * 96 KiB. One figure for every driver, deliberately: a per-driver ceiling makes
+ * the same recipe work or fail depending on which model answered, which is a
+ * property no author can reason about. The recipe gets one predictable limit.
+ *
+ * The number is chosen against the argv-bound path, which is the one with a
+ * hard ceiling rather than a policy: the Claude CLI receives the prompt as a
+ * single argv element, and Linux caps ONE argument at 128 KiB
+ * (`MAX_ARG_STRLEN`) regardless of how much total argv space is free. Above it
+ * `spawn` fails E2BIG — so an over-cap prompt is not "expensive", it is
+ * unrunnable on a Linux bridge while working on a developer's macOS box. 96 KiB
+ * leaves room for the system prompt, the flags and the environment without the
+ * author's budget having to know any of that.
+ *
+ * It is the AUTHOR's budget. The mandatory system/governance instruction is
+ * reserved separately and never counted against it — see `executeAgent`.
+ */
+export const MAX_AGENT_PROMPT_BYTES = 98_304;
+
 export async function executeAgent(
   input: AgentExecutorInput,
   deps: AgentExecutorDeps,
@@ -690,6 +711,39 @@ export async function executeAgent(
       labelSource: input.boundary?.dataPolicy ? "declared" : "assumed",
       ...(boundary.categories && { categories: boundary.categories }),
     });
+  }
+
+  // ── PROMPT BYTE CAP ─────────────────────────────────────────────────────
+  // One byte-limit decision, after the prompt is fully composed and before any
+  // transport receives it. No driver implements its own cap: two places
+  // deciding this would drift, and the drift is silent — a prompt refused by
+  // one driver and dispatched by another is indistinguishable, from the
+  // recipe's side, from a flaky model.
+  //
+  // REFUSES; never truncates. Truncation would cut the tail of a rendered
+  // prompt, which is where the author's instructions sit once a large tool
+  // output has been interpolated above them — the model would then act on the
+  // data with no task, and the run would look successful. It can also sever the
+  // closing tag of an `<untrusted>` envelope this codebase put there.
+  //
+  // Measured on the AUTHORED prompt only. The governed instruction is 550 bytes
+  // against compat's 257, so charging the reservation to the author would
+  // shrink every recipe's allowance by 293 bytes the day an operator switched
+  // profile — a policy change quietly rewriting what recipes are allowed to
+  // say. Both figures are constants; neither is the author's to pay for.
+  //
+  // Placed AFTER the boundary so a refused dispatch still writes its privacy
+  // receipt, and a boundary refusal still wins: an over-cap prompt to a
+  // destination that may not receive it is a boundary event first.
+  const promptBytes = Buffer.byteLength(prompt, "utf8");
+  if (promptBytes > MAX_AGENT_PROMPT_BYTES) {
+    // Numbers FIRST. `stepObservation` truncates the matched fragment at 120
+    // characters, which already amputated the actionable half of the
+    // information-boundary message once. Never echo the prompt: this string
+    // reaches the run log, the halt summary and a push notification.
+    return {
+      text: `[agent step failed: prompt_too_large: ${promptBytes} bytes > ${MAX_AGENT_PROMPT_BYTES} byte limit — shorten the step's prompt or the tool output it interpolates]`,
+    };
   }
 
   // ── AGENT CONTAINMENT (Phase 0 step 6) ──────────────────────────────────

--- a/src/recipes/haltCategory.ts
+++ b/src/recipes/haltCategory.ts
@@ -26,6 +26,15 @@ export type HaltCategory =
   | "unresolved_tool"
   /** Recipe's `tokensMax` budget breached (PR2b). */
   | "budget_exceeded"
+  /**
+   * The composed prompt exceeded the agent prompt byte cap, so the step was
+   * refused BEFORE dispatch. Its own category, not `budget_exceeded`: that one
+   * means real tokens or dollars were spent up to a ceiling the author set,
+   * while this one means nothing was spent and nothing was sent. Not
+   * `agent_threw` either — no model was called, so a run trace shows no model
+   * call to open.
+   */
+  | "prompt_too_large"
   /** Per-step `expect` assertion failed (slice 2). */
   | "expect_failed"
   /** Per-step wall-clock `timeout_ms` exceeded (sandbox-alternative slice). */
@@ -113,6 +122,7 @@ export const HALT_CATEGORY_LABELS: Record<HaltCategory, string> = {
   policy_denied: "policy refused",
   unresolved_tool: "tool not registered",
   budget_exceeded: "budget exceeded",
+  prompt_too_large: "prompt too large",
   expect_failed: "expect failed",
   step_timeout: "step timeout",
   judge_revisions_exhausted: "judge revisions exhausted",
@@ -146,6 +156,8 @@ export const HALT_CATEGORY_HINTS: Record<HaltCategory, string> = {
   unresolved_tool:
     "run `recipe doctor`; install or allowlist the plugin that provides the tool",
   budget_exceeded: "raise tokensMax / usdMax or shrink prompts",
+  prompt_too_large:
+    "shorten the step prompt, or the tool output it interpolates — nothing was sent",
   expect_failed: "inspect assertion vs actual output",
   step_timeout: "bump timeout_ms or speed up step",
   judge_revisions_exhausted:
@@ -182,6 +194,9 @@ export function categoriseHaltReason(reason: string | undefined): HaltCategory {
   if (/kill[- _]?switch/i.test(reason)) return "kill_switch";
   if (/budget[_ ]?exceeded|exceeded its token budget/i.test(reason))
     return "budget_exceeded";
+  // Before every generic matcher: the sentence contains "agent step failed",
+  // which `agent_threw` would otherwise claim.
+  if (/prompt_too_large/i.test(reason)) return "prompt_too_large";
   // Both must precede the rejection matcher: its `rejected by .*approval`
   // alternative is broad, and a mis-ordered expiry reading as a rejection is
   // exactly the failure this split exists to end.


### PR DESCRIPTION
An agent prompt larger than any transport can carry was dispatched anyway, and
failed downstream in a way that named nothing. The Claude CLI receives the
prompt as a single argv element and Linux caps ONE argument at 128 KiB
(`MAX_ARG_STRLEN`), so `spawn` returned E2BIG and the run recorded
`Agent step … threw` with the hint "open run trace" — a trace of a model call
that never happened. The same recipe worked on macOS, whose limit is on total
argv rather than per argument. API drivers arrived at the same category by a
different route: a provider 400.

There is now one byte-limit decision, at the `executeAgent` seam, after the
prompt is fully composed and before any transport receives it.

## Invariants

- **98,304 UTF-8 bytes** (96 KiB) of *authored* prompt, measured with
  `Buffer.byteLength` — a `.length` check admits ~24.5k emoji characters that
  are four times that in bytes.
- **Both profiles, every transport.** The same figure for `compat` and
  `governed`, and for subprocess, Anthropic, provider and local alike. A
  per-driver ceiling would make the same recipe work or fail depending on which
  model answered, which no author can reason about.
- **Mandatory system/governance text does not consume the author's allowance.**
  The governed instruction is 550 bytes against compat's 257; charging the
  reservation to the author would shrink every recipe's budget by 293 bytes the
  day an operator switched profile — a policy change quietly rewriting what
  recipes may say.
- **Refuse, never truncate.** Truncation cuts the tail of a rendered prompt, and
  the tail is where the author's instructions sit once a large tool output has
  been interpolated above them: the model would act on the data with no task and
  the run would look successful. It can also sever the closing tag of an
  `<untrusted>` envelope this codebase put there.
- **`prompt_too_large` is an explicit halt with its own evidence.** Not
  `budget_exceeded` (real spend, up to a ceiling the author set) and not
  `agent_threw` (which sends an operator to a trace containing no model call).
  The reason leads with both byte figures because `stepObservation` truncates the
  matched fragment at 120 characters, and it never echoes prompt content.
- **Zero dispatch, zero usage, zero attempt on refusal.** No `servedBy`, no
  usage, and a refused judge revision is not counted as a revision — so a
  refusal stays distinguishable from a model attempt that failed.
- **fan_out keeps its existing per-iteration behaviour.** An over-cap iteration
  fails that iteration; it does not halt the batch. Unlike the budget halt one
  line below it in `fanOut.ts`, an over-cap prompt is a property of ONE item's
  rendered text, so the next item may be small. `on_iter_error` semantics are
  unchanged.

## Coverage

Failing-first: the tests were committed red, with 15 of 27 assertions failing —
every one because the model *was* called with a prompt no transport could carry.
Each refusal test counts driver invocations and asserts zero, because an
assertion on the error string alone is satisfied by a seam that formats a message
and dispatches anyway; each block carries a positive control that does dispatch,
so a seam refusing everything (or never reached) cannot pass.

Runner coverage exists because the seam is only useful if everything reaches it:
flat runner, fan_out iteration, judge/refine, and the closure `buildChainedDeps`
hands the chained runner — mocking the chained runner's injected `executeAgent`
would have tested the mock.

Mutation-checked: disabling the comparison fails 13 of 27; charging the governed
reservation to the author fails exactly the two tests that exist to catch it.

The dashboard keeps its own `HaltCategory` union and compiles separately, so the
category, label, hint and owner-facing phrasing are added there too;
`haltCategoryContract.test.ts` compares the two as text, since a
`Record<HaltCategory, string>` over a shorter union is perfectly well-typed.

## Not in this PR

No truncation anywhere, no transport-specific caps, no change to
`runClaudeTask`'s operator cap or the automation hooks' 32 KB truncation, and no
provenance-propagation work.

**No runtime deployment.** The bridges stay on their current build; this merges
as code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)