### PR TITLE
fix(cli): refuse an argument the command cannot honour

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -57,6 +57,8 @@ _Empty is a legitimate state. See "Retire your own entry before merging" above._
 ## Recently closed (informal log, prune periodically)
 
 - **feat/provenance-propagation** — proven origins carried through agent, judge/refine and nested outputs; zero origins stays unmarked (#1589)
+- 2026-09-04 `fix/fail-closed-cli-parsing` — an unrecognised argument exits non-zero and names what it did not understand, in the two confirmed instances of that family (`patchwork evidence`, `audit-private-identifiers.mjs`) plus a shared `rejectUnknownArgs` helper the remaining verbs can adopt incrementally. Usage errors exit 2 so a typo stays distinguishable from `evidence verify`'s exit 1 on a broken chain. Touches src/cliArgs.ts, src/index.ts, scripts/audit-private-identifiers.mjs and two new tests. — Claude Code (fail-closed-cli-parsing worktree) PR #1590
+
 
 - **feat/prompt-byte-cap** — 96 KiB author-prompt cap refused at the `executeAgent` seam, `prompt_too_large` halt (#1588)
 

--- a/scripts/audit-private-identifiers.mjs
+++ b/scripts/audit-private-identifiers.mjs
@@ -127,8 +127,55 @@ function loadPatterns(p) {
     .filter((l) => l && !l.startsWith("#"));
 }
 
+/**
+ * Refuse an argument this gate cannot honour.
+ *
+ * `--message-file <path>` — the real flag is `--message` — matched neither
+ * branch below, fell through to the staged-diff default, scanned ~19 bytes of
+ * branch name and printed OK. The commit message it was pointed at was never
+ * read. This runs from a git hook, where nobody reads the output of a passing
+ * check, so the wrong flag name could have stood indefinitely.
+ *
+ * Deliberately a local copy of `src/cliArgs.ts` rather than an import: hooks
+ * run BEFORE any build, so a gate that imported from `dist/` would break on a
+ * clean clone. The echo rule is the part that must stay in step, and both sides
+ * have a test asserting a path-shaped argument is not echoed.
+ */
+function rejectUnknownArgs(argv) {
+  const VALUE_FLAGS = ["--message", "--text"];
+  const unknown = [];
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (VALUE_FLAGS.includes(tok)) {
+      i++; // its value follows and is not ours to judge
+      continue;
+    }
+    unknown.push(tok);
+  }
+  if (unknown.length === 0) return;
+
+  // A refusal reaches a terminal, scrollback and CI logs. This script exists to
+  // keep private strings out of published text and never prints a matched
+  // identifier — only an entry number — so it holds the same line here: a bare
+  // word or a flag is echoed, anything path-shaped is described.
+  const named = unknown
+    .map((t) =>
+      /^-{0,2}[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/.test(t)
+        ? `'${t}'`
+        : "an argument that is not shown, because it may contain a private path",
+    )
+    .join(", ");
+  console.error(
+    `[private-ids] unrecognised ${unknown.length === 1 ? "argument" : "arguments"}: ${named}\n` +
+      `  accepted: --message <file> | --text <file> | (no arguments: staged diff + branch name)\n` +
+      `  NOTHING WAS SCANNED.`,
+  );
+  process.exit(2);
+}
+
 /** Sources to scan: `{ label, text }`. */
 function collectSources(argv) {
+  rejectUnknownArgs(argv);
   const msgIdx = argv.indexOf("--message");
   if (msgIdx !== -1) {
     const f = argv[msgIdx + 1];

--- a/src/__tests__/cliFailClosed.test.ts
+++ b/src/__tests__/cliFailClosed.test.ts
@@ -1,0 +1,188 @@
+/**
+ * An unrecognised argument must exit non-zero and name what it did not
+ * understand.
+ *
+ * Three instances of one family were found by hand, all of which reported
+ * SUCCESS while doing something other than what was asked:
+ *
+ *   - `patchwork evidence verify` ran the plain coverage report and exited 0,
+ *     because the CLI predated the subcommand. The operator believes an
+ *     integrity check passed; none ran. `verify` exists now — but any NEIGHBOUR
+ *     of it (`check`, `validate`) still degrades to the report the same way, so
+ *     the hole that produced that incident is open, merely moved one token
+ *     over.
+ *   - `audit-private-identifiers.mjs --message-file <f>` (the real flag is
+ *     `--message`) fell through to the staged-diff branch, scanned 19 bytes of
+ *     branch name, and printed OK.
+ *   - a scripted `string.replace` that matched nothing exited 0.
+ *
+ * The shared property is that the failure is INVISIBLE: a silently-ignored
+ * argument is indistinguishable from an honoured one, so the louder the
+ * command's success message the more convincing the wrong answer. That is why
+ * these tests assert on the EXIT CODE first and the text second.
+ *
+ * They SPAWN the built CLI. A unit test over the parser could not have caught
+ * the `evidence` instance, because the parser was never wired to reject
+ * anything — the defect was the absence of a call, which only the real entry
+ * point can demonstrate. Same reasoning as `doctorDispatch.test.ts`.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { rejectUnknownArgs, UNRECOGNISED_EXIT } from "../cliArgs.js";
+
+const distIndex = path.resolve(import.meta.dirname, "../../dist/index.js");
+
+let tmp = "";
+afterAll(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+function run(...args: string[]): { status: number; out: string } {
+  const r = spawnSync(process.execPath, [distIndex, ...args], {
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe("`patchwork evidence` refuses what it cannot honour", () => {
+  /**
+   * The shape of the original incident, with the token moved one over.
+   * `check` is a plausible typo for the real `verify`, and today it runs the
+   * coverage report and exits 0 — so an operator checking ledger integrity is
+   * told everything is fine by a command that never looked. Exactly the
+   * failure that stood before `verify` existed.
+   */
+  it("refuses an unknown subcommand instead of running the plain report", () => {
+    const r = run("evidence", "check");
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("check");
+    // The tell: the coverage report must NOT have been produced.
+    expect(r.out).not.toMatch(/rows carry|joinable/i);
+  });
+
+  it("refuses an unknown flag and names it", () => {
+    const r = run("evidence", "--summary");
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("--summary");
+  });
+
+  /**
+   * Usage errors exit 2, not 1. `evidence verify` exits 1 for a BROKEN CHAIN —
+   * the one form of this verb that gates.
+   * Collapsing "I did not understand you" into the same code as "your ledgers
+   * are tampered with" would make a typo indistinguishable from a real
+   * integrity failure in exactly the cron job written to act on it.
+   */
+  it("uses a usage exit code distinct from a gate failure", () => {
+    expect(run("evidence", "--summary").status).toBe(UNRECOGNISED_EXIT);
+    expect(UNRECOGNISED_EXIT).not.toBe(1);
+  });
+});
+
+describe("controls — the accepted forms must still work", () => {
+  it("bare `evidence` still reports and exits 0", () => {
+    const r = run("evidence");
+    expect(r.status).toBe(0);
+  });
+
+  /**
+   * The real subcommand must keep working, and must keep GATING: it is the one
+   * form of this verb that exits non-zero on a broken chain. A guard that
+   * refused it would disable the integrity check while looking like a fix.
+   */
+  it("`evidence verify` still runs the integrity check", () => {
+    const r = run("evidence", "verify");
+    expect(r.out).toContain("is the spine internally intact?");
+    expect(r.status).not.toBe(UNRECOGNISED_EXIT);
+  });
+
+  it("`evidence verify --json` still runs", () => {
+    const r = run("evidence", "verify", "--json");
+    expect(r.status).not.toBe(UNRECOGNISED_EXIT);
+    expect(r.out).toContain('"ok"');
+  });
+
+  it("`--json` still exits 0", () => {
+    expect(run("evidence", "--json").status).toBe(0);
+  });
+
+  it("`--help` still exits 0", () => {
+    const r = run("evidence", "--help");
+    expect(r.status).toBe(0);
+    expect(r.out).toContain("--dir");
+  });
+
+  /**
+   * The value after a value-taking flag must not itself be read as an unknown
+   * argument. Without this the guard would reject every real `--dir` call —
+   * a fail-closed check that breaks the working path is worse than the hole.
+   */
+  it("does not mistake a --dir value for an unknown argument", () => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "evidence-args-"));
+    const r = run("evidence", "--dir", tmp);
+    expect(r.status).toBe(0);
+  });
+});
+
+describe("naming the argument must not disclose a private path", () => {
+  /**
+   * This repository is world-readable and its operator ledgers are not. A
+   * refusal is printed to a terminal, scrollback and CI logs, so echoing an
+   * arbitrary token back would put whatever the operator typed — a path under
+   * a real client directory, say — into all three. Flags and bare words are
+   * echoed; anything path-shaped is described, never quoted. Same reasoning as
+   * the private-identifier gate, which prints an entry NUMBER and never the
+   * matched string.
+   */
+  it("echoes a bare word", () => {
+    const r = rejectUnknownArgs({
+      command: "evidence",
+      args: ["verify"],
+      flags: [],
+      exit: false,
+    });
+    expect(r?.message).toContain("verify");
+  });
+
+  it("echoes a flag", () => {
+    const r = rejectUnknownArgs({
+      command: "evidence",
+      args: ["--message-file"],
+      flags: [],
+      exit: false,
+    });
+    expect(r?.message).toContain("--message-file");
+  });
+
+  it("does NOT echo a path-shaped argument", () => {
+    const secret = "/Users/someone/AcmeConfidentialCo/notes.txt";
+    const r = rejectUnknownArgs({
+      command: "evidence",
+      args: [secret],
+      flags: [],
+      exit: false,
+    });
+    expect(r).not.toBeNull();
+    expect(r?.message).not.toContain("AcmeConfidentialCo");
+    expect(r?.message).not.toContain(secret);
+  });
+
+  it("returns null when every argument is recognised", () => {
+    expect(
+      rejectUnknownArgs({
+        command: "evidence",
+        args: ["--dir", os.tmpdir(), "--json"],
+        flags: ["--json"],
+        valueFlags: ["--dir"],
+        exit: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/__tests__/privateIdentifierGateArgs.test.ts
+++ b/src/__tests__/privateIdentifierGateArgs.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `audit-private-identifiers.mjs` must refuse an argument it does not
+ * understand, rather than scanning something else and printing OK.
+ *
+ * The instance: `--message-file <path>` — the real flag is `--message` —
+ * matched neither branch of `collectSources`, fell through to the staged-diff
+ * default, scanned ~19 bytes of branch name, and reported success. The commit
+ * message it was pointed at was never read. This gate runs from a git hook,
+ * where nobody reads the output of a passing check, so the wrong flag name
+ * could have stood indefinitely.
+ *
+ * A SEPARATE file from `privateIdentifierGate.test.ts` on purpose: this covers
+ * argument dispatch, that one covers denylist matching, and they are edited by
+ * different work.
+ *
+ * NOTE ON FIXTURES: every denylist pattern here is invented for the test, per
+ * the same rule as its sibling.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const REPO = path.resolve(import.meta.dirname, "..", "..");
+const SCRIPT = path.join(REPO, "scripts", "audit-private-identifiers.mjs");
+
+let dir = "";
+let denylist = "";
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), "priv-ids-args-"));
+  denylist = path.join(dir, "denylist.txt");
+  writeFileSync(denylist, "# synthetic\nAcmeConfidentialCo\n");
+});
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+function run(args: string[]): { status: number; out: string } {
+  const r = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: REPO,
+    encoding: "utf8",
+    env: { ...process.env, PATCHWORK_DENYLIST: denylist },
+  });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe("refuses an argument it cannot honour", () => {
+  /**
+   * The exact defect. The file contains a denylisted identifier, so a gate
+   * that had honoured the flag would BLOCK; one that ignored it prints OK.
+   * Asserting only on the exit code would therefore have been ambiguous —
+   * hence the assertion that the flag name is named.
+   */
+  it("rejects --message-file rather than scanning the staged diff", () => {
+    const f = path.join(dir, "msg.txt");
+    writeFileSync(f, "AcmeConfidentialCo");
+
+    const r = run(["--message-file", f]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("--message-file");
+    expect(r.out).not.toMatch(/\bOK\b/);
+  });
+
+  it("rejects an unknown bare argument", () => {
+    const r = run(["scan"]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("scan");
+  });
+
+  /**
+   * The refusal reaches a terminal, scrollback and CI logs. This script exists
+   * precisely to keep private strings out of published text and never prints a
+   * matched identifier — only an entry number — so its own usage error must
+   * hold the same line.
+   */
+  it("does not echo a path-shaped argument back", () => {
+    const r = run(["/Users/someone/AcmeConfidentialCo/notes.txt"]);
+    expect(r.status).not.toBe(0);
+    expect(r.out).not.toContain("AcmeConfidentialCo");
+  });
+});
+
+describe("controls — accepted forms are unchanged", () => {
+  it("--message still scans the named file and blocks", () => {
+    const f = path.join(dir, "msg.txt");
+    writeFileSync(f, "AcmeConfidentialCo");
+    expect(run(["--message", f]).status).toBe(1);
+  });
+
+  it("--message on clean text still passes", () => {
+    const f = path.join(dir, "clean.txt");
+    writeFileSync(f, "fix: a perfectly ordinary commit message");
+    expect(run(["--message", f]).status).toBe(0);
+  });
+
+  it("--text still scans the named file", () => {
+    const f = path.join(dir, "body.txt");
+    writeFileSync(f, "AcmeConfidentialCo");
+    expect(run(["--text", f]).status).toBe(1);
+  });
+
+  it("no arguments still scans the staged diff and branch name", () => {
+    expect(run([]).status).toBe(0);
+  });
+});

--- a/src/cliArgs.ts
+++ b/src/cliArgs.ts
@@ -1,0 +1,133 @@
+/**
+ * Refuse an argument the command cannot honour.
+ *
+ * Three instances of one family were found by hand, each of which reported
+ * SUCCESS while doing something other than what was asked: `patchwork evidence
+ * verify` running the plain coverage report, `audit-private-identifiers.mjs
+ * --message-file` scanning the branch name instead of the commit message, and
+ * a scripted `string.replace` that matched nothing. The common property is that
+ * the failure is invisible — a silently-ignored argument is indistinguishable
+ * from an honoured one, and the command's own success message is what makes the
+ * wrong answer convincing.
+ *
+ * So an unrecognised argument exits non-zero and names what it did not
+ * understand. Both halves matter: the exit code is what a script or git hook
+ * can act on, and the name is what stops the operator re-running the same typo.
+ *
+ * ## Why this is not shared with `scripts/audit-*.mjs`
+ *
+ * Those gates run from `.husky/` hooks, BEFORE any build, so they cannot import
+ * from `dist/`, and they are plain `.mjs` outside the TypeScript project. The
+ * private-identifier gate therefore carries its own small copy of this rule.
+ * That is a real duplication and is recorded rather than hidden: the shared
+ * alternative would make a pre-commit hook depend on a build artefact that may
+ * not exist, which is a worse failure than two short functions agreeing by
+ * review. The echo rule below is the part that must stay in step, and both
+ * sides have tests asserting a path-shaped argument is not echoed.
+ */
+
+/**
+ * Usage errors exit 2, distinct from 1.
+ *
+ * `evidence verify` exits 1 for a BROKEN CHAIN — the one form of that verb
+ * which gates. Collapsing "I did not understand you" into the same code would
+ * make a typo indistinguishable from a real integrity failure, in exactly the
+ * cron job written to act on one.
+ */
+export const UNRECOGNISED_EXIT = 2;
+
+/**
+ * Is this token safe to print back?
+ *
+ * A refusal reaches a terminal, scrollback and CI logs. This repository is
+ * world-readable and the operator paths typed at it are not, so an arbitrary
+ * token is not echoed: a bare word or a flag is, and anything carrying a path
+ * separator, an `@`, whitespace or unusual length is described instead. Same
+ * line the private-identifier gate holds when it prints an entry NUMBER and
+ * never the matched string.
+ */
+function safeToEcho(token: string): boolean {
+  return /^-{0,2}[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/.test(token);
+}
+
+function describe(token: string): string {
+  return safeToEcho(token)
+    ? `'${token}'`
+    : "an argument that is not shown, because it may contain a private path";
+}
+
+export interface RejectUnknownArgsOpts {
+  /** The command being parsed, for the message (e.g. "evidence"). */
+  command: string;
+  /** Arguments after the command, i.e. `process.argv.slice(3)`. */
+  args: string[];
+  /** Value-less flags this command accepts. `--help`/`-h` are always allowed. */
+  flags: string[];
+  /** Flags that consume the following token as their value. */
+  valueFlags?: string[];
+  /** Subcommands accepted in first position. */
+  subcommands?: string[];
+  /**
+   * Exit the process on a rejection (the default). Pass false to get the
+   * message back instead — used by tests, which must be able to assert on the
+   * text without terminating the runner.
+   */
+  exit?: boolean;
+}
+
+/**
+ * Returns null when every argument is recognised. Otherwise prints to stderr
+ * and exits {@link UNRECOGNISED_EXIT}, or — with `exit: false` — returns the
+ * message it would have printed.
+ */
+export function rejectUnknownArgs(
+  opts: RejectUnknownArgsOpts,
+): { message: string } | null {
+  const {
+    command,
+    args,
+    flags,
+    valueFlags = [],
+    subcommands = [],
+    exit = true,
+  } = opts;
+
+  const known = new Set([...flags, ...valueFlags, "--help", "-h"]);
+  const unknown: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: index is bounded by length
+    const tok = args[i]!;
+
+    // A subcommand is only a subcommand in first position. Accepting one
+    // anywhere would let `evidence --json verify` read as a verify, which is
+    // the silent-honour failure this function exists to prevent.
+    if (i === 0 && !tok.startsWith("-")) {
+      if (subcommands.includes(tok)) continue;
+      unknown.push(tok);
+      continue;
+    }
+
+    if (valueFlags.includes(tok)) {
+      i++; // its value is whatever follows, and is not ours to judge
+      continue;
+    }
+    if (known.has(tok)) continue;
+    unknown.push(tok);
+  }
+
+  if (unknown.length === 0) return null;
+
+  const named = unknown.map(describe).join(", ");
+  const accepted = [...subcommands, ...valueFlags, ...flags];
+  const message =
+    `patchwork ${command}: unrecognised ${unknown.length === 1 ? "argument" : "arguments"}: ${named}\n` +
+    // Naming what IS accepted turns the refusal into the answer. Without it the
+    // operator's next move is to guess again.
+    (accepted.length > 0 ? `  accepted: ${accepted.join(" ")}\n` : "") +
+    `  Nothing was run. Try: patchwork ${command} --help\n`;
+
+  if (!exit) return { message };
+  process.stderr.write(message);
+  process.exit(UNRECOGNISED_EXIT);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5318,6 +5318,19 @@ if (process.argv[2] === "evidence") {
   }
   (async () => {
     try {
+      // Fail closed. Before this, `evidence check` — a plausible typo for the
+      // real `verify` — ran the plain coverage report and exited 0, telling an
+      // operator who asked about ledger integrity that everything was fine from
+      // a command that never looked. That is the exact incident this guard is
+      // named for, one token over.
+      const { rejectUnknownArgs } = await import("./cliArgs.js");
+      rejectUnknownArgs({
+        command: "evidence",
+        args,
+        subcommands: ["verify"],
+        valueFlags: ["--dir"],
+        flags: ["--json"],
+      });
       const dirIdx = args.indexOf("--dir");
       const dir = dirIdx !== -1 ? args[dirIdx + 1] : undefined;
       if (args[0] === "verify") {


### PR DESCRIPTION
## What

An unrecognised argument now exits non-zero and names what it did not understand, in the two places a silent fall-through was confirmed by hand.

## Why

Three instances of one family, each reporting **success** while doing something other than what was asked:

| Invocation | What it did | What it printed |
|---|---|---|
| `patchwork evidence verify` (before the subcommand existed) | plain coverage report | exit 0 |
| `patchwork evidence check` (**today, on main**) | plain coverage report | exit 0 |
| `audit-private-identifiers.mjs --message-file <f>` | scanned ~19 bytes of branch name | `OK`, exit 0 |
| a scripted `string.replace` matching nothing | nothing | exit 0 |

The shared property is that the failure is **invisible** — a silently-ignored argument is indistinguishable from an honoured one, and the command's own success message is what makes the wrong answer convincing. `evidence check` is a plausible typo for the real `verify`, so an operator asking about ledger integrity is told everything is fine by a command that never looked.

The *top* level of the CLI is already fail-closed (`Unknown command: '…'. Did you mean: …?`, with a Levenshtein suggestion). The gap is uniformly one level down: subcommand-local arguments.

## Decisions

**Usage errors exit 2, not 1.** `evidence verify` exits 1 for a broken chain — the one form of that verb which gates. Collapsing "I did not understand you" into the same code would make a typo indistinguishable from a real integrity failure, in exactly the cron job written to act on one.

**The token is not echoed unconditionally.** A refusal reaches a terminal, scrollback and CI logs. A bare word or a flag is echoed; anything path-shaped, `@`-bearing or overlong is described instead. Same line the private-identifier gate holds when it prints an entry *number* and never the matched string.

**The gate keeps a local copy of the rule rather than importing it.** `scripts/audit-*.mjs` run from `.husky/` hooks *before* any build and are outside the TypeScript project, so a gate importing from `dist/` would break on a clean clone. The duplication is recorded in both files rather than hidden, and both sides carry a test asserting a path-shaped argument is not echoed.

## Scope

Deliberately the two confirmed instances plus the shared helper — `rejectUnknownArgs` in `src/cliArgs.ts`, adoptable incrementally. Sweeping all ~50 subcommand dispatch blocks at once would risk newly rejecting a stray flag in a verb invoked from a hook or cron, turning a silent hole into a live failure.

`src/__tests__/privateIdentifierGateArgs.test.ts` is a **new file** rather than an addition to `privateIdentifierGate.test.ts`: argument dispatch and denylist matching are edited by different work, and there is unrelated in-progress work on the latter.

## Verification

Tests were written first and observed failing: 3 of 7 on the gate script, and the `evidence` defect reproduced directly against the built CLI (`evidence check` → exit 0 with the coverage report).

**Mutation-checked, both boundaries:**

- replacing the echo rule with `return true` → kills exactly one test per side (the path-shaped-not-echoed pair), and nothing else
- disabling the `evidence` guard call → kills exactly the three rejection tests, leaving all controls green

Controls pin the accepted forms: bare `evidence`, `--json`, `--help`, `--dir <value>`, `evidence verify`, `evidence verify --json`, and `--message` / `--text` / no-args on the gate script.

Green locally: full vitest (11 045 passed), `typecheck`, `typecheck:tests:core`, and every `scripts/audit-*.mjs` ratchet (they run outside vitest and tsc — `audit-test-fixtures` caught a hardcoded `/tmp/` path in a new test, now fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)